### PR TITLE
[feature/http-warning] Warn of plain HTTP URLs during setup

### DIFF
--- a/ownCloud/Bookmarks/BookmarkViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkViewController.swift
@@ -742,7 +742,7 @@ class BookmarkViewController: StaticTableViewController {
 	func isAuthenticationMethodTokenBased(_ authenticationMethodIdentifier: OCAuthenticationMethodIdentifier) -> Bool {
 		return authenticationMethodTypeForIdentifier(authenticationMethodIdentifier) == OCAuthenticationMethodType.token
 	}
-	
+
 	// MARK: - Keyboard AccessoryView
 	@objc func toogleTextField (_ sender: UIBarButtonItem) {
 		if passwordRow?.textField?.isFirstResponder ?? false {
@@ -789,7 +789,7 @@ extension BookmarkViewController : OCClassSettingsSupport {
 
 // MARK: - Keyboard / return key tracking
 extension BookmarkViewController : UITextFieldDelegate {
-	
+
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
 		if self.navigationItem.rightBarButtonItem == continueBarButtonItem {
 			if !updateInputFocus() {
@@ -801,7 +801,7 @@ extension BookmarkViewController : UITextFieldDelegate {
 
 		return true
 	}
-	
+
 	func textFieldDidBeginEditing(_ textField: UITextField) {
 		activeTextField = textField
 		if textField.isEqual(urlRow?.textField) {

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -596,7 +596,7 @@ class ClientQueryViewController: UITableViewController, Themeable {
 			let filename = ressource.originalFilename
 
 			let progress = Progress(totalUnitCount: 100)
-			progress.localizedDescription = String(format: "Importing '%@' from photo library".localized , filename)
+			progress.localizedDescription = String(format: "Importing '%@' from photo library".localized, filename)
 
 			let options = PHAssetResourceRequestOptions()
 			options.isNetworkAccessAllowed = true

--- a/ownCloud/Client/PhotoSelectionViewCell.swift
+++ b/ownCloud/Client/PhotoSelectionViewCell.swift
@@ -28,7 +28,7 @@ class PhotoSelectionViewCell: UICollectionViewCell {
 	var mediaTypeBadgeImageView = UIImageView()
 	var checkmarkBadgeImageView = UIImageView()
 	var videoDurationLabel = UILabel()
-	
+
 	var assetIdentifier: String!
 
 	var thumbnailImage: UIImage! {

--- a/ownCloud/SDK Extensions/OCIssue+Extension.swift
+++ b/ownCloud/SDK Extensions/OCIssue+Extension.swift
@@ -46,7 +46,7 @@ extension OCIssue {
 					}
 				}
 
-			case .urlRedirection, .certificate, .error, .multipleChoice:
+			case .urlRedirection, .certificate, .error, .generic, .multipleChoice:
 				displayIssues = [self]
 		}
 


### PR DESCRIPTION
## Description
Introduces a new warning when trying to setup an account with a plain HTTP URL (via updated SDK and a new generic issue type).

## Related Issue
#267 ( @michaelstingl 's comment: https://github.com/owncloud/ios-app/issues/267#issuecomment-475214961)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
