### PR TITLE
Fixed an issue with go-to button not being shown in PDF viewer

### DIFF
--- a/ownCloud/Client/Viewer/DisplayViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayViewController.swift
@@ -82,6 +82,8 @@ class DisplayViewController: UIViewController, OCQueryDelegate {
 		}
 	}
 
+	var shallDisplayMoreButtonInToolbar = true
+
 	private var state: DisplayViewState = .hasNetworkConnection {
 		didSet {
 			OnMainThread(inline: true) {
@@ -254,9 +256,11 @@ class DisplayViewController: UIViewController, OCQueryDelegate {
 		if let parent = parent, let itemName = item?.name {
 			parent.navigationItem.title = itemName
 
-			let actionsBarButtonItem = UIBarButtonItem(title: "•••", style: .plain, target: self, action: #selector(optionsBarButtonPressed))
-			actionsBarButtonItem.accessibilityLabel = itemName + " " + "Actions".localized
-			parent.navigationItem.rightBarButtonItem = actionsBarButtonItem
+			if shallDisplayMoreButtonInToolbar {
+				let actionsBarButtonItem = UIBarButtonItem(image: UIImage(named: "more-dots"), style: .plain, target: self, action: #selector(optionsBarButtonPressed))
+				actionsBarButtonItem.accessibilityLabel = itemName + " " + "Actions".localized
+				parent.navigationItem.rightBarButtonItem = actionsBarButtonItem
+			}
 		}
 	}
 
@@ -434,10 +438,7 @@ class DisplayViewController: UIViewController, OCQueryDelegate {
 					}
 				}
 
-				if let parent = parent {
-					parent.navigationItem.title = item.name
-					parent.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "•••", style: .plain, target: self, action: #selector(optionsBarButtonPressed))
-				}
+				updateNavigationBarItems()
 		}
 	}
 }

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -7,362 +7,364 @@
 //
 
 /*
- * Copyright (C) 2018, ownCloud GmbH.
- *
- * This code is covered by the GNU Public License Version 3.
- *
- * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
- * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
- *
- */
+* Copyright (C) 2018, ownCloud GmbH.
+*
+* This code is covered by the GNU Public License Version 3.
+*
+* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+*
+*/
 
 import UIKit
 import ownCloudSDK
 import PDFKit
 
 extension UILabel {
-    func _setupPdfInfoLabel() {
-        self.layer.masksToBounds = true
-        self.layer.cornerRadius = 8.0
-        self.backgroundColor = UIColor.darkGray
-        self.textColor = UIColor.white
-        self.font = UIFont.systemFont(ofSize: 14.0, weight: UIFont.Weight.medium)
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.textAlignment = .center
-        self.adjustsFontSizeToFitWidth = true
-    }
+	func _setupPdfInfoLabel() {
+		self.layer.masksToBounds = true
+		self.layer.cornerRadius = 8.0
+		self.backgroundColor = UIColor.darkGray
+		self.textColor = UIColor.white
+		self.font = UIFont.systemFont(ofSize: 14.0, weight: UIFont.Weight.medium)
+		self.translatesAutoresizingMaskIntoConstraints = false
+		self.textAlignment = .center
+		self.adjustsFontSizeToFitWidth = true
+	}
 }
 
 class PDFViewerViewController: DisplayViewController, DisplayExtension {
 
-    enum ThumbnailViewPosition {
-        case left, right, bottom, none
-        func isVertical() -> Bool {
-            return self == .bottom ? false : true
-        }
-    }
+	enum ThumbnailViewPosition {
+		case left, right, bottom, none
+		func isVertical() -> Bool {
+			return self == .bottom ? false : true
+		}
+	}
 
-    static let PDFGoToPageNotification = Notification(name: Notification.Name(rawValue: "PDFGoToPageNotification"))
+	static let PDFGoToPageNotification = Notification(name: Notification.Name(rawValue: "PDFGoToPageNotification"))
 
 	fileprivate var gotoPageNotificationObserver : Any?
 
-    fileprivate let searchAnnotationDelay = 3.0
-    fileprivate let thumbnailViewWidthMultiplier: CGFloat = 0.15
-    fileprivate let thumbnailViewHeightMultiplier: CGFloat = 0.1
-    fileprivate let thumbnailMargin: CGFloat = 32.0
-    fileprivate let filenameContainerTopMargin: CGFloat = 10.0
-    fileprivate let pdfView = PDFView()
-    fileprivate let thumbnailView = PDFThumbnailView()
+	fileprivate let searchAnnotationDelay = 3.0
+	fileprivate let thumbnailViewWidthMultiplier: CGFloat = 0.15
+	fileprivate let thumbnailViewHeightMultiplier: CGFloat = 0.1
+	fileprivate let thumbnailMargin: CGFloat = 32.0
+	fileprivate let filenameContainerTopMargin: CGFloat = 10.0
+	fileprivate let pdfView = PDFView()
+	fileprivate let thumbnailView = PDFThumbnailView()
 
-    fileprivate let containerView = UIStackView()
-    fileprivate let pageCountLabel = UILabel()
+	fileprivate let containerView = UIStackView()
+	fileprivate let pageCountLabel = UILabel()
 
-    fileprivate var searchButtonItem: UIBarButtonItem?
-    fileprivate var gotoButtonItem: UIBarButtonItem?
-    fileprivate var outlineItem: UIBarButtonItem?
+	fileprivate var searchButtonItem: UIBarButtonItem?
+	fileprivate var gotoButtonItem: UIBarButtonItem?
+	fileprivate var outlineItem: UIBarButtonItem?
 
-    fileprivate var thumbnailViewPosition : ThumbnailViewPosition = .bottom {
-        didSet {
-            switch thumbnailViewPosition {
-            case .left, .right:
-                thumbnailView.layoutMode = .vertical
-            case .bottom:
-                thumbnailView.layoutMode = .horizontal
-            default:
-                break
-            }
+	fileprivate var thumbnailViewPosition : ThumbnailViewPosition = .bottom {
+		didSet {
+			switch thumbnailViewPosition {
+			case .left, .right:
+				thumbnailView.layoutMode = .vertical
+			case .bottom:
+				thumbnailView.layoutMode = .horizontal
+			default:
+				break
+			}
 
-            pageCountLabel.isHidden = thumbnailViewPosition == .none ? true : false
+			pageCountLabel.isHidden = thumbnailViewPosition == .none ? true : false
 
-            setupConstraints()
-        }
-    }
-
-    fileprivate var activeViewConstraints: [NSLayoutConstraint] = [] {
-        willSet {
-            NSLayoutConstraint.deactivate(activeViewConstraints)
-        }
-        didSet {
-            NSLayoutConstraint.activate(activeViewConstraints)
-        }
-    }
-
-    // MARK: - DisplayExtension
-
-    static var customMatcher: OCExtensionCustomContextMatcher?
-    static var displayExtensionIdentifier: String = "org.owncloud.pdfViewer.default"
-    static var supportedMimeTypes: [String]? = ["application/pdf"]
-    static var features: [String : Any]? = [FeatureKeys.canEdit : false]
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-        if gotoPageNotificationObserver != nil {
-	        NotificationCenter.default.removeObserver(gotoPageNotificationObserver!)
+			setupConstraints()
+		}
 	}
-    }
 
-    override func renderSpecificView() {
-        if let source = source, let document = PDFDocument(url: source) {
-            setupToolbar()
-
-            self.view.backgroundColor = UIColor.gray
-            self.thumbnailViewPosition = .none
-
-            // Configure thumbnail view
-            thumbnailView.translatesAutoresizingMaskIntoConstraints = false
-            thumbnailView.backgroundColor = UIColor.gray
-            thumbnailView.pdfView = pdfView
-            thumbnailView.isExclusiveTouch = true
-
-            self.view.addSubview(thumbnailView)
-
-            containerView.spacing = UIStackView.spacingUseSystem
-            containerView.isLayoutMarginsRelativeArrangement = true
-            containerView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: filenameContainerTopMargin,
-                                                                             leading: 0,
-                                                                             bottom: 0,
-                                                                             trailing: 0)
-            containerView.backgroundColor = UIColor.lightGray
-            containerView.translatesAutoresizingMaskIntoConstraints = false
-            containerView.axis = .vertical
-            containerView.distribution = .fill
-
-            // Configure PDFView instance
-            pdfView.displayDirection = .horizontal
-            pdfView.translatesAutoresizingMaskIntoConstraints = false
-            pdfView.usePageViewController(true, withViewOptions: nil)
-            containerView.addArrangedSubview(pdfView)
-
-            let pageCountContainerView = UIView()
-            pageCountContainerView.backgroundColor = UIColor.gray
-            pageCountContainerView.translatesAutoresizingMaskIntoConstraints = false
-            pageCountContainerView.addSubview(pageCountLabel)
-
-            pageCountLabel._setupPdfInfoLabel()
-            pageCountLabel.centerXAnchor.constraint(equalTo: pageCountContainerView.centerXAnchor).isActive = true
-            pageCountLabel.centerYAnchor.constraint(equalTo: pageCountContainerView.centerYAnchor).isActive = true
-            pageCountLabel.widthAnchor.constraint(equalTo: pageCountContainerView.widthAnchor, multiplier: 0.25).isActive = true
-            pageCountLabel.heightAnchor.constraint(equalTo: pageCountContainerView.heightAnchor, multiplier: 0.9).isActive = true
-
-            containerView.addArrangedSubview(pageCountContainerView)
-
-            self.view.addSubview(containerView)
-
-            setupConstraints()
-
-            self.view.layoutIfNeeded()
-
-            pdfView.document = document
-
-            pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
-            pdfView.autoScales = true
-            updatePageLabel()
-
-            adjustThumbnailsSize()
-
-        }
-    }
-
-    // MARK: - View lifecycle management
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(handlePageChanged), name: .PDFViewPageChanged, object: nil)
-
-        gotoPageNotificationObserver = NotificationCenter.default.addObserver(forName: PDFViewerViewController.PDFGoToPageNotification.name, object: nil, queue: OperationQueue.main) { [weak self] (notification) in
-            if let page = notification.object as? PDFPage {
-                self?.pdfView.go(to: page)
-            }
-        }
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        self.thumbnailViewPosition = .bottom
-
-        pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
-        pdfView.autoScales = true
-    }
-
-    func save(item: OCItem) {
-    	if let source = source {
-	        editingDelegate?.save(item: item, fileURL: source)
+	fileprivate var activeViewConstraints: [NSLayoutConstraint] = [] {
+		willSet {
+			NSLayoutConstraint.deactivate(activeViewConstraints)
+		}
+		didSet {
+			NSLayoutConstraint.activate(activeViewConstraints)
+		}
 	}
-    }
 
-    // MARK: - Handlers for PDF View notifications
+	// MARK: - DisplayExtension
 
-    @objc func handlePageChanged() {
-        updatePageLabel()
-    }
+	static var customMatcher: OCExtensionCustomContextMatcher?
+	static var displayExtensionIdentifier: String = "org.owncloud.pdfViewer.default"
+	static var supportedMimeTypes: [String]? = ["application/pdf"]
+	static var features: [String : Any]? = [FeatureKeys.canEdit : false]
 
-    // MARK: - Toolbar actions
+	deinit {
+		NotificationCenter.default.removeObserver(self)
+		if gotoPageNotificationObserver != nil {
+			NotificationCenter.default.removeObserver(gotoPageNotificationObserver!)
+		}
+	}
 
-    @objc func goToPage() {
+	override func renderSpecificView() {
+		if let source = source, let document = PDFDocument(url: source) {
+			setupToolbar()
 
-        guard let pdfDocument = pdfView.document else { return }
+			self.view.backgroundColor = UIColor.gray
+			self.thumbnailViewPosition = .none
 
-        let alertMessage = NSString(format: "This document has %@ pages".localized as NSString, "\(pdfDocument.pageCount)") as String
-        let alertController = UIAlertController(title: "Go to page".localized, message: alertMessage, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "Cancel".localized, style: .cancel, handler: nil))
+			// Configure thumbnail view
+			thumbnailView.translatesAutoresizingMaskIntoConstraints = false
+			thumbnailView.backgroundColor = UIColor.gray
+			thumbnailView.pdfView = pdfView
+			thumbnailView.isExclusiveTouch = true
 
-        alertController.addTextField(configurationHandler: { textField in
-            textField.placeholder = "Page".localized
-            textField.keyboardType = .decimalPad
-        })
+			self.view.addSubview(thumbnailView)
 
-        alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: { [unowned self] _ in
-            if let pageLabel = alertController.textFields?.first?.text {
-                self.selectPage(with: pageLabel)
-            }
-        }))
+			containerView.spacing = UIStackView.spacingUseSystem
+			containerView.isLayoutMarginsRelativeArrangement = true
+			containerView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: filenameContainerTopMargin,
+																			 leading: 0,
+																			 bottom: 0,
+																			 trailing: 0)
+			containerView.backgroundColor = UIColor.lightGray
+			containerView.translatesAutoresizingMaskIntoConstraints = false
+			containerView.axis = .vertical
+			containerView.distribution = .fill
 
