### PR TITLE
[fix/weak-self] Remove strong references to OCCore throughout the project

### DIFF
--- a/ownCloud/Client/Actions/Action.swift
+++ b/ownCloud/Client/Actions/Action.swift
@@ -192,7 +192,7 @@ class Action : NSObject {
 	// MARK: - Action metadata
 	var context : ActionContext
 	var actionExtension: ActionExtension
-	var core : OCCore
+	weak var core : OCCore?
 
 	// MARK: - Action creation
 	required init(for actionExtension: ActionExtension, with context: ActionContext) {

--- a/ownCloud/Client/Actions/Actions+Extensions/CreateFolderAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/CreateFolderAction.swift
@@ -64,7 +64,7 @@ class CreateFolderAction : Action {
 				return
 			}
 
-			if let progress = self.core.createFolder(newName!, inside: item!, options: nil, resultHandler: { (error, _, _, _) in
+			if let progress = self.core?.createFolder(newName!, inside: item!, options: nil, resultHandler: { (error, _, _, _) in
 				if error != nil {
 					Log.error("Error \(String(describing: error)) creating folder \(String(describing: newName))")
 					self.completed(with: error)

--- a/ownCloud/Client/Actions/Actions+Extensions/DeleteAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DeleteAction.swift
@@ -60,7 +60,7 @@ class DeleteAction : Action {
 			preferredStyle: UIDevice.current.isIpad() ? UIAlertController.Style.alert : UIAlertController.Style.actionSheet,
 			destructiveAction: {
 				for item in items {
-					if let progress = self.core.delete(item, requireMatch: true, resultHandler: { (error, _, _, _) in
+					if let progress = self.core?.delete(item, requireMatch: true, resultHandler: { (error, _, _, _) in
 						if error != nil {
 							Log.log("Error \(String(describing: error)) deleting \(String(describing: item.path))")
 							self.completed(with: error)

--- a/ownCloud/Client/Actions/Actions+Extensions/DuplicateAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DuplicateAction.swift
@@ -34,7 +34,7 @@ class DuplicateAction : Action {
 
 	// MARK: - Action implementation
 	override func run() {
-		guard context.items.count > 0 else {
+		guard context.items.count > 0, let core = self.core else {
 			completed(with: NSError(ocError: OCError.errorItemNotFound))
 			return
 		}
@@ -60,7 +60,7 @@ class DuplicateAction : Action {
 			name = "\(itemName) copy\(fileExtension)"
 		}
 
-		if let progress = self.core.copy(item, to: rootItem!, withName: name, options: nil, resultHandler: { (error, _, item, _) in
+		if let progress = core.copy(item, to: rootItem!, withName: name, options: nil, resultHandler: { (error, _, item, _) in
 			if error != nil {
 				Log.log("Error \(String(describing: error)) duplicating \(String(describing: item?.path))")
 				self.completed(with: error)

--- a/ownCloud/Client/Actions/Actions+Extensions/MoveAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/MoveAction.swift
@@ -32,7 +32,7 @@ class MoveAction : Action {
 
 	// MARK: - Action implementation
 	override func run() {
-		guard context.items.count > 0, let viewController = context.viewController else {
+		guard context.items.count > 0, let viewController = context.viewController, let core = self.core else {
 			completionHandler?(NSError(ocError: .errorInsufficientParameters))
 			return
 		}
@@ -40,9 +40,8 @@ class MoveAction : Action {
 		let items = context.items
 
 		let directoryPickerViewController = ClientDirectoryPickerViewController(core: core, path: "/", completion: { (selectedDirectory) in
-
 			items.forEach({ (item) in
-				if let progress = self.core.move(item, to: selectedDirectory, withName: item.name, options: nil, resultHandler: { (error, _, _, _) in
+				if let progress = self.core?.move(item, to: selectedDirectory, withName: item.name, options: nil, resultHandler: { (error, _, _, _) in
 					if error != nil {
 						self.completed(with: error)
 					} else {

--- a/ownCloud/Client/Actions/Actions+Extensions/OpenInAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/OpenInAction.swift
@@ -48,7 +48,7 @@ class OpenInAction: Action {
 		let controller = DownloadFileProgressHUDViewController()
 
 		controller.present(on: viewController) {
-			if let progress = self.core.downloadItem(item, options: nil, resultHandler: { (error, _, _, file) in
+			if let progress = self.core?.downloadItem(item, options: nil, resultHandler: { (error, _, _, file) in
 				if error != nil {
 					Log.log("Error \(String(describing: error)) downloading \(String(describing: item.path)) in openIn function")
 					controller.dismiss(animated: true, completion: {

--- a/ownCloud/Client/Actions/Actions+Extensions/RenameAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/RenameAction.swift
@@ -35,7 +35,7 @@ class RenameAction : Action {
 
 	// MARK: - Action implementation
 	override func run() {
-		guard context.items.count > 0, let viewController = context.viewController else {
+		guard context.items.count > 0, let viewController = context.viewController, let core = self.core else {
 			completionHandler?(NSError(ocError: .errorInsufficientParameters))
 			return
 		}
@@ -60,7 +60,7 @@ class RenameAction : Action {
 				return
 			}
 
-			if let progress = self.core.move(item, to: rootItem!, withName: newName!, options: nil, resultHandler: { (error, _, _, _) in
+			if let progress = self.core?.move(item, to: rootItem!, withName: newName!, options: nil, resultHandler: { (error, _, _, _) in
 				if error != nil {
 					Log.log("Error \(String(describing: error)) renaming \(String(describing: item.path))")
 					self.completed(with: error)

--- a/ownCloud/Client/Actions/ClientDirectoryPickerViewController.swift
+++ b/ownCloud/Client/Actions/ClientDirectoryPickerViewController.swift
@@ -87,7 +87,7 @@ class ClientDirectoryPickerViewController: ClientQueryViewController {
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		let item: OCItem = itemAtIndexPath(indexPath)
 
-		guard item.type == OCItemType.collection else {
+		guard item.type == OCItemType.collection, let core = self.core else {
 			return
 		}
 

--- a/ownCloud/Client/Actions/MoreViewController.swift
+++ b/ownCloud/Client/Actions/MoreViewController.swift
@@ -22,7 +22,7 @@ import ownCloudSDK
 class MoreViewController: UIViewController {
 
 	private var item: OCItem
-	private var core: OCCore
+	private weak var core: OCCore?
 
 	private var headerView: UIView
 	private var viewController: UIViewController

--- a/ownCloud/Theming/TVG/TVGImage.swift
+++ b/ownCloud/Theming/TVG/TVGImage.swift
@@ -186,4 +186,3 @@ class TVGImage: NSObject {
 		}
 	}
 }
-

--- a/ownCloud/Viewer/DisplayHostViewController.swift
+++ b/ownCloud/Viewer/DisplayHostViewController.swift
@@ -24,7 +24,7 @@ class DisplayHostViewController: UIViewController {
 
 	// MARK: - Instance Properties
 	private var itemsToDisplay: [OCItem] = []
-	private var core: OCCore
+	private weak var core: OCCore?
 	private var rootItem: OCItem
 
 	// MARK: - Init & deinit


### PR DESCRIPTION
## Description
- Removes strong references to OCCore throughout the project
- Removes query.reload on return to ClientQueryViewController because it's not needed

## Motivation and Context
Strong references to `OCCore` have repeatedly led to instances of `OCCore` being "leaked" whenever there was a memory leak in another part of the app that held a reference. This led to side effects like several `OCConnectionQueue` instances targeting the same background queue in the same app, which could lead to unroutable responses, breaking the Core and its Sync Engine.

After fixing several such leaks in `fix/memleaks`, with major PRs now merged, it's a good time to remove the last remaining strong references to `OCCore` from the source.

Going forward, classes and closures in the app should only hold weak references to instances of OCCore, by adding `weak` in front of instance variables or `[weak core]` at the beginning of closures as appropriate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
