### PR TITLE
File list view sorting

### DIFF
--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -21,14 +21,14 @@
 		23BEF1182076667F00DD2E6F /* IssuesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23BEF1172076667F00DD2E6F /* IssuesViewController.swift */; };
 		23D0E09E205BCF8D002D7C80 /* ownCloudUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 230B84F020597F6E00C9F828 /* ownCloudUI.framework */; };
 		23D0E09F205BCF8D002D7C80 /* ownCloudUI.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 230B84F020597F6E00C9F828 /* ownCloudUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		23E22BB720C6A5C40024D11E /* UIDevide+UIUserInterfaceIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E22BB220C6A5C40024D11E /* UIDevide+UIUserInterfaceIdiom.swift */; };
+		23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* SortMethod.swift */; };
+		23FA23E620BFD3D8009A6D73 /* SortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA23E520BFD3D8009A6D73 /* SortBar.swift */; };
 		593BAB46209AE1BC00023634 /* PasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593BAB44209AE1BC00023634 /* PasscodeViewController.swift */; };
 		593BAB47209AE1BC00023634 /* PasscodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 593BAB45209AE1BC00023634 /* PasscodeViewController.xib */; };
 		593BAB97209F8A0500023634 /* AppLockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593BAB96209F8A0500023634 /* AppLockManager.swift */; };
 		5958C9BE20C000A700E0E567 /* PasscodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5958C9BD20C000A700E0E567 /* PasscodeTests.swift */; };
 		597A404920AD59EF00B028B2 /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597A404820AD59EF00B028B2 /* AppLockWindow.swift */; };
-		23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* OCSortMethod.swift */; };
-		23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* SortMethod.swift */; };
-		23FA23E620BFD3D8009A6D73 /* SortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA23E520BFD3D8009A6D73 /* SortBar.swift */; };
 		6D107AA0B21417432C72755A /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3B3E74D4B04F9CAF95C09 /* EarlGrey.swift */; };
 		6E83C77E20A32C1B0066EC23 /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */; };
 		6E83C78420A33C180066EC23 /* LAContext+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C78320A33C180066EC23 /* LAContext+Extension.swift */; };
@@ -265,14 +265,14 @@
 		23957A6C209AFFE8003C8537 /* MoreSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreSettingsSection.swift; sourceTree = "<group>"; };
 		239F1318205A693A0029F186 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		23BEF1172076667F00DD2E6F /* IssuesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuesViewController.swift; sourceTree = "<group>"; };
+		23E22BB220C6A5C40024D11E /* UIDevide+UIUserInterfaceIdiom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIDevide+UIUserInterfaceIdiom.swift"; sourceTree = "<group>"; };
+		23F6238020B587EF004FDE8B /* SortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMethod.swift; sourceTree = "<group>"; };
+		23FA23E520BFD3D8009A6D73 /* SortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBar.swift; sourceTree = "<group>"; };
 		593BAB44209AE1BC00023634 /* PasscodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeViewController.swift; sourceTree = "<group>"; };
 		593BAB45209AE1BC00023634 /* PasscodeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PasscodeViewController.xib; sourceTree = "<group>"; };
 		593BAB96209F8A0500023634 /* AppLockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockManager.swift; sourceTree = "<group>"; };
 		5958C9BD20C000A700E0E567 /* PasscodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeTests.swift; sourceTree = "<group>"; };
 		597A404820AD59EF00B028B2 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockWindow.swift; sourceTree = "<group>"; };
-		23F6238020B587EF004FDE8B /* OCSortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSortMethod.swift; sourceTree = "<group>"; };
-		23F6238020B587EF004FDE8B /* SortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMethod.swift; sourceTree = "<group>"; };
-		23FA23E520BFD3D8009A6D73 /* SortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBar.swift; sourceTree = "<group>"; };
 		6CBDF92D3844CF78B20B5770 /* Pods-ownCloudTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ownCloudTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ownCloudTests/Pods-ownCloudTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
 		6E83C78320A33C180066EC23 /* LAContext+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LAContext+Extension.swift"; sourceTree = "<group>"; };
@@ -753,6 +753,7 @@
 				DC3BE0E02077CD4B002A0AC0 /* Synchronized.swift */,
 				DC4FEAE9209E48E800D4476B /* DispatchQueueTools.swift */,
 				DC9BFBBC20A1C37B007064B5 /* PasswordManagerAccess.swift */,
+				23E22BB220C6A5C40024D11E /* UIDevide+UIUserInterfaceIdiom.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1119,6 +1120,7 @@
 				593BAB97209F8A0500023634 /* AppLockManager.swift in Sources */,
 				DCFED972208095E200A2D984 /* ClientItemCell.swift in Sources */,
 				DC7DF17E205141C100189B9A /* BookmarkManager.swift in Sources */,
+				23E22BB720C6A5C40024D11E /* UIDevide+UIUserInterfaceIdiom.swift in Sources */,
 				23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */,
 				239F1319205A693A0029F186 /* UIColor+Extension.swift in Sources */,
 				DC3BE0E12077CD4B002A0AC0 /* Synchronized.swift in Sources */,

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		597A404920AD59EF00B028B2 /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597A404820AD59EF00B028B2 /* AppLockWindow.swift */; };
 		23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* OCSortMethod.swift */; };
 		23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* SortMethod.swift */; };