-        self.present(alertController, animated: true)
-    }
+			// Configure PDFView instance
+			pdfView.displayDirection = .horizontal
+			pdfView.translatesAutoresizingMaskIntoConstraints = false
+			pdfView.usePageViewController(true, withViewOptions: nil)
+			containerView.addArrangedSubview(pdfView)
 
-    @objc func search() {
-        guard let pdfDocument = pdfView.document else { return }
+			let pageCountContainerView = UIView()
+			pageCountContainerView.backgroundColor = UIColor.gray
+			pageCountContainerView.translatesAutoresizingMaskIntoConstraints = false
+			pageCountContainerView.addSubview(pageCountLabel)
 
-        let pdfSearchController = PDFSearchViewController()
-        let searchNavigationController = ThemeNavigationController(rootViewController: pdfSearchController)
-        pdfSearchController.pdfDocument = pdfDocument
-        pdfSearchController.userSelectedMatchCallback = { (selection) in
-            DispatchQueue.main.async {
-                selection.color = UIColor.yellow
-                self.pdfView.setCurrentSelection(selection, animate: true)
-                self.pdfView.scrollSelectionToVisible(nil)
+			pageCountLabel._setupPdfInfoLabel()
+			pageCountLabel.centerXAnchor.constraint(equalTo: pageCountContainerView.centerXAnchor).isActive = true
+			pageCountLabel.centerYAnchor.constraint(equalTo: pageCountContainerView.centerYAnchor).isActive = true
+			pageCountLabel.widthAnchor.constraint(equalTo: pageCountContainerView.widthAnchor, multiplier: 0.25).isActive = true
+			pageCountLabel.heightAnchor.constraint(equalTo: pageCountContainerView.heightAnchor, multiplier: 0.9).isActive = true
 
-                DispatchQueue.main.asyncAfter(deadline: .now() + self.searchAnnotationDelay, execute: {
-                    self.pdfView.clearSelection()
-                })
-            }
-        }
+			containerView.addArrangedSubview(pageCountContainerView)
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            searchNavigationController.modalPresentationStyle = .popover
-            searchNavigationController.popoverPresentationController?.barButtonItem = searchButtonItem
-        }
+			self.view.addSubview(containerView)
 
