### PR TITLE
Fixing #365: Colliding names when uploading from Albums

### DIFF
--- a/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
@@ -7,13 +7,13 @@
 //
 
 /*
- * Copyright (C) 2019, ownCloud GmbH.
- *
- * This code is covered by the GNU Public License Version 3.
- *
- * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
- * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
- *
+* Copyright (C) 2019, ownCloud GmbH.
+*
+* This code is covered by the GNU Public License Version 3.
+*
+* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+*
 */
 
 import UIKit
@@ -36,20 +36,30 @@ class UploadBaseAction: Action {
 	}
 
 	// MARK: - Upload
-	func upload(itemURL: URL, to rootItem: OCItem, name: String, completionHandler: ClientActionCompletionHandler? = nil) {
-		if let progress = core?.importFileNamed(name, at: rootItem, from: itemURL, isSecurityScoped: false, options: nil, placeholderCompletionHandler: nil, resultHandler: { (error, _ core, _ item, _) in
-			if error != nil {
-				Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path))")
-				completionHandler?(false)
-			} else {
-				Log.debug("Success uploading \(Log.mask(name)) to \(Log.mask(rootItem.path))")
-				completionHandler?(true)
-			}
+	func upload(itemURL: URL, to rootItem: OCItem, name: String, completionHandler: ClientActionCompletionHandler? = nil, importByCopy:Bool = false) {
+		if let progress = core?.importFileNamed(name,
+												at: rootItem,
+												from: itemURL,
+												isSecurityScoped: false,
+												options: importByCopy ? [OCCoreOption.importByCopying : true] : nil,
+												placeholderCompletionHandler: { (error, item) in
+													Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
+													completionHandler?(false, error)
+
+		},
+												resultHandler: { (error, _ core, _ item, _) in
+													if error != nil {
+														Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
+														completionHandler?(false, error)
+													} else {
+														Log.debug("Success uploading \(Log.mask(name)) to \(Log.mask(rootItem.path))")
+														completionHandler?(true, nil)
+													}
 		}) {
 			self.publish(progress: progress)
 		} else {
 			Log.debug("Error setting up upload of \(Log.mask(name)) to \(Log.mask(rootItem.path))")
-			completionHandler?(false)
+			completionHandler?(false, nil)
 		}
 	}
 }

