### PR TITLE
Fix retain cycle in ThemeNavigationController

### DIFF
--- a/ownCloud/Theming/UI/ThemeNavigationController.swift
+++ b/ownCloud/Theming/UI/ThemeNavigationController.swift
@@ -28,12 +28,12 @@ class ThemeNavigationController: UINavigationController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-		themeToken = Theme.shared.add(applier: { (_, themeCollection, event) in
-			self.applyThemeCollection(themeCollection)
-			self.toolbar.applyThemeCollection(themeCollection)
+		themeToken = Theme.shared.add(applier: {[weak self] (_, themeCollection, event) in
+			self?.applyThemeCollection(themeCollection)
+			self?.toolbar.applyThemeCollection(themeCollection)
 
 			if event == .update {
-				self.setNeedsStatusBarAppearanceUpdate()
+				self?.setNeedsStatusBarAppearanceUpdate()
 			}
 		}, applyImmediately: true)
 	}


### PR DESCRIPTION
This fixes a retain cycle in ThemeNavigationController that had large side effects like f.ex. `OCCore`s and `ClientQueryViewController`s never getting released and causing conflicts with new instances of `OCCore`.