+		23FA23E620BFD3D8009A6D73 /* SortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA23E520BFD3D8009A6D73 /* SortBar.swift */; };
 		6D107AA0B21417432C72755A /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3B3E74D4B04F9CAF95C09 /* EarlGrey.swift */; };
 		6E83C77E20A32C1B0066EC23 /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */; };
 		6E83C78420A33C180066EC23 /* LAContext+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C78320A33C180066EC23 /* LAContext+Extension.swift */; };
@@ -271,6 +272,7 @@
 		597A404820AD59EF00B028B2 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockWindow.swift; sourceTree = "<group>"; };
 		23F6238020B587EF004FDE8B /* OCSortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSortMethod.swift; sourceTree = "<group>"; };
 		23F6238020B587EF004FDE8B /* SortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMethod.swift; sourceTree = "<group>"; };
+		23FA23E520BFD3D8009A6D73 /* SortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBar.swift; sourceTree = "<group>"; };
 		6CBDF92D3844CF78B20B5770 /* Pods-ownCloudTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ownCloudTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ownCloudTests/Pods-ownCloudTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
 		6E83C78320A33C180066EC23 /* LAContext+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LAContext+Extension.swift"; sourceTree = "<group>"; };
@@ -534,6 +536,7 @@
 				DC3BE0DC2077CC13002A0AC0 /* ClientQueryViewController.swift */,
 				DC3BE0DD2077CC13002A0AC0 /* ClientRootViewController.swift */,
 				23F6238020B587EF004FDE8B /* SortMethod.swift */,
+				23FA23E520BFD3D8009A6D73 /* SortBar.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1097,6 +1100,7 @@
 				DC3BE0DF2077CC14002A0AC0 /* ClientRootViewController.swift in Sources */,
 				DC1B2709209CF0D3004715E1 /* CertificateViewController.swift in Sources */,
 				DC136582208223F000FC0F60 /* OCBookmark+Extension.swift in Sources */,
+				23FA23E620BFD3D8009A6D73 /* SortBar.swift in Sources */,
 				6E83C78420A33C180066EC23 /* LAContext+Extension.swift in Sources */,
 				593BAB46209AE1BC00023634 /* PasscodeViewController.swift in Sources */,
 				DC6428D02081406800493A01 /* CollapsibleProgressBar.swift in Sources */,

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		593BAB97209F8A0500023634 /* AppLockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593BAB96209F8A0500023634 /* AppLockManager.swift */; };
 		5958C9BE20C000A700E0E567 /* PasscodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5958C9BD20C000A700E0E567 /* PasscodeTests.swift */; };
 		597A404920AD59EF00B028B2 /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597A404820AD59EF00B028B2 /* AppLockWindow.swift */; };
+		23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* OCSortMethod.swift */; };
 		6D107AA0B21417432C72755A /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3B3E74D4B04F9CAF95C09 /* EarlGrey.swift */; };
 		6E83C77E20A32C1B0066EC23 /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */; };
 		6E83C78420A33C180066EC23 /* LAContext+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C78320A33C180066EC23 /* LAContext+Extension.swift */; };
@@ -267,6 +268,7 @@
 		593BAB96209F8A0500023634 /* AppLockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockManager.swift; sourceTree = "<group>"; };
 		5958C9BD20C000A700E0E567 /* PasscodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeTests.swift; sourceTree = "<group>"; };
 		597A404820AD59EF00B028B2 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockWindow.swift; sourceTree = "<group>"; };
+		23F6238020B587EF004FDE8B /* OCSortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSortMethod.swift; sourceTree = "<group>"; };
 		6CBDF92D3844CF78B20B5770 /* Pods-ownCloudTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ownCloudTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ownCloudTests/Pods-ownCloudTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
 		6E83C78320A33C180066EC23 /* LAContext+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LAContext+Extension.swift"; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 				DCFED971208095E200A2D984 /* ClientItemCell.swift */,
 				DC3BE0DC2077CC13002A0AC0 /* ClientQueryViewController.swift */,
 				DC3BE0DD2077CC13002A0AC0 /* ClientRootViewController.swift */,
+				23F6238020B587EF004FDE8B /* OCSortMethod.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1110,6 +1113,7 @@
 				593BAB97209F8A0500023634 /* AppLockManager.swift in Sources */,
 				DCFED972208095E200A2D984 /* ClientItemCell.swift in Sources */,
 				DC7DF17E205141C100189B9A /* BookmarkManager.swift in Sources */,
+				23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */,
 				239F1319205A693A0029F186 /* UIColor+Extension.swift in Sources */,
 				DC3BE0E12077CD4B002A0AC0 /* Synchronized.swift in Sources */,
 				DCE5E8B82080D8D9005F60CE /* OCItem+Extension.swift in Sources */,

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		5958C9BE20C000A700E0E567 /* PasscodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5958C9BD20C000A700E0E567 /* PasscodeTests.swift */; };
 		597A404920AD59EF00B028B2 /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597A404820AD59EF00B028B2 /* AppLockWindow.swift */; };
 		23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* OCSortMethod.swift */; };