-        self.present(searchNavigationController, animated: true)
-    }
+			setupConstraints()
 
-    @objc func showOutline() {
-        guard let pdfDocument = pdfView.document else { return }
+			self.view.layoutIfNeeded()
 
-        let outlineViewController = PDFOutlineViewController()
-        let searchNavigationController = ThemeNavigationController(rootViewController: outlineViewController)
-        outlineViewController.pdfDocument = pdfDocument
+			pdfView.document = document
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            searchNavigationController.modalPresentationStyle = .popover
-            searchNavigationController.popoverPresentationController?.barButtonItem = outlineItem
-        }
+			pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
+			pdfView.autoScales = true
+			updatePageLabel()
 
-        self.present(searchNavigationController, animated: true)
-    }
+			adjustThumbnailsSize()
 
-    // MARK: - Private helpers
+		}
+	}
 
-    fileprivate func adjustThumbnailsSize() {
-        let maxHeight = floor(self.view.bounds.height * thumbnailViewHeightMultiplier - thumbnailMargin)
-        let maxWidth = floor(self.view.bounds.width * thumbnailViewWidthMultiplier - thumbnailMargin)
-        thumbnailView.thumbnailSize = CGSize(width: maxWidth, height: maxHeight)
-    }
+	// MARK: - View lifecycle management
 
