### PR TITLE
Changed full width button to a rounded button

### DIFF
--- a/ownCloud/Server List/ServerListTableViewController.xib
+++ b/ownCloud/Server List/ServerListTableViewController.xib
@@ -56,6 +56,9 @@
                             <rect key="frame" x="0.0" y="283" width="241.5" height="43"/>
                             <color key="backgroundColor" red="0.27450980390000002" green="0.54901960780000003" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                             <accessibility key="accessibilityConfiguration" identifier="addServer"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="280" id="ddm-Lk-mEG"/>
+                            </constraints>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <state key="normal" title="Add account">
                                 <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -80,9 +83,7 @@ Start by adding your server.</string>
                         </view>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="Jaa-D8-ghC" firstAttribute="leading" secondItem="IEC-5d-Hb5" secondAttribute="leading" id="52z-ez-wTm"/>
                         <constraint firstItem="IEC-5d-Hb5" firstAttribute="centerX" secondItem="PJc-v9-DYn" secondAttribute="centerX" id="5VX-tG-MwV"/>
-                        <constraint firstItem="Jaa-D8-ghC" firstAttribute="trailing" secondItem="IEC-5d-Hb5" secondAttribute="trailing" id="7v3-R6-kKd"/>
                         <constraint firstItem="c8n-gy-7HF" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xJw-Td-7h2" secondAttribute="leading" id="9hZ-i6-GgM"/>
                         <constraint firstItem="c8n-gy-7HF" firstAttribute="top" secondItem="fP1-O2-lkg" secondAttribute="bottom" constant="30" id="9vT-H5-xlR"/>
                         <constraint firstItem="IEC-5d-Hb5" firstAttribute="leading" relation="lessThanOrEqual" secondItem="xJw-Td-7h2" secondAttribute="leading" id="AcY-Wr-x1B"/>
@@ -93,12 +94,14 @@ Start by adding your server.</string>
                         <constraint firstItem="fP1-O2-lkg" firstAttribute="top" secondItem="xJw-Td-7h2" secondAttribute="top" id="c7O-MV-CAw"/>
                         <constraint firstItem="xJw-Td-7h2" firstAttribute="trailing" secondItem="fP1-O2-lkg" secondAttribute="trailing" id="cF9-UI-9xL"/>
                         <constraint firstItem="xJw-Td-7h2" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="c8n-gy-7HF" secondAttribute="trailing" id="fQE-8k-zir"/>
+                        <constraint firstItem="xJw-Td-7h2" firstAttribute="trailing" secondItem="Jaa-D8-ghC" secondAttribute="trailing" id="gLY-Nv-73j"/>
                         <constraint firstItem="x7I-De-RhT" firstAttribute="bottom" secondItem="fP1-O2-lkg" secondAttribute="bottom" id="hPm-L8-5gB"/>
                         <constraint firstItem="fP1-O2-lkg" firstAttribute="centerX" secondItem="PJc-v9-DYn" secondAttribute="centerX" id="iBg-us-cdK"/>
                         <constraint firstItem="xJw-Td-7h2" firstAttribute="bottom" secondItem="Jaa-D8-ghC" secondAttribute="bottom" id="jPt-3z-e1W"/>
                         <constraint firstItem="x7I-De-RhT" firstAttribute="top" secondItem="fP1-O2-lkg" secondAttribute="top" id="oXa-Tt-Kb4"/>
                         <constraint firstItem="x7I-De-RhT" firstAttribute="leading" secondItem="fP1-O2-lkg" secondAttribute="leading" id="r2P-zD-FI5"/>
                         <constraint firstItem="Jaa-D8-ghC" firstAttribute="centerX" secondItem="PJc-v9-DYn" secondAttribute="centerX" id="rYy-mZ-wyn"/>
+                        <constraint firstItem="Jaa-D8-ghC" firstAttribute="leading" secondItem="xJw-Td-7h2" secondAttribute="leading" id="s2Y-9J-kgb"/>
                         <constraint firstItem="c8n-gy-7HF" firstAttribute="centerX" secondItem="PJc-v9-DYn" secondAttribute="centerX" id="u0i-ca-Uiz"/>
                         <constraint firstItem="Jaa-D8-ghC" firstAttribute="top" secondItem="IEC-5d-Hb5" secondAttribute="bottom" constant="25" id="wen-iH-60d"/>
                     </constraints>