+		23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F6238020B587EF004FDE8B /* SortMethod.swift */; };
 		6D107AA0B21417432C72755A /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3B3E74D4B04F9CAF95C09 /* EarlGrey.swift */; };
 		6E83C77E20A32C1B0066EC23 /* SettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */; };
 		6E83C78420A33C180066EC23 /* LAContext+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E83C78320A33C180066EC23 /* LAContext+Extension.swift */; };
@@ -269,6 +270,7 @@
 		5958C9BD20C000A700E0E567 /* PasscodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeTests.swift; sourceTree = "<group>"; };
 		597A404820AD59EF00B028B2 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockWindow.swift; sourceTree = "<group>"; };
 		23F6238020B587EF004FDE8B /* OCSortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSortMethod.swift; sourceTree = "<group>"; };
+		23F6238020B587EF004FDE8B /* SortMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMethod.swift; sourceTree = "<group>"; };
 		6CBDF92D3844CF78B20B5770 /* Pods-ownCloudTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ownCloudTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ownCloudTests/Pods-ownCloudTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E83C77D20A32C1B0066EC23 /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
 		6E83C78320A33C180066EC23 /* LAContext+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LAContext+Extension.swift"; sourceTree = "<group>"; };
@@ -531,7 +533,7 @@
 				DCFED971208095E200A2D984 /* ClientItemCell.swift */,
 				DC3BE0DC2077CC13002A0AC0 /* ClientQueryViewController.swift */,
 				DC3BE0DD2077CC13002A0AC0 /* ClientRootViewController.swift */,
-				23F6238020B587EF004FDE8B /* OCSortMethod.swift */,
+				23F6238020B587EF004FDE8B /* SortMethod.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1113,7 +1115,7 @@
 				593BAB97209F8A0500023634 /* AppLockManager.swift in Sources */,
 				DCFED972208095E200A2D984 /* ClientItemCell.swift in Sources */,
 				DC7DF17E205141C100189B9A /* BookmarkManager.swift in Sources */,
-				23F6238120B587EF004FDE8B /* OCSortMethod.swift in Sources */,
+				23F6238120B587EF004FDE8B /* SortMethod.swift in Sources */,
 				239F1319205A693A0029F186 /* UIColor+Extension.swift in Sources */,
 				DC3BE0E12077CD4B002A0AC0 /* Synchronized.swift in Sources */,
 				DCE5E8B82080D8D9005F60CE /* OCItem+Extension.swift in Sources */,
@@ -1327,7 +1329,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.owncloud.ios-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1982de66-7f72-48d9-bfcd-8dd2aec5d741";
+				PROVISIONING_PROFILE = "dcf544f9-b9dc-4e36-908f-9aeacd954ea2";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.owncloud.ios-app";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1354,7 +1356,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.owncloud.ios-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "73869bed-48b0-423a-940e-438fc0b07be0";
+				PROVISIONING_PROFILE = "0720808b-becc-4621-8839-347863375834";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.owncloud.ios-app";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -55,12 +55,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 		progressSummarizer = ProgressSummarizer.shared(forCore: inCore)
 
 		query?.delegate = self
-		query?.sortComparator = { (left, right) in
-			let leftItem = left as? OCItem
-			let rightItem = right as? OCItem
-
-			return (leftItem?.name.compare(rightItem!.name))!
-		}
+        query?.sortComparator = SortMethod.alphabeticallyAscendant.comparator()
 
 		query?.addObserver(self, forKeyPath: "state", options: .initial, context: observerContext)
 		core?.addObserver(self, forKeyPath: "reachabilityMonitor.available", options: .initial, context: observerContext)

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -111,8 +111,8 @@ class ClientQueryViewController: UITableViewController, Themeable {
 		// Uncomment the following line to display an Edit button in the navigation bar for this view controller.
 		// self.navigationItem.rightBarButtonItem = self.editButtonItem
 
-        sortBar = SortBar(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 40))
-        sortBar?.sortButton.addTarget(self, action: #selector(presentSortOptions), for: .touchUpInside)
+		sortBar = SortBar(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 40), sortMethod: sortMethod)
+		sortBar?.delegate = self
 		sortBar?.sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
 
         tableView.tableHeaderView = sortBar
@@ -138,6 +138,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
 		updateQueryProgressSummary()
 
+		sortBar?.sortMethod = self.sortMethod
         query?.sortComparator = self.sortMethod.comparator()
 	}
 
@@ -370,36 +371,13 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
 		set {
 			UserDefaults.standard.setValue(newValue.rawValue, forKey: "sort-method")
-			sortBar?.sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
 		}
 
 		get {
 			let sort = SortMethod(rawValue: UserDefaults.standard.integer(forKey: "sort-method")) ?? SortMethod.alphabeticallyDescendant
-			sortBar?.sortButton.setTitle("sort by \(sort.localizedName()) ▼", for: .normal)
 			return sort
 		}
 	}
-
-    @objc private func presentSortOptions() {
-
-        let controller = UIAlertController(title: "Sort by".localized, message: nil, preferredStyle: .actionSheet)
-
-        for method in SortMethod.all {
-            let action = UIAlertAction(title: method.localizedName(), style: .default, handler: { (_) in
-                self.changeSortMethod(to: method)
-            })
-            controller.addAction(action)
-        }
-
-        let cancel = UIAlertAction(title: "Cancel".localized, style: .cancel, handler: nil)
-        controller.addAction(cancel)
-        present(controller, animated: true)
-    }
-
-    private func changeSortMethod(to newSortMethod: SortMethod) {
-        sortMethod = newSortMethod
-        query?.sortComparator = sortMethod.comparator()
-    }
 }
 
 // MARK: - Query Delegate