-    fileprivate func setupConstraints() {
+	override func viewDidLoad() {
+		shallDisplayMoreButtonInToolbar = false
 
-        if thumbnailView.superview == nil || pdfView.superview == nil {
-            return
-        }
+		super.viewDidLoad()
 
-        let guide = view.safeAreaLayoutGuide
+		NotificationCenter.default.addObserver(self, selector: #selector(handlePageChanged), name: .PDFViewPageChanged, object: nil)
 
-        var constraints = [NSLayoutConstraint]()
-        constraints.append(containerView.topAnchor.constraint(equalTo: guide.topAnchor))
+		gotoPageNotificationObserver = NotificationCenter.default.addObserver(forName: PDFViewerViewController.PDFGoToPageNotification.name, object: nil, queue: OperationQueue.main) { [weak self] (notification) in
+			if let page = notification.object as? PDFPage {
+				self?.pdfView.go(to: page)
+			}
+		}
+	}
 
-        thumbnailView.isHidden = false
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		self.thumbnailViewPosition = .bottom
 
-        switch thumbnailViewPosition {
-        case .left:
-            constraints.append(thumbnailView.topAnchor.constraint(equalTo: guide.topAnchor))
-            constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
-            constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
-            constraints.append(thumbnailView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: thumbnailViewWidthMultiplier))
+		pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
+		pdfView.autoScales = true
+	}
 
-            constraints.append(containerView.leadingAnchor.constraint(equalTo: thumbnailView.trailingAnchor))
-            constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
-            constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+	func save(item: OCItem) {
+		if let source = source {
+			editingDelegate?.save(item: item, fileURL: source)
+		}
+	}
 
-        case .right:
-            constraints.append(thumbnailView.topAnchor.constraint(equalTo: guide.topAnchor))
-            constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: containerView.trailingAnchor))
-            constraints.append(thumbnailView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
-            constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
-            constraints.append(thumbnailView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: thumbnailViewWidthMultiplier))
+	// MARK: - Handlers for PDF View notifications
 
