### PR TITLE
Feature/heic to jpeg

### DIFF
--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		4C464BF62187AF1500D30602 /* PDFTocItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C464BEE2187AF1500D30602 /* PDFTocItem.swift */; };
 		4C6B78102226B83300C5F3DB /* PhotoAlbumTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B780F2226B83300C5F3DB /* PhotoAlbumTableViewController.swift */; };
 		4C6B78122226B86300C5F3DB /* PhotoAlbumTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B78112226B86300C5F3DB /* PhotoAlbumTableViewCell.swift */; };
+		4C80B1E62271BBB400252901 /* PhotoUploadSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C80B1E52271BBB400252901 /* PhotoUploadSection.swift */; };
 		4CF8CAB121F9B70600B8CA67 /* UIBarButtonItem+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CAB021F9B70500B8CA67 /* UIBarButtonItem+Extension.swift */; };
 		5917244E20D3DC2100809B38 /* BiometricalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917244D20D3DC2100809B38 /* BiometricalTests.swift */; };
 		593A821120C7D4C5000E2A90 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 593A821320C7D4C5000E2A90 /* Localizable.strings */; };
@@ -508,6 +509,7 @@
 		4C464BEE2187AF1500D30602 /* PDFTocItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PDFTocItem.swift; sourceTree = "<group>"; };
 		4C6B780F2226B83300C5F3DB /* PhotoAlbumTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoAlbumTableViewController.swift; sourceTree = "<group>"; };
 		4C6B78112226B86300C5F3DB /* PhotoAlbumTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoAlbumTableViewCell.swift; sourceTree = "<group>"; };
+		4C80B1E52271BBB400252901 /* PhotoUploadSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoUploadSection.swift; sourceTree = "<group>"; };
 		4CF8CAB021F9B70500B8CA67 /* UIBarButtonItem+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Extension.swift"; sourceTree = "<group>"; };
 		5917244D20D3DC2100809B38 /* BiometricalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricalTests.swift; sourceTree = "<group>"; };
 		593A821220C7D4C5000E2A90 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; lineEnding = 0; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1357,6 +1359,7 @@
 				233E0FD72099F11D00C3D8D5 /* SecuritySettingsSection.swift */,
 				DC854935218331CF00782BA8 /* UserInterfaceSettingsSection.swift */,
 				232F7CAC2097140300EE22E4 /* UploadsSettingsSection.swift */,
+				4C80B1E52271BBB400252901 /* PhotoUploadSection.swift */,
 				23957A6C209AFFE8003C8537 /* MoreSettingsSection.swift */,
 				DCF4F1812051A94200189B9A /* GlobalSettingsViewController.swift */,
 				232F7CAE2097260400EE22E4 /* SettingsViewController.swift */,
@@ -1873,6 +1876,7 @@
 				DC018F8C20A1060A00135198 /* ProgressHUDViewController.swift in Sources */,
 				DC7DBA29207F71D600E7337D /* VectorImage.swift in Sources */,
 				4C464BF12187AF1500D30602 /* PDFTocTableViewCell.swift in Sources */,
+				4C80B1E62271BBB400252901 /* PhotoUploadSection.swift in Sources */,
 				DC1B270C209CF34B004715E1 /* BookmarkViewController.swift in Sources */,
 				DC63208321FCAC1E007EC0A8 /* ClientActivityViewController.swift in Sources */,
 				23EC775A2137F3DD0032D4E6 /* DisplayHostViewController.swift in Sources */,

--- a/ownCloud/Resources/de-DE.lproj/Localizable.strings
+++ b/ownCloud/Resources/de-DE.lproj/Localizable.strings
@@ -253,3 +253,7 @@
 "%@ of %@" = "%@ von %@";
 "Invalid Page" = "Ungültige Seite";
 "The entered page number doesn't exist" = "Die eingegebene Seitennummer existiert nicht";
+
+/* Photo upload settings */
+"Photo Upload" = "Fotos hochladen";
+"Convert HEIC to JPEG" = "HEIC in JPEG konvertieren";

--- a/ownCloud/Resources/de.lproj/Localizable.strings
+++ b/ownCloud/Resources/de.lproj/Localizable.strings
@@ -253,3 +253,7 @@
 "%@ of %@" = "%@ von %@";
 "Invalid Page" = "Ungültige Seite";
 "The entered page number doesn't exist" = "Die angegebene Seitennummer existiert nicht.";
+
+/* Photo upload settings */
+"Photo Upload" = "Fotos hochladen";
+"Convert HEIC to JPEG" = "HEIC in JPEG konvertieren";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -268,3 +268,7 @@
 "All Photos" = "All Photos";
 "Albums" = "Albums";
 "Importing '%@' from photo library" = "Importing '%@' from photo library";
+
+/* Photo upload settings */
+"Photo Upload" = "Photo Upload";
+"Convert HEIC to JPEG" = "Convert HEIC to JPEG";

--- a/ownCloud/Resources/ru.lproj/Localizable.strings
+++ b/ownCloud/Resources/ru.lproj/Localizable.strings
@@ -233,3 +233,7 @@
 "%@ of %@" = "%@ из %@";
 "Invalid Page" = "Неверная страница";
 "The entered page number doesn't exist" = "Введённый номер страницы не существует";