--- a/ownCloud/Settings/Passcode/PasscodeViewController.swift
+++ b/ownCloud/Settings/Passcode/PasscodeViewController.swift
@@ -157,6 +157,8 @@ class PasscodeViewController: UIViewController, Themeable {
 		self.keypadButtonsEnabled = { self.keypadButtonsEnabled }()
 		self.keypadButtonsHidden = { self.keypadButtonsHidden }()
 		self.screenBlurringEnabled = { self.screenBlurringEnabled }()
+		self.errorMessageLabel?.minimumScaleFactor = 0.5
+		self.errorMessageLabel?.adjustsFontSizeToFitWidth = true
 	}
 
 	override func viewWillAppear(_ animated: Bool) {
@@ -267,7 +269,6 @@ class PasscodeViewController: UIViewController, Themeable {
 		deleteButton?.themeColorCollection = ThemeColorPairCollection(fromPair: ThemeColorPair(foreground: collection.tintColor, background: collection.tableBackgroundColor))
 
 		cancelButton?.applyThemeCollection(collection, itemStyle: .defaultForItem)
-		cancelButton?.layer.cornerRadius = 0
 	}
 
     // MARK: - External Keyboard Commands

--- a/ownCloud/Settings/Passcode/PasscodeViewController.xib
+++ b/ownCloud/Settings/Passcode/PasscodeViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -37,36 +37,37 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1ua-9z-VE2">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZQ4-NE-Hrm">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Kaa-V6-9Rt">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </view>
                     <blurEffect style="light"/>
                 </visualEffectView>
                 <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i5M-Pr-FkT" userLabel="Lock Screen">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timeout message label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ox7-yY-YRf">
-                            <rect key="frame" x="71.5" y="273.5" width="177" height="21"/>
+                            <rect key="frame" x="71.5" y="229.5" width="177" height="21"/>
                             <accessibility key="accessibilityConfiguration" identifier="timeoutMessageLabel"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view verifyAmbiguity="off" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C0s-hA-da3" userLabel="Keypad" customClass="KeyboardInput" customModule="ownCloud" customModuleProvider="target">
-                            <rect key="frame" x="30" y="153" width="260" height="355"/>
+                            <rect key="frame" x="39" y="95" width="242" height="315"/>
                             <subviews>
                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="85k-O3-nSF" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="70" height="70"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number1Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="70" id="eia-AT-jAc"/>
-                                        <constraint firstAttribute="width" constant="70" id="zuA-Uu-jG1"/>
+                                        <constraint firstAttribute="width" secondItem="85k-O3-nSF" secondAttribute="height" multiplier="1:1" id="Vh0-fP-3Vw"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="eia-AT-jAc"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="l8L-Vh-klR"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="1"/>
@@ -75,11 +76,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VzK-5I-Ct8" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="95" y="0.0" width="70" height="70"/>
+                                    <rect key="frame" x="91" y="0.0" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number2Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="2Jp-SW-8nV"/>
-                                        <constraint firstAttribute="height" constant="70" id="esv-xX-2ed"/>
+                                        <constraint firstAttribute="width" secondItem="VzK-5I-Ct8" secondAttribute="height" multiplier="1:1" id="UQj-g6-A3V"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="dpI-qb-IjA"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="esv-xX-2ed"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="2"/>
@@ -88,11 +90,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gBp-H8-606" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="190" y="0.0" width="70" height="70"/>
+                                    <rect key="frame" x="182" y="0.0" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number3Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="90V-lO-EAt"/>
-                                        <constraint firstAttribute="height" constant="70" id="RuB-tn-22s"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="Owh-E0-zIP"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="RuB-tn-22s"/>
+                                        <constraint firstAttribute="width" secondItem="gBp-H8-606" secondAttribute="height" multiplier="1:1" id="f2n-WR-ohI"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="3"/>
@@ -101,11 +104,11 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IVZ-la-esK" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="95" width="70" height="70"/>
+                                    <rect key="frame" x="0.0" y="85" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number4Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="hUb-vr-VMe"/>
-                                        <constraint firstAttribute="height" constant="70" id="wtu-8B-yFJ"/>
+                                        <constraint firstAttribute="width" secondItem="IVZ-la-esK" secondAttribute="height" multiplier="1:1" id="RMu-ty-Arw"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="wtu-8B-yFJ"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="4"/>
@@ -114,11 +117,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9xg-xz-Tph" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="95" y="95" width="70" height="70"/>
+                                    <rect key="frame" x="91" y="85" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number5Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="GEd-Ft-3Gb"/>
-                                        <constraint firstAttribute="height" constant="70" id="Oq1-Hm-cLy"/>
+                                        <constraint firstAttribute="width" secondItem="9xg-xz-Tph" secondAttribute="height" multiplier="1:1" id="CUF-qf-Jqe"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="Oq1-Hm-cLy"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="jsp-hF-Q3t"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="5"/>
@@ -127,11 +131,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgh-7z-Fto" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="190" y="95" width="70" height="70"/>
+                                    <rect key="frame" x="182" y="85" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number6Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="70" id="4Up-dH-UDB"/>
-                                        <constraint firstAttribute="width" constant="70" id="tWx-T7-sKh"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="4Up-dH-UDB"/>
+                                        <constraint firstAttribute="width" secondItem="hgh-7z-Fto" secondAttribute="height" multiplier="1:1" id="9fj-9g-nuU"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="sk8-Ra-Leo"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="6"/>
@@ -140,11 +145,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fMx-64-bYq" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="190" width="70" height="70"/>
+                                    <rect key="frame" x="0.0" y="170" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number7Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="cRr-u5-lQw"/>
-                                        <constraint firstAttribute="height" constant="70" id="um1-9z-Fld"/>
+                                        <constraint firstAttribute="width" secondItem="fMx-64-bYq" secondAttribute="height" multiplier="1:1" id="7ly-Lj-IMy"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="tcV-YL-brG"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="um1-9z-Fld"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="7"/>
@@ -153,11 +159,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="8" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMI-IV-KI3" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="95" y="190" width="70" height="70"/>
+                                    <rect key="frame" x="91" y="170" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number8Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="16p-uS-Way"/>
-                                        <constraint firstAttribute="height" constant="70" id="4AQ-IU-kLz"/>
+                                        <constraint firstAttribute="width" secondItem="qMI-IV-KI3" secondAttribute="height" multiplier="1:1" id="19A-do-8lq"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="4AQ-IU-kLz"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="b0h-ir-2Sq"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="8"/>
@@ -166,11 +173,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="9" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="48Q-nf-LTg" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="190" y="190" width="70" height="70"/>
+                                    <rect key="frame" x="182" y="170" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number9Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="l9b-r6-Rvh"/>
-                                        <constraint firstAttribute="height" constant="70" id="v3f-Wd-fta"/>
+                                        <constraint firstAttribute="width" secondItem="48Q-nf-LTg" secondAttribute="height" multiplier="1:1" id="3ze-2B-jFg"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="eJV-li-BVi"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="v3f-Wd-fta"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="9"/>
@@ -179,11 +187,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TIO-8z-Ags" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="95" y="285" width="70" height="70"/>
+                                    <rect key="frame" x="91" y="255" width="66" height="66"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number0Button"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="70" id="Pq5-Dx-0EG"/>
-                                        <constraint firstAttribute="width" constant="70" id="fao-vC-quL"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="700" id="Pq5-Dx-0EG"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="lxK-T4-YZ5"/>
+                                        <constraint firstAttribute="width" secondItem="TIO-8z-Ags" secondAttribute="height" multiplier="1:1" id="yF7-vI-pYh"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="0"/>
@@ -192,11 +201,12 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F9C-Vg-uCq" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="190" y="285" width="70" height="70"/>
+                                    <rect key="frame" x="182" y="255" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="deleteButton"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="6Fm-gg-AH0"/>
-                                        <constraint firstAttribute="height" constant="70" id="eG6-EM-pft"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="MaJ-rl-XGF"/>
+                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="70" id="eG6-EM-pft"/>
+                                        <constraint firstAttribute="width" secondItem="F9C-Vg-uCq" secondAttribute="height" multiplier="1:1" id="vIK-f5-d7o"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                     <state key="normal" title="←"/>
@@ -232,36 +242,24 @@
                                 <constraint firstItem="F9C-Vg-uCq" firstAttribute="leading" secondItem="48Q-nf-LTg" secondAttribute="leading" id="um2-Vu-YJz"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g0I-oo-iOZ" customClass="ThemeButton" customModule="ownCloud" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="528" width="320" height="40"/>
-                            <accessibility key="accessibilityConfiguration" identifier="cancelButton"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="40" id="0Oj-9o-xDM"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <state key="normal" title="Cancel"/>
-                            <connections>
-                                <action selector="cancel:" destination="-1" eventType="touchUpInside" id="zbk-aE-dpX"/>
-                            </connections>
-                        </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oPw-HC-8y2">
-                            <rect key="frame" x="0.0" y="30" width="320" height="103"/>
+                            <rect key="frame" x="0.0" y="30" width="320" height="107"/>
                             <subviews>
-                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Enter code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vti-jb-9pW">
+                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Enter code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vti-jb-9pW">
                                     <rect key="frame" x="118.5" y="20" width="83" height="21"/>
                                     <accessibility key="accessibilityConfiguration" identifier="messageLabel"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="* * * *" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Udf-vz-0kh">
+                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="* * * *" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Udf-vz-0kh">
                                     <rect key="frame" x="138.5" y="53" width="43" height="21"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mT7-pc-IHc">
-                                    <rect key="frame" x="141" y="86" width="38" height="21"/>
+                                <label verifyAmbiguity="ignoreSizes" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Error" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mT7-pc-IHc">
+                                    <rect key="frame" x="10" y="86" width="300" height="21"/>
                                     <accessibility key="accessibilityConfiguration" identifier="errorMessageLabel"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
@@ -272,27 +270,41 @@
                                 <constraint firstItem="vti-jb-9pW" firstAttribute="centerX" secondItem="oPw-HC-8y2" secondAttribute="centerX" id="3Df-UV-RCR"/>
                                 <constraint firstAttribute="bottom" secondItem="mT7-pc-IHc" secondAttribute="bottom" id="D8y-kw-hYG"/>
                                 <constraint firstItem="mT7-pc-IHc" firstAttribute="top" secondItem="Udf-vz-0kh" secondAttribute="bottom" constant="12" id="WXd-sw-amI"/>
+                                <constraint firstAttribute="trailing" secondItem="mT7-pc-IHc" secondAttribute="trailing" constant="10" id="aa3-bQ-KTm"/>
                                 <constraint firstItem="Udf-vz-0kh" firstAttribute="top" secondItem="vti-jb-9pW" secondAttribute="bottom" constant="12" id="hEr-H5-YnS"/>
+                                <constraint firstItem="mT7-pc-IHc" firstAttribute="leading" secondItem="oPw-HC-8y2" secondAttribute="leading" constant="10" id="if2-mc-P1w"/>
                                 <constraint firstItem="vti-jb-9pW" firstAttribute="top" secondItem="oPw-HC-8y2" secondAttribute="top" constant="20" symbolic="YES" id="m0D-rg-jNe"/>
                                 <constraint firstItem="mT7-pc-IHc" firstAttribute="centerX" secondItem="oPw-HC-8y2" secondAttribute="centerX" id="yb6-fF-dnc"/>
                                 <constraint firstItem="Udf-vz-0kh" firstAttribute="centerX" secondItem="oPw-HC-8y2" secondAttribute="centerX" id="zJZ-al-5Qp"/>
                             </constraints>
                         </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g0I-oo-iOZ" customClass="ThemeButton" customModule="ownCloud" customModuleProvider="target">
+                            <rect key="frame" x="39" y="430" width="242" height="40"/>
+                            <accessibility key="accessibilityConfiguration" identifier="cancelButton"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="40" id="0Oj-9o-xDM"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <state key="normal" title="Cancel"/>
+                            <connections>
+                                <action selector="cancel:" destination="-1" eventType="touchUpInside" id="zbk-aE-dpX"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="C0s-hA-da3" secondAttribute="bottom" constant="20" id="6uw-gm-S8h"/>
-                        <constraint firstItem="C0s-hA-da3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oPw-HC-8y2" secondAttribute="bottom" constant="20" id="7Rk-YS-2Zz"/>
+                        <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="g0I-oo-iOZ" secondAttribute="bottom" constant="10" id="0Px-wZ-QWT"/>
+                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="C0s-hA-da3" secondAttribute="bottom" priority="950" constant="20" id="6uw-gm-S8h"/>
+                        <constraint firstItem="C0s-hA-da3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oPw-HC-8y2" secondAttribute="bottom" priority="800" constant="20" id="7Rk-YS-2Zz"/>
                         <constraint firstItem="oPw-HC-8y2" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="10" id="BxH-1x-Cyq"/>
                         <constraint firstItem="oPw-HC-8y2" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="DOJ-Do-KD6"/>
-                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="GWS-Or-63N"/>
                         <constraint firstItem="C0s-hA-da3" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" priority="750" id="JGQ-XG-40S"/>
-                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="Qth-0N-kkC"/>
-                        <constraint firstItem="C0s-hA-da3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oPw-HC-8y2" secondAttribute="bottom" priority="800" constant="40" id="TK8-nl-3PE"/>
+                        <constraint firstItem="C0s-hA-da3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oPw-HC-8y2" secondAttribute="bottom" priority="900" constant="10" id="Qow-fk-Qhw"/>
                         <constraint firstItem="ox7-yY-YRf" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="WDx-6c-mIr"/>
+                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="width" secondItem="C0s-hA-da3" secondAttribute="width" id="cia-Wu-KP3"/>
                         <constraint firstItem="oPw-HC-8y2" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="e99-lj-C90"/>
                         <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="oPw-HC-8y2" secondAttribute="trailing" id="g0o-gI-ftc"/>
                         <constraint firstItem="ox7-yY-YRf" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="mep-i5-O1J"/>
-                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="pX7-gx-3Oz"/>
+                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="rkx-CB-L4A"/>
                         <constraint firstItem="C0s-hA-da3" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="sXo-1O-IQ9"/>
                     </constraints>
                     <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/ownCloud/Settings/Passcode/PasscodeViewController.xib
+++ b/ownCloud/Settings/Passcode/PasscodeViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina3_5" orientation="portrait">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -37,32 +37,32 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1ua-9z-VE2">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZQ4-NE-Hrm">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Kaa-V6-9Rt">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </view>
                     <blurEffect style="light"/>
                 </visualEffectView>
                 <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i5M-Pr-FkT" userLabel="Lock Screen">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timeout message label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ox7-yY-YRf">
-                            <rect key="frame" x="71.5" y="229.5" width="177" height="21"/>
+                            <rect key="frame" x="71.5" y="273.5" width="177" height="21"/>
                             <accessibility key="accessibilityConfiguration" identifier="timeoutMessageLabel"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view verifyAmbiguity="off" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C0s-hA-da3" userLabel="Keypad" customClass="KeyboardInput" customModule="ownCloud" customModuleProvider="target">
-                            <rect key="frame" x="39" y="95" width="242" height="315"/>
+                            <rect key="frame" x="45" y="157" width="230" height="315"/>
                             <subviews>
                                 <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="85k-O3-nSF" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="66" height="66"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number1Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="85k-O3-nSF" secondAttribute="height" multiplier="1:1" id="Vh0-fP-3Vw"/>
@@ -76,7 +76,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VzK-5I-Ct8" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="91" y="0.0" width="66" height="66"/>
+                                    <rect key="frame" x="85" y="0.0" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number2Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="VzK-5I-Ct8" secondAttribute="height" multiplier="1:1" id="UQj-g6-A3V"/>
@@ -90,7 +90,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gBp-H8-606" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="182" y="0.0" width="60" height="60"/>
+                                    <rect key="frame" x="170" y="0.0" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number3Button"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="Owh-E0-zIP"/>
@@ -104,7 +104,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IVZ-la-esK" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="85" width="66" height="66"/>
+                                    <rect key="frame" x="0.0" y="85" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number4Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="IVZ-la-esK" secondAttribute="height" multiplier="1:1" id="RMu-ty-Arw"/>
@@ -117,7 +117,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9xg-xz-Tph" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="91" y="85" width="66" height="66"/>
+                                    <rect key="frame" x="85" y="85" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number5Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="9xg-xz-Tph" secondAttribute="height" multiplier="1:1" id="CUF-qf-Jqe"/>
@@ -131,7 +131,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgh-7z-Fto" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="182" y="85" width="60" height="60"/>
+                                    <rect key="frame" x="170" y="85" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number6Button"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="lessThanOrEqual" priority="700" constant="70" id="4Up-dH-UDB"/>
@@ -145,7 +145,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fMx-64-bYq" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="170" width="66" height="66"/>
+                                    <rect key="frame" x="0.0" y="170" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number7Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="fMx-64-bYq" secondAttribute="height" multiplier="1:1" id="7ly-Lj-IMy"/>
@@ -159,7 +159,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="8" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMI-IV-KI3" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="91" y="170" width="66" height="66"/>
+                                    <rect key="frame" x="85" y="170" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number8Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="qMI-IV-KI3" secondAttribute="height" multiplier="1:1" id="19A-do-8lq"/>
@@ -173,7 +173,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" tag="9" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="48Q-nf-LTg" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="182" y="170" width="60" height="60"/>
+                                    <rect key="frame" x="170" y="170" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number9Button"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="48Q-nf-LTg" secondAttribute="height" multiplier="1:1" id="3ze-2B-jFg"/>
@@ -187,7 +187,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TIO-8z-Ags" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="91" y="255" width="66" height="66"/>
+                                    <rect key="frame" x="85" y="255" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="number0Button"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="700" id="Pq5-Dx-0EG"/>
@@ -201,7 +201,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F9C-Vg-uCq" customClass="ThemeRoundedButton" customModule="ownCloud" customModuleProvider="target">
-                                    <rect key="frame" x="182" y="255" width="60" height="60"/>
+                                    <rect key="frame" x="170" y="255" width="60" height="60"/>
                                     <accessibility key="accessibilityConfiguration" identifier="deleteButton"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="MaJ-rl-XGF"/>
@@ -279,10 +279,11 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g0I-oo-iOZ" customClass="ThemeButton" customModule="ownCloud" customModuleProvider="target">
-                            <rect key="frame" x="39" y="430" width="242" height="40"/>
+                            <rect key="frame" x="20" y="518" width="280" height="40"/>
                             <accessibility key="accessibilityConfiguration" identifier="cancelButton"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="0Oj-9o-xDM"/>
+                                <constraint firstAttribute="width" constant="280" id="4Fy-O9-b7t"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <state key="normal" title="Cancel"/>
@@ -300,7 +301,6 @@
                         <constraint firstItem="C0s-hA-da3" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" priority="750" id="JGQ-XG-40S"/>
                         <constraint firstItem="C0s-hA-da3" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oPw-HC-8y2" secondAttribute="bottom" priority="900" constant="10" id="Qow-fk-Qhw"/>
                         <constraint firstItem="ox7-yY-YRf" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="WDx-6c-mIr"/>
-                        <constraint firstItem="g0I-oo-iOZ" firstAttribute="width" secondItem="C0s-hA-da3" secondAttribute="width" id="cia-Wu-KP3"/>
                         <constraint firstItem="oPw-HC-8y2" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="e99-lj-C90"/>
                         <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="oPw-HC-8y2" secondAttribute="trailing" id="g0o-gI-ftc"/>
                         <constraint firstItem="ox7-yY-YRf" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="mep-i5-O1J"/>
@@ -321,7 +321,7 @@
                 <constraint firstItem="i5M-Pr-FkT" firstAttribute="trailing" secondItem="1ua-9z-VE2" secondAttribute="trailing" id="zyI-Ld-o7i"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="vyp-4Q-SVo"/>
-            <point key="canvasLocation" x="414" y="50"/>
+            <point key="canvasLocation" x="412.5" y="50"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
## Description
- changed full width button to a rounded button
- fixed passcode view, error label and cancel button for smaller display sizes (iPhone SE)

## Related Issue
#302 

## Motivation and Context
- remove full width buttons, because it doesn't look like a button (see #232)

## How Has This Been Tested?
- open settings
- enable / disable pass-lock 
- please test on iPhone SE, iPhone XS Max, iPad Pro 12,9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
