### PR TITLE
Fix for imageScrollView center function.

### DIFF
--- a/ownCloud/UI Elements/ImageScrollView.swift
+++ b/ownCloud/UI Elements/ImageScrollView.swift
@@ -49,6 +49,10 @@ class ImageScrollView: UIScrollView {
 
 	// MARK: - Manage Scale
 	private func centerImage() {
+		guard imageView != nil else {
+			return
+		}
+
 		let boundsSize: CGSize = bounds.size
 		var frameToCenter: CGRect = imageView?.frame ?? .zero
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
<!--- Describe your changes in detail -->
Fixes a crash when trying to set the frame to the image view and the image view is nil. Now the frame is only set if the image view is not nil.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/ios-app/issues/154

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

