### PR TITLE
Exclude app ownCloudTests from lint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 excluded:
-    - ownCloudTests/EarlGrey.swift
+    - ownCloudTests
     - external
 
 function_body_length: 100


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

### Description
SwiftLint rules are designed to correctness in app code. UI tests are not fitting such rules:

- Test names use to be longer than `func`names, so they describe the scope of the test
- Trailing whitespaces to distinguish different parts of each test.

App and tests also run on different targets.

For such reasons, excluding test folder will avoid unnecessary warnings.