+
+/* Photo upload settings */
+"Photo Upload" = "Загрузка фото";
+"Convert HEIC to JPEG" = "Конвертировать HEIC в JPEG";

--- a/ownCloud/Settings/PhotoUploadSection.swift
+++ b/ownCloud/Settings/PhotoUploadSection.swift
@@ -6,6 +6,16 @@
 //  Copyright © 2019 ownCloud GmbH. All rights reserved.
 //
 
+/*
+* Copyright (C) 2018, ownCloud GmbH.
+*
+* This code is covered by the GNU Public License Version 3.
+*
+* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+*
+*/
+
 import UIKit
 
 extension UserDefaults {

--- a/ownCloud/Settings/PhotoUploadSection.swift
+++ b/ownCloud/Settings/PhotoUploadSection.swift
@@ -1,0 +1,48 @@
+//
+//  PhotoUploadSection.swift
+//  ownCloud
+//
+//  Created by Michael Neuwert on 25.04.2019.
+//  Copyright © 2019 ownCloud GmbH. All rights reserved.
+//
+
+import UIKit
+
+extension UserDefaults {
+
+	enum PhtoUploadKeys : String {
+		case ConvertHEICtoJPEGKey = "convert-heic-to-jpeg"
+	}
+
+	public var convertHeic: Bool {
+		set {
+			self.set(newValue, forKey: PhtoUploadKeys.ConvertHEICtoJPEGKey.rawValue)
+		}
+
+		get {
+			return self.bool(forKey: PhtoUploadKeys.ConvertHEICtoJPEGKey.rawValue)
+		}
+	}
+}
+
+class PhotoUploadSettingsSection: SettingsSection {
+
+	private var convertSwitchRow: StaticTableViewRow?
+
+	override init(userDefaults: UserDefaults) {
+
+		super.init(userDefaults: userDefaults)
+
+		self.headerTitle = "Photo Upload".localized
+		self.identifier = "photo-upload"
+
+		convertSwitchRow = StaticTableViewRow(switchWithAction: { [weak self] (_, sender) in
+			if let convertSwitch = sender as? UISwitch {
+				self?.userDefaults.convertHeic = convertSwitch.isOn
+			}
+			}, title: "Convert HEIC to JPEG".localized, value: self.userDefaults.convertHeic)
+
+		self.add(row: convertSwitchRow!)
+	}
+
+}

--- a/ownCloud/Settings/SettingsViewController.swift
+++ b/ownCloud/Settings/SettingsViewController.swift
@@ -20,22 +20,22 @@ import UIKit
 import ownCloudSDK
 
 class SettingsViewController: StaticTableViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        self.navigationItem.title = "Settings".localized
-
-        let userDefaults = OCAppIdentity.shared.userDefaults
-
-        let securitySettings = SecuritySettingsSection(userDefaults: userDefaults!)
-        let userInterfaceSettings = UserInterfaceSettingsSection(userDefaults: userDefaults!)
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		self.navigationItem.title = "Settings".localized
+		
+		let userDefaults = OCAppIdentity.shared.userDefaults
+		
+		let securitySettings = SecuritySettingsSection(userDefaults: userDefaults!)
+		let userInterfaceSettings = UserInterfaceSettingsSection(userDefaults: userDefaults!)
 		let photoUploadSettings = PhotoUploadSettingsSection(userDefaults: userDefaults!)
-        let moreSettings = MoreSettingsSection(userDefaults: userDefaults!)
-        self.addSection(securitySettings)
-        self.addSection(userInterfaceSettings)
+		let moreSettings = MoreSettingsSection(userDefaults: userDefaults!)
+		self.addSection(securitySettings)
+		self.addSection(userInterfaceSettings)
 		self.addSection(photoUploadSettings)
-        self.addSection(moreSettings)
-    }
-
+		self.addSection(moreSettings)
+	}
+	
 }

--- a/ownCloud/Settings/SettingsViewController.swift
+++ b/ownCloud/Settings/SettingsViewController.swift
@@ -30,9 +30,11 @@ class SettingsViewController: StaticTableViewController {
 
         let securitySettings = SecuritySettingsSection(userDefaults: userDefaults!)
         let userInterfaceSettings = UserInterfaceSettingsSection(userDefaults: userDefaults!)
+		let photoUploadSettings = PhotoUploadSettingsSection(userDefaults: userDefaults!)
         let moreSettings = MoreSettingsSection(userDefaults: userDefaults!)
         self.addSection(securitySettings)
         self.addSection(userInterfaceSettings)
+		self.addSection(photoUploadSettings)
         self.addSection(moreSettings)
     }
 


### PR DESCRIPTION
## Description
Added possibility to convert photos stored in HEIC format to JPEG before uploading. Also added corresponding settings.

## Motivation and Context
Many users who would like to open their photos on platforms other than macOS / iOS where the HEIF support is either limited or non-existing.

## Known Issues
Metadata is not preserved when the photo is uploaded but it seems to apply also to non-converted photos. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