-            constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
-            constraints.append(containerView.trailingAnchor.constraint(equalTo: thumbnailView.leadingAnchor))
-            constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+	@objc func handlePageChanged() {
+		updatePageLabel()
+	}
 
-        case .bottom:
-            constraints.append(thumbnailView.topAnchor.constraint(equalTo: containerView.bottomAnchor))
-            constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
-            constraints.append(thumbnailView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
-            constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
-            constraints.append(thumbnailView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: thumbnailViewHeightMultiplier))
+	// MARK: - Toolbar actions
 
-            constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
-            constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
-            constraints.append(containerView.bottomAnchor.constraint(equalTo: thumbnailView.topAnchor))
+	@objc func goToPage() {
 
-        case .none:
-            constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
-            constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
-            constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
-            thumbnailView.isHidden = true
-        }
+		guard let pdfDocument = pdfView.document else { return }
 
-        self.activeViewConstraints = constraints
+		let alertMessage = NSString(format: "This document has %@ pages".localized as NSString, "\(pdfDocument.pageCount)") as String
+		let alertController = UIAlertController(title: "Go to page".localized, message: alertMessage, preferredStyle: .alert)
+		alertController.addAction(UIAlertAction(title: "Cancel".localized, style: .cancel, handler: nil))
 
-    }
+		alertController.addTextField(configurationHandler: { textField in
+			textField.placeholder = "Page".localized
+			textField.keyboardType = .decimalPad
+		})
 
-    fileprivate func setupToolbar() {
-        searchButtonItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(search))
-        gotoButtonItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_go_to_page"), style: .plain, target: self, action: #selector(goToPage))
-        outlineItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_outline"), style: .plain, target: self, action: #selector(showOutline))
+		alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: { [unowned self] _ in
+			if let pageLabel = alertController.textFields?.first?.text {
+				self.selectPage(with: pageLabel)
+			}
+		}))
 
