### PR TITLE
#294 added missing view controller title for "Lock application"

### DIFF
--- a/ownCloud/Settings/SecuritySettingsSection.swift
+++ b/ownCloud/Settings/SecuritySettingsSection.swift
@@ -103,6 +103,7 @@ class SecuritySettingsSection: SettingsSection {
 			if let vc = self?.viewController {
 
 				let newVC = StaticTableViewController(style: .grouped)
+				newVC.title = "Lock application".localized
 				let frequencySection = StaticTableViewSection(headerTitle: "Lock application".localized, footerTitle: nil)
 
 				var radioButtons: [[String : Any]] = []


### PR DESCRIPTION
## Description
There was a missing view controller title in "Settings" > "Lock application"

## Related Issue
#294 

## How Has This Been Tested?
- open Settings
- open "Lock application"
- view controller title should be visible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