@@ -440,5 +418,14 @@ extension ClientQueryViewController : OCQueryDelegate {
 				}
 			}
 		}
+	}
+}
+
+// MARK: - SortBar Delegate
+extension ClientQueryViewController : SortBarDelegate {
+
+	func sortBar(_ sortBar: SortBar, didUpdateSortMethod: SortMethod) {
+		sortMethod = didUpdateSortMethod
+		query?.sortComparator = sortMethod.comparator()
 	}
 }

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -412,7 +412,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
     @objc private func presentSortOptions() {
 
-        let controller = UIAlertController(title: "Select sorting method".localized, message: nil, preferredStyle: .actionSheet)
+        let controller = UIAlertController(title: "Sort by".localized, message: nil, preferredStyle: .actionSheet)
 
         for method in SortMethod.all {
             let action = UIAlertAction(title: method.localizedName(), style: .default, handler: { (_) in

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -19,52 +19,6 @@
 import UIKit
 import ownCloudSDK
 
-class SortBar: UIView, Themeable {
-
-    var sortButton: ThemeButton
-    var sortMethod: SortMethod {
-
-        set {
-            UserDefaults.standard.setValue(newValue.rawValue, forKey: "sort-method")
-            sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
-        }
-
-        get {
-            let sort = SortMethod(rawValue: UserDefaults.standard.integer(forKey: "sort-method")) ?? SortMethod.alphabeticallyDescendant
-            sortButton.setTitle("sort by \(sort.localizedName()) ▼", for: .normal)
-            return sort
-        }
-    }
-
-    override init(frame: CGRect) {
-        sortButton = ThemeButton(frame: .zero)
-        super.init(frame: frame)
-        sortButton.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(sortButton)
-
-        sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
-
-        sortButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 10).isActive = true
-        sortButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
-        sortButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-        Theme.shared.register(client: self)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        Theme.shared.unregister(client: self)
-    }
-
-    func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
-        self.sortButton.applyThemeCollection(collection)
-        self.applyThemeCollection(collection)
-    }
-
-}
-
 class ClientQueryViewController: UITableViewController, Themeable {
 	var core : OCCore?
 	var query : OCQuery?
@@ -159,6 +113,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
         sortBar = SortBar(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 40))
         sortBar?.sortButton.addTarget(self, action: #selector(presentSortOptions), for: .touchUpInside)
+		sortBar?.sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
 
         tableView.tableHeaderView = sortBar
     }
@@ -183,7 +138,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
 		updateQueryProgressSummary()
 
-        query?.sortComparator = self.sortBar?.sortMethod.comparator()
+        query?.sortComparator = self.sortMethod.comparator()
 	}
 
 	func updateQueryProgressSummary() {
@@ -273,6 +228,8 @@ class ClientQueryViewController: UITableViewController, Themeable {
 		// Make sure we don't request the thumbnail multiple times in that case.
 		if cell?.item?.versionIdentifier != newItem.versionIdentifier {
 			cell?.item = newItem
+		} else {
+			cell?.updateWith(newItem)
 		}
 
 		return cell!
@@ -409,6 +366,19 @@ class ClientQueryViewController: UITableViewController, Themeable {
     // MARK: - Sorting
 
     private var sortBar: SortBar?
+	private var sortMethod: SortMethod {
+
+		set {
+			UserDefaults.standard.setValue(newValue.rawValue, forKey: "sort-method")
+			sortBar?.sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
+		}
+
+		get {
+			let sort = SortMethod(rawValue: UserDefaults.standard.integer(forKey: "sort-method")) ?? SortMethod.alphabeticallyDescendant
+			sortBar?.sortButton.setTitle("sort by \(sort.localizedName()) ▼", for: .normal)
+			return sort
+		}
+	}
 
     @objc private func presentSortOptions() {
 
@@ -426,8 +396,8 @@ class ClientQueryViewController: UITableViewController, Themeable {
         present(controller, animated: true)
     }
 
-    private func changeSortMethod(to sortMethod: SortMethod) {
-        sortBar?.sortMethod = sortMethod
+    private func changeSortMethod(to newSortMethod: SortMethod) {
+        sortMethod = newSortMethod
         query?.sortComparator = sortMethod.comparator()
     }
 }

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -113,7 +113,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
 		sortBar = SortBar(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.width, height: 40), sortMethod: sortMethod)
 		sortBar?.delegate = self
-		sortBar?.sortButton.setTitle("sort by \(sortMethod.localizedName()) ▼", for: .normal)
+		sortBar?.updateSortMethod()
 
         tableView.tableHeaderView = sortBar
     }
@@ -428,6 +428,7 @@ extension ClientQueryViewController : SortBarDelegate {
 	}
 
 	func sortBar(_ sortBar: SortBar, presentViewController: UIViewController, animated: Bool, completionHandler: (() -> Void)?) {
+
 		self.present(presentViewController, animated: animated, completion: completionHandler)
 	}
 }

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -227,10 +227,8 @@ class ClientQueryViewController: UITableViewController, Themeable {
 
 		// UITableView can call this method several times for the same cell, and .dequeueReusableCell will then return the same cell again.
 		// Make sure we don't request the thumbnail multiple times in that case.
-		if cell?.item?.versionIdentifier != newItem.versionIdentifier {
+		if (cell?.item?.versionIdentifier != newItem.versionIdentifier) || (cell?.item?.name != newItem.name) {
 			cell?.item = newItem
-		} else {
-			cell?.updateWith(newItem)
 		}
 
 		return cell!
@@ -427,5 +425,9 @@ extension ClientQueryViewController : SortBarDelegate {
 	func sortBar(_ sortBar: SortBar, didUpdateSortMethod: SortMethod) {
 		sortMethod = didUpdateSortMethod
 		query?.sortComparator = sortMethod.comparator()
+	}
+
+	func sortBar(_ sortBar: SortBar, presentViewController: UIViewController, animated: Bool, completionHandler: (() -> Void)?) {
+		self.present(presentViewController, animated: animated, completion: completionHandler)
 	}
 }

--- a/ownCloud/Client/OCSortMethod.swift
+++ b/ownCloud/Client/OCSortMethod.swift
@@ -1,0 +1,79 @@
+//
+//  OCSortMethod.swift
+//  ownCloud
+//
+//  Created by Pablo Carrascal on 23/05/2018.
+//  Copyright © 2018 ownCloud GmbH. All rights reserved.
+//
+
+import Foundation
+import ownCloudSDK
+
+typealias OCSort = Comparator
+
+public enum SortMethod {
+
+    case alphabeticallyAscendant
+    case alphabeticallyDescendant
+    case kindOfFiles
+    case size
+
+    func comparator() -> OCSort? {
+        var comparator: OCSort? = nil
+
+        switch self {
+        case .size:
+            comparator = { (left, right) in
+                let leftItem = left as? OCItem
+                let rightItem = right as? OCItem
+
+                let leftSize = leftItem!.size as NSNumber
+                let rightSize = rightItem!.size as NSNumber
+
+                return (rightSize.compare(leftSize))
+            }
+
+        case .alphabeticallyAscendant:
+            comparator = { (left, right) in
+                let leftItem = left as? OCItem
+                let rightItem = right as? OCItem
+
+                return (leftItem?.name.compare(rightItem!.name))!
+
+            }
+
+        case .alphabeticallyDescendant:
+            comparator = {
+                (left, right) in
+                let leftItem = left as? OCItem
+                let rightItem = right as? OCItem
+
+                return (rightItem?.name.compare(leftItem!.name))!
+            }
+
+        case .kindOfFiles:
+            comparator = {
+                (left, right) in
+                let leftItem = left as? OCItem
+                let rightItem = right as? OCItem
+
+                var leftMimeType = leftItem?.mimeType
+                var rightMimeType = rightItem?.mimeType
+
+                if leftItem?.mimeType == nil {
+                    leftMimeType = "00folder"
+                }
+
+                if rightItem?.mimeType == nil {
+                    rightMimeType = "00folder"
+                }
+
+                return leftMimeType!.compare(rightMimeType!)
+            }
+
+        default:
+            comparator = nil
+        }
+        return comparator
+    }
+}

--- a/ownCloud/Client/SortBar.swift
+++ b/ownCloud/Client/SortBar.swift
@@ -6,14 +6,38 @@
 //  Copyright © 2018 ownCloud GmbH. All rights reserved.
 //
 
+/*
+* Copyright (C) 2018, ownCloud GmbH.
+*
+* This code is covered by the GNU Public License Version 3.
+*
+* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+*
+*/
+
 import UIKit
+
+protocol SortBarDelegate: class {
+	func sortBar(_ sortBar: SortBar, didUpdateSortMethod: SortMethod)
+}
 
 class SortBar: UIView, Themeable {
 
-	var sortButton: ThemeButton
+	weak var delegate: SortBarDelegate?
 
-	override init(frame: CGRect) {
+	var sortButton: ThemeButton
+	var sortMethod: SortMethod {
+		didSet {
+			let title = NSString(format: "Sorted by %@ ▼".localized as NSString, sortMethod.localizedName()) as String
+			sortButton.setTitle(title, for: .normal)
+			delegate?.sortBar(self, didUpdateSortMethod: sortMethod)
+		}
+	}
+
+	init(frame: CGRect, sortMethod: SortMethod) {
 		sortButton = ThemeButton(frame: .zero)
+		self.sortMethod = sortMethod
 		super.init(frame: frame)
 		sortButton.translatesAutoresizingMaskIntoConstraints = false
 		self.addSubview(sortButton)
@@ -21,6 +45,10 @@ class SortBar: UIView, Themeable {
 		sortButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 10).isActive = true
 		sortButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
 		sortButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+		sortButton.addTarget(self, action: #selector(presentSortOptions), for: .touchUpInside)
+		sortButton.accessibilityIdentifier = "sort-button"
+		self.accessibilityIdentifier = "sort-bar"
+
 		Theme.shared.register(client: self)
 	}
 
@@ -35,5 +63,21 @@ class SortBar: UIView, Themeable {
 	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
 		self.sortButton.applyThemeCollection(collection)
 		self.applyThemeCollection(collection)
+	}
+
+	@objc private func presentSortOptions() {
+
+		let controller = UIAlertController(title: "Sort by".localized, message: nil, preferredStyle: .actionSheet)
+
+		for method in SortMethod.all {
+			let action = UIAlertAction(title: method.localizedName(), style: .default, handler: {(_) in
+				self.sortMethod = method
+			})
+			controller.addAction(action)
+		}
+
+		let cancel = UIAlertAction(title: "Cancel".localized, style: .cancel)
+		controller.addAction(cancel)
+		UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.present(controller, animated: true, completion: nil)
 	}
 }

--- a/ownCloud/Client/SortBar.swift
+++ b/ownCloud/Client/SortBar.swift
@@ -20,6 +20,8 @@ import UIKit
 
 protocol SortBarDelegate: class {
 	func sortBar(_ sortBar: SortBar, didUpdateSortMethod: SortMethod)
+
+	func sortBar(_ sortBar: SortBar, presentViewController: UIViewController, animated: Bool, completionHandler: (() -> Void)?)
 }
 
 class SortBar: UIView, Themeable {
@@ -78,6 +80,6 @@ class SortBar: UIView, Themeable {
 
 		let cancel = UIAlertAction(title: "Cancel".localized, style: .cancel)
 		controller.addAction(cancel)
-		UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.present(controller, animated: true, completion: nil)
+		delegate?.sortBar(self, presentViewController: controller, animated: true, completionHandler: nil)
 	}
 }

--- a/ownCloud/Client/SortBar.swift
+++ b/ownCloud/Client/SortBar.swift
@@ -1,0 +1,39 @@
+//
+//  SortBar.swift
+//  ownCloud
+//
+//  Created by Pablo Carrascal on 31/05/2018.
+//  Copyright © 2018 ownCloud GmbH. All rights reserved.
+//
+
+import UIKit
+
+class SortBar: UIView, Themeable {
+
+	var sortButton: ThemeButton
+
+	override init(frame: CGRect) {
+		sortButton = ThemeButton(frame: .zero)
+		super.init(frame: frame)
+		sortButton.translatesAutoresizingMaskIntoConstraints = false
+		self.addSubview(sortButton)
+
+		sortButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 10).isActive = true
+		sortButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10).isActive = true
+		sortButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+		Theme.shared.register(client: self)
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	deinit {
+		Theme.shared.unregister(client: self)
+	}
+
+	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
+		self.sortButton.applyThemeCollection(collection)
+		self.applyThemeCollection(collection)
+	}
+}

--- a/ownCloud/Client/SortMethod.swift
+++ b/ownCloud/Client/SortMethod.swift
@@ -11,12 +11,31 @@ import ownCloudSDK
 
 typealias OCSort = Comparator
 
-public enum SortMethod {
+public enum SortMethod: Int {
 
-    case alphabeticallyAscendant
-    case alphabeticallyDescendant
-    case kindOfFiles
-    case size
+    case alphabeticallyAscendant = 0
+    case alphabeticallyDescendant = 1
+    case kindOfFiles = 2
+    case size = 3
+
+    static var all: [SortMethod] = [alphabeticallyAscendant, alphabeticallyDescendant, kindOfFiles, size]
+
+    func localizedName() -> String {
+        var name = ""
+
+        switch self {
+        case .alphabeticallyAscendant:
+            name = "A-Z".localized
+        case .alphabeticallyDescendant:
+            name = "Z-A".localized
+        case .kindOfFiles:
+            name = "Kind".localized
+        case .size:
+            name = "Size".localized
+        }
+
+        return name
+    }
 
     func comparator() -> OCSort? {
         var comparator: OCSort? = nil
@@ -60,19 +79,24 @@ public enum SortMethod {
                 var leftMimeType = leftItem?.mimeType
                 var rightMimeType = rightItem?.mimeType
 
+                if leftItem?.type == OCItemType.collection {
+                    leftMimeType = "folder"
+                }
+
+                if rightItem?.type == OCItemType.collection {
+                    rightMimeType = "folder"
+                }
+
                 if leftItem?.mimeType == nil {
-                    leftMimeType = "00folder"
+                    leftMimeType = "various"
                 }
 
                 if rightItem?.mimeType == nil {
-                    rightMimeType = "00folder"
+                    rightMimeType = "various"
                 }
 
                 return leftMimeType!.compare(rightMimeType!)
             }
-
-        default:
-            comparator = nil
         }
         return comparator
     }

--- a/ownCloud/Client/SortMethod.swift
+++ b/ownCloud/Client/SortMethod.swift
@@ -13,91 +13,101 @@ typealias OCSort = Comparator
 
 public enum SortMethod: Int {
 
-    case alphabeticallyAscendant = 0
-    case alphabeticallyDescendant = 1
-    case type = 2
-    case size = 3
+	case alphabeticallyAscendant = 0
+	case alphabeticallyDescendant = 1
+	case type = 2
+	case size = 3
+	case date = 4
 
-    static var all: [SortMethod] = [alphabeticallyAscendant, alphabeticallyDescendant, type, size]
+	static var all: [SortMethod] = [alphabeticallyAscendant, alphabeticallyDescendant, type, size, date]
 
-    func localizedName() -> String {
-        var name = ""
+	func localizedName() -> String {
+		var name = ""
 
-        switch self {
-        case .alphabeticallyAscendant:
-            name = "A-Z".localized
-        case .alphabeticallyDescendant:
-            name = "Z-A".localized
-        case .type:
-            name = "Type".localized
-        case .size:
-            name = "Size".localized
-        }
+		switch self {
+		case .alphabeticallyAscendant:
+			name = "name (A-Z)".localized
+		case .alphabeticallyDescendant:
+			name = "name (Z-A)".localized
+		case .type:
+			name = "type".localized
+		case .size:
+			name = "size".localized
+		case .date:
+			name = "date".localized
+		}
 
-        return name
-    }
+		return name
+	}
 
-    func comparator() -> OCSort? {
-        var comparator: OCSort? = nil
+	func comparator() -> OCSort {
+		var comparator: OCSort
 
-        switch self {
-        case .size:
-            comparator = { (left, right) in
-                let leftItem = left as? OCItem
-                let rightItem = right as? OCItem
+		switch self {
+		case .size:
+			comparator = { (left, right) in
+				let leftItem = left as? OCItem
+				let rightItem = right as? OCItem
 
-                let leftSize = leftItem!.size as NSNumber
-                let rightSize = rightItem!.size as NSNumber
+				let leftSize = leftItem!.size as NSNumber
+				let rightSize = rightItem!.size as NSNumber
 
-                return (rightSize.compare(leftSize))
-            }
+				return (rightSize.compare(leftSize))
+			}
 
-        case .alphabeticallyAscendant:
-            comparator = { (left, right) in
-                let leftItem = left as? OCItem
-                let rightItem = right as? OCItem
+		case .alphabeticallyAscendant:
+			comparator = { (left, right) in
+				let leftItem = left as? OCItem
+				let rightItem = right as? OCItem
 
-                return (leftItem?.name.compare(rightItem!.name))!
+				return (leftItem?.name.lowercased().compare(rightItem!.name.lowercased()))!
+			}
 
-            }
+		case .alphabeticallyDescendant:
+			comparator = {
+				(left, right) in
+				let leftItem = left as? OCItem
+				let rightItem = right as? OCItem
 
-        case .alphabeticallyDescendant:
-            comparator = {
-                (left, right) in
-                let leftItem = left as? OCItem
-                let rightItem = right as? OCItem
+				return (rightItem?.name.lowercased().compare(leftItem!.name.lowercased()))!
+			}
 
-                return (rightItem?.name.compare(leftItem!.name))!
-            }
+		case .type:
+			comparator = {
+				(left, right) in
+				let leftItem = left as? OCItem
+				let rightItem = right as? OCItem
 
-        case .type:
-            comparator = {
-                (left, right) in
-                let leftItem = left as? OCItem
-                let rightItem = right as? OCItem
+				var leftMimeType = leftItem?.mimeType
+				var rightMimeType = rightItem?.mimeType
 
-                var leftMimeType = leftItem?.mimeType
-                var rightMimeType = rightItem?.mimeType
+				if leftItem?.type == OCItemType.collection {
+					leftMimeType = "folder"
+				}
 
-                if leftItem?.type == OCItemType.collection {
-                    leftMimeType = "folder"
-                }
+				if rightItem?.type == OCItemType.collection {
+					rightMimeType = "folder"
+				}
 
-                if rightItem?.type == OCItemType.collection {
-                    rightMimeType = "folder"
-                }
+				if leftItem?.mimeType == nil {
+					leftMimeType = "various"
+				}
 
-                if leftItem?.mimeType == nil {
-                    leftMimeType = "various"
-                }
+				if rightItem?.mimeType == nil {
+					rightMimeType = "various"
+				}
 
-                if rightItem?.mimeType == nil {
-                    rightMimeType = "various"
-                }
+				return leftMimeType!.compare(rightMimeType!)
+			}
+		case .date:
+			comparator = {
+				(left, right) in
+				let leftItem = left as? OCItem
+				let rightItem = right as? OCItem
 
-                return leftMimeType!.compare(rightMimeType!)
-            }
-        }
-        return comparator
-    }
+				return (rightItem?.lastModified.compare(leftItem!.lastModified))!
+			}
+		}
+		return comparator
+	}
 }

--- a/ownCloud/Client/SortMethod.swift
+++ b/ownCloud/Client/SortMethod.swift
@@ -1,10 +1,20 @@
 //
-//  OCSortMethod.swift
+//  SortMethod.swift
 //  ownCloud
 //
 //  Created by Pablo Carrascal on 23/05/2018.
 //  Copyright © 2018 ownCloud GmbH. All rights reserved.
 //
+
+/*
+* Copyright (C) 2018, ownCloud GmbH.
+*
+* This code is covered by the GNU Public License Version 3.
+*
+* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+*
+*/
 
 import Foundation
 import ownCloudSDK

--- a/ownCloud/Client/SortMethod.swift
+++ b/ownCloud/Client/SortMethod.swift
@@ -15,10 +15,10 @@ public enum SortMethod: Int {
 
     case alphabeticallyAscendant = 0
     case alphabeticallyDescendant = 1
-    case kindOfFiles = 2
+    case type = 2
     case size = 3
 
-    static var all: [SortMethod] = [alphabeticallyAscendant, alphabeticallyDescendant, kindOfFiles, size]
+    static var all: [SortMethod] = [alphabeticallyAscendant, alphabeticallyDescendant, type, size]
 
     func localizedName() -> String {
         var name = ""
@@ -28,8 +28,8 @@ public enum SortMethod: Int {
             name = "A-Z".localized
         case .alphabeticallyDescendant:
             name = "Z-A".localized
-        case .kindOfFiles:
-            name = "Kind".localized
+        case .type:
+            name = "Type".localized
         case .size:
             name = "Size".localized
         }
@@ -70,7 +70,7 @@ public enum SortMethod: Int {
                 return (rightItem?.name.compare(leftItem!.name))!
             }
 
-        case .kindOfFiles:
+        case .type:
             comparator = {
                 (left, right) in
                 let leftItem = left as? OCItem

--- a/ownCloud/Resources/Localizable.strings
+++ b/ownCloud/Resources/Localizable.strings
@@ -50,10 +50,10 @@
 "This folder no longer exists." = "This folder no longer exists.";
 "Everything up-to-date." = "Everything up-to-date.";
 "Please wait…" = "Please wait…";
-"Select sorting method" = "Select sorting method";
+"Sort by" = "Sort by";
 "A-Z" = "A-Z";
 "Z-A" = "Z-A";
-"Kind" = "Kind";
+"Type" = "Type";
 "Size" = "Size";
 }
 

--- a/ownCloud/Resources/Localizable.strings
+++ b/ownCloud/Resources/Localizable.strings
@@ -51,11 +51,11 @@
 "Everything up-to-date." = "Everything up-to-date.";
 "Please wait…" = "Please wait…";
 "Sort by" = "Sort by";
-"A-Z" = "A-Z";
-"Z-A" = "Z-A";
-"Type" = "Type";
-"Size" = "Size";
-}
+"name (A-Z)" = "name (A-Z)";
+"name (Z-A)" = "name (Z-A)";
+"type" = "type";
+"size" = "size";
+"date" = "date";
 
 /* Client Messages */
 "Empty folder" = "Empty folder";

--- a/ownCloud/Resources/Localizable.strings
+++ b/ownCloud/Resources/Localizable.strings
@@ -50,6 +50,12 @@
 "This folder no longer exists." = "This folder no longer exists.";
 "Everything up-to-date." = "Everything up-to-date.";
 "Please wait…" = "Please wait…";
+"Select sorting method" = "Select sorting method";
+"A-Z" = "A-Z";
+"Z-A" = "Z-A";
+"Kind" = "Kind";
+"Size" = "Size";
+}
 
 /* Client Messages */
 "Empty folder" = "Empty folder";

--- a/ownCloud/Resources/Localizable.strings
+++ b/ownCloud/Resources/Localizable.strings
@@ -50,7 +50,9 @@
 "This folder no longer exists." = "This folder no longer exists.";
 "Everything up-to-date." = "Everything up-to-date.";
 "Please wait…" = "Please wait…";
+"Sorted by %@ ▼" = "Sorted by %@ ▼";
 "Sort by" = "Sort by";
+
 "name (A-Z)" = "name (A-Z)";
 "name (Z-A)" = "name (Z-A)";
 "type" = "type";

--- a/ownCloud/Tools/UIDevide+UIUserInterfaceIdiom.swift
+++ b/ownCloud/Tools/UIDevide+UIUserInterfaceIdiom.swift
@@ -1,0 +1,20 @@
+//
+//  UIDevide+UIUserInterfaceIdiom.swift
+//  ownCloud
+//
+//  Created by Pablo Carrascal on 05/06/2018.
+//  Copyright © 2018 ownCloud GmbH. All rights reserved.
+//
+
+import UIKit
+
+extension UIDevice {
+
+	func isIpad() -> Bool {
+		if self.userInterfaceIdiom == .pad {
+			return true
+		}
+
+		return false
+	}
+}


### PR DESCRIPTION
This PR aims to add support in the file list screen to different sorting methods.

The way I'm coding this is:

- I've created an enum with the possible sorting options, in our case I've coded:

```Swift
    case alphabeticallyAscendant
    case alphabeticallyDescendant
    case type
    case size
```

Taking advantage of the Swift's enums, the `SortMethod` enum has a method called `comparator()` which return a `Comparator`. This allows us to simply call
```Swift 
SortMethod.alphabeticallyAscendant.comparator()
```
to get the comparator for each sort method option in the enum.


Inside this method, there is a switch that returns the correct `Comparator` for each case.

- Next, I'll create a custom view with three buttons:
       
     - ~~**Create folder button**: like in the files app, this button in this pull request is not connected with any action but in the future should present some screen for creating a folder.~~

     - **Sort button**: the title of this button should be __sort by <sort method>__ and should present an action sheet with the different available sorting methods.

     - ~~**Change the view to List/Grid**: again, like in the files app, this button should change the layout to a Grid/List layout. In this pull request button is not connected with any action.~~

- Then I'll connect the sort button with the action sheet presentation method and present all the possible options and finally, when the user selects some option, we should change the `comparator` of the query and then relaunch the query. 

____

bugs & improvements:

- [x] (1) iPad sort menu with crash https://github.com/owncloud/ios-app/pull/55#issuecomment-394637594 [FIXED]