-        self.parent?.navigationItem.rightBarButtonItems = [
-            gotoButtonItem!,
-            searchButtonItem!,
-            outlineItem!]
-    }
+		self.present(alertController, animated: true)
+	}
 
-    fileprivate func selectPage(with label:String) {
-        guard let pdf = pdfView.document else { return }
+	@objc func search() {
+		guard let pdfDocument = pdfView.document else { return }
 
-        if let pageNr = Int(label) {
-            if pageNr > 0 && pageNr < pdf.pageCount {
-                if let page = pdf.page(at: pageNr - 1) {
-                    self.pdfView.go(to: page)
-                }
-            } else {
-                let alertController = UIAlertController(title: "Invalid Page".localized,
-                                                        message: "The entered page number doesn't exist".localized,
-                                                        preferredStyle: .alert)
-                alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: nil))
-                self.present(alertController, animated: true, completion: nil)
-            }
-        }
-    }
+		let pdfSearchController = PDFSearchViewController()
+		let searchNavigationController = ThemeNavigationController(rootViewController: pdfSearchController)
+		pdfSearchController.pdfDocument = pdfDocument
+		pdfSearchController.userSelectedMatchCallback = { (selection) in
+			DispatchQueue.main.async {
+				selection.color = UIColor.yellow
+				self.pdfView.setCurrentSelection(selection, animate: true)
+				self.pdfView.scrollSelectionToVisible(nil)
 
-    fileprivate func updatePageLabel() {
-        guard let pdf = pdfView.document else { return }
+				DispatchQueue.main.asyncAfter(deadline: .now() + self.searchAnnotationDelay, execute: {
+					self.pdfView.clearSelection()
+				})
+			}
+		}
 
-        guard let page = pdfView.currentPage else { return }
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			searchNavigationController.modalPresentationStyle = .popover
+			searchNavigationController.popoverPresentationController?.barButtonItem = searchButtonItem
+		}
 