--- a/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
@@ -43,9 +43,10 @@ class UploadBaseAction: Action {
 												isSecurityScoped: false,
 												options: importByCopy ? [OCCoreOption.importByCopying : true] : nil,
 												placeholderCompletionHandler: { (error, item) in
-													Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
-													completionHandler?(false, error)
-
+													if error != nil {
+														Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
+														completionHandler?(false, error)
+													}
 		},
 												resultHandler: { (error, _ core, _ item, _) in
 													if error != nil {

--- a/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/UploadBaseAction.swift
@@ -20,6 +20,10 @@ import UIKit
 import ownCloudSDK
 
 class UploadBaseAction: Action {
+
+	typealias UploadCompletionHandler = (_ success: Bool, _ item:OCItem?) -> Void
+	typealias UploadPlaceholderCompletionHandler = (_ item:OCItem?, _ error:Error?) -> Void
+
 	// MARK: - Action Matching
 	override class func applicablePosition(forContext: ActionContext) -> ActionPosition {
 		// Only available for a single item ..
@@ -36,7 +40,7 @@ class UploadBaseAction: Action {
 	}
 
 	// MARK: - Upload
-	func upload(itemURL: URL, to rootItem: OCItem, name: String, completionHandler: ClientActionCompletionHandler? = nil, importByCopy:Bool = false) {
+	func upload(itemURL: URL, to rootItem: OCItem, name: String, completionHandler: UploadCompletionHandler? = nil, placeholderHandler:UploadPlaceholderCompletionHandler? = nil, importByCopy:Bool = false) {
 		if let progress = core?.importFileNamed(name,
 												at: rootItem,
 												from: itemURL,
@@ -45,16 +49,16 @@ class UploadBaseAction: Action {
 												placeholderCompletionHandler: { (error, item) in
 													if error != nil {
 														Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
-														completionHandler?(false, error)
 													}
+													placeholderHandler?(item, error)
 		},
 												resultHandler: { (error, _ core, _ item, _) in
 													if error != nil {
 														Log.debug("Error uploading \(Log.mask(name)) to \(Log.mask(rootItem.path)), error: \(error?.localizedDescription ?? "" )")
-														completionHandler?(false, error)
+														completionHandler?(false, item)
 													} else {
 														Log.debug("Success uploading \(Log.mask(name)) to \(Log.mask(rootItem.path))")
-														completionHandler?(true, nil)
+														completionHandler?(true, item)
 													}
 		}) {
 			self.publish(progress: progress)

--- a/ownCloud/Client/Actions/Actions+Extensions/UploadPhotosAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/UploadPhotosAction.swift
@@ -231,7 +231,7 @@ class UploadPhotosAction: UploadBaseAction {
 							// Upload to the cloud
 							performUpload(sourceURL: localURL, copySource: false)
 						} else {
-							completion(false, false)
+							completion(false, true)
 						}
 					}
 				} else {

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -21,7 +21,7 @@ import ownCloudSDK
 import MobileCoreServices
 
 typealias ClientActionVieDidAppearHandler = () -> Void
-typealias ClientActionCompletionHandler = (_ actionPerformed: Bool, _ error:Error?) -> Void
+typealias ClientActionCompletionHandler = (_ actionPerformed: Bool) -> Void
 
 extension OCQueryState {
 	var isFinal: Bool {
@@ -744,10 +744,10 @@ class ClientQueryViewController: UITableViewController, Themeable, UIDropInterac
 		   let progress = core?.importFileNamed(name, at: rootItem, from: itemURL, isSecurityScoped: false, options: nil, placeholderCompletionHandler: nil, resultHandler: { (error, _ core, _ item, _) in
 			if error != nil {
 				Log.debug("Error uploading \(Log.mask(name)) file to \(Log.mask(rootItem.path))")
-				completionHandler?(false, error)
+				completionHandler?(false)
 			} else {
 				Log.debug("Success uploading \(Log.mask(name)) file to \(Log.mask(rootItem.path))")
-				completionHandler?(true, nil)
+				completionHandler?(true)
 			}
 		}) {
 			self.progressSummarizer?.startTracking(progress: progress)

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -21,7 +21,7 @@ import ownCloudSDK
 import MobileCoreServices
 
 typealias ClientActionVieDidAppearHandler = () -> Void
-typealias ClientActionCompletionHandler = (_ actionPerformed: Bool) -> Void
+typealias ClientActionCompletionHandler = (_ actionPerformed: Bool, _ error:Error?) -> Void
 
 extension OCQueryState {
 	var isFinal: Bool {
@@ -744,10 +744,10 @@ class ClientQueryViewController: UITableViewController, Themeable, UIDropInterac
 		   let progress = core?.importFileNamed(name, at: rootItem, from: itemURL, isSecurityScoped: false, options: nil, placeholderCompletionHandler: nil, resultHandler: { (error, _ core, _ item, _) in
 			if error != nil {
 				Log.debug("Error uploading \(Log.mask(name)) file to \(Log.mask(rootItem.path))")
-				completionHandler?(false)
+				completionHandler?(false, error)
 			} else {
 				Log.debug("Success uploading \(Log.mask(name)) file to \(Log.mask(rootItem.path))")
-				completionHandler?(true)
+				completionHandler?(true, nil)
 			}
 		}) {
 			self.progressSummarizer?.startTracking(progress: progress)

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -267,7 +267,7 @@
 "Deselect All" = "Deselect All";
 "All Photos" = "All Photos";
 "Albums" = "Albums";
-"Importing asset from photo library" = "Importing asset from photo library";
+"Importing from photo library" = "Importing from photo library";
 
 /* Photo upload settings */
 "Photo Upload" = "Photo Upload";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -267,7 +267,7 @@
 "Deselect All" = "Deselect All";
 "All Photos" = "All Photos";
 "Albums" = "Albums";
-"Importing '%@' from photo library" = "Importing '%@' from photo library";
+"Importing asset from photo library" = "Importing asset from photo library";
 
 /* Photo upload settings */
 "Photo Upload" = "Photo Upload";


### PR DESCRIPTION
## Description
- Offloaded photo import operations off the main thread
- Using fullsize image URL to derive filename

## Related Issue
#365 

## Motivation and Context
@felix-schwarz reported that UI thread is blocked while uploading a bunch of images.
@jesmrec reported in #365 that there are name conflicts on his device when uploading images from 'Screenshots' album.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

____

Bugs & improvements:

- [ ] (1) Colliding name https://github.com/owncloud/ios-app/pull/370#issuecomment-488618221