-        let pageNrText = "\(pdf.index(for: page) + 1)"
-        let maxPageCountText = "\(pdf.pageCount)"
-        pageCountLabel.text = NSString(format: "%@ of %@".localized as NSString, pageNrText, maxPageCountText) as String
-    }
+		self.present(searchNavigationController, animated: true)
+	}
+
+	@objc func showOutline() {
+		guard let pdfDocument = pdfView.document else { return }
+
+		let outlineViewController = PDFOutlineViewController()
+		let searchNavigationController = ThemeNavigationController(rootViewController: outlineViewController)
+		outlineViewController.pdfDocument = pdfDocument
+
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			searchNavigationController.modalPresentationStyle = .popover
+			searchNavigationController.popoverPresentationController?.barButtonItem = outlineItem
+		}
+
+		self.present(searchNavigationController, animated: true)
+	}
+
+	// MARK: - Private helpers
+
+	fileprivate func adjustThumbnailsSize() {
+		let maxHeight = floor(self.view.bounds.height * thumbnailViewHeightMultiplier - thumbnailMargin)
+		let maxWidth = floor(self.view.bounds.width * thumbnailViewWidthMultiplier - thumbnailMargin)
+		thumbnailView.thumbnailSize = CGSize(width: maxWidth, height: maxHeight)
+	}
+
+	fileprivate func setupConstraints() {
+
+		if thumbnailView.superview == nil || pdfView.superview == nil {
+			return
+		}
+
+		let guide = view.safeAreaLayoutGuide
+
+		var constraints = [NSLayoutConstraint]()
+		constraints.append(containerView.topAnchor.constraint(equalTo: guide.topAnchor))
+
+		thumbnailView.isHidden = false
+
+		switch thumbnailViewPosition {
+		case .left:
+			constraints.append(thumbnailView.topAnchor.constraint(equalTo: guide.topAnchor))
+			constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
+			constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+			constraints.append(thumbnailView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: thumbnailViewWidthMultiplier))
+
+			constraints.append(containerView.leadingAnchor.constraint(equalTo: thumbnailView.trailingAnchor))
+			constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
+			constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+
+		case .right:
+			constraints.append(thumbnailView.topAnchor.constraint(equalTo: guide.topAnchor))
+			constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: containerView.trailingAnchor))
+			constraints.append(thumbnailView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
+			constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+			constraints.append(thumbnailView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: thumbnailViewWidthMultiplier))
+
+			constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
+			constraints.append(containerView.trailingAnchor.constraint(equalTo: thumbnailView.leadingAnchor))
+			constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+
+		case .bottom:
+			constraints.append(thumbnailView.topAnchor.constraint(equalTo: containerView.bottomAnchor))
+			constraints.append(thumbnailView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
+			constraints.append(thumbnailView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
+			constraints.append(thumbnailView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+			constraints.append(thumbnailView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: thumbnailViewHeightMultiplier))
+
+			constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
+			constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
+			constraints.append(containerView.bottomAnchor.constraint(equalTo: thumbnailView.topAnchor))
+
+		case .none:
+			constraints.append(containerView.leadingAnchor.constraint(equalTo: guide.leadingAnchor))
+			constraints.append(containerView.trailingAnchor.constraint(equalTo: guide.trailingAnchor))
+			constraints.append(containerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor))
+			thumbnailView.isHidden = true
+		}
+
+		self.activeViewConstraints = constraints
+
+	}
+
+	fileprivate func setupToolbar() {
+		searchButtonItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(search))
+		gotoButtonItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_go_to_page"), style: .plain, target: self, action: #selector(goToPage))
+		outlineItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_outline"), style: .plain, target: self, action: #selector(showOutline))
+
+		self.parent?.navigationItem.rightBarButtonItems = [
+			gotoButtonItem!,
+			searchButtonItem!,
+			outlineItem!]
+	}
+
+	fileprivate func selectPage(with label:String) {
+		guard let pdf = pdfView.document else { return }
+
+		if let pageNr = Int(label) {
+			if pageNr > 0 && pageNr < pdf.pageCount {
+				if let page = pdf.page(at: pageNr - 1) {
+					self.pdfView.go(to: page)
+				}
+			} else {
+				let alertController = UIAlertController(title: "Invalid Page".localized,
+														message: "The entered page number doesn't exist".localized,
+														preferredStyle: .alert)
+				alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: nil))
+				self.present(alertController, animated: true, completion: nil)
+			}
+		}
+	}
+
+	fileprivate func updatePageLabel() {
+		guard let pdf = pdfView.document else { return }
+
+		guard let page = pdfView.currentPage else { return }
+
+		let pageNrText = "\(pdf.index(for: page) + 1)"
+		let maxPageCountText = "\(pdf.pageCount)"
+		pageCountLabel.text = NSString(format: "%@ of %@".localized as NSString, pageNrText, maxPageCountText) as String
+	}
 }

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -334,6 +334,10 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		gotoButtonItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_go_to_page"), style: .plain, target: self, action: #selector(goToPage))
 		outlineItem = UIBarButtonItem(image: UIImage(named: "ic_pdf_outline"), style: .plain, target: self, action: #selector(showOutline))
 
+		searchButtonItem?.accessibilityLabel = "Search PDF".localized
+		gotoButtonItem?.accessibilityLabel = "Go to page".localized
+		outlineItem?.accessibilityLabel = "Outline".localized
+
 		self.parent?.navigationItem.rightBarButtonItems = [
 			gotoButtonItem!,
 			searchButtonItem!,

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -275,6 +275,8 @@
 "%@ of %@" = "%@ of %@";
 "Invalid Page" = "Invalid Page";
 "The entered page number doesn't exist" = "The entered page number doesn't exist";
+"Search PDF" = "Search PDF";
+"Outline" = "Outline";
 
 /* Photo Upload */
 "Upload" = "Upload";


### PR DESCRIPTION
## Description
- Made DisplayViewController configurable in terms of adding more button
- Also replaced textual more (3 dots) symbol with corresponding icon
- Disabled display of more toolbar button in PDFViewerViewController

## Related Issue
n.a.

## Motivation and Context
More button from the parent class made goto button in PDF view invisible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

