### PR TITLE
Bring learnings from 1.0.1 release to release_template.md

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -5,46 +5,43 @@ This is the template to release a new version on the App Store
 Release a new version
 ## TASKS:
 
-Git & Code
+### Git & Code
 
 - [ ] [GIT] Create branch `release/[major].[minor].[patch]` (freeze the code)
-- [ ] [DEV] Update version number `[major].[minor].[patch]`
+- [ ] [DEV] Update `APP_SHORT_VERSION` `[major].[minor].[patch]` in [ownCloud.xcodeproj/project.pbxproj](https://github.com/owncloud/ios-app/blob/master/ownCloud.xcodeproj/project.pbxproj)
+- [ ] [TRFX] Update translations from transifex branch.
 - [ ] [DIS] Update [changelog](https://github.com/owncloud/ios-app/blob/master/CHANGELOG.md)
 - [ ] [QA] Design Test plan
 - [ ] [QA] Regression Test plan
 - [ ] [DOC] Update user manual with the new functionalities
-- [ ] [DOC] Update owncloud.org/download version numbers (notify rocketchat #marketing)
-
-App Store
-
-- [ ] [DIS] App Store Connect: Create a new version following the `[major].[minor].[patch]`
-- [ ] [DIS] App Store Connect: Update screenshots if needed
-- [ ] [DIS] Upload the binary to the App Store
-- [ ] [DIS] App Store Connect: When release (manually, automatically, automatically not early than date)
-- [ ] [DIS] App Store Connect: How to releae (immediately to all the users o 7-day period phased release)
-- [ ] [DIS] App Store Connect: Reset iOS Summary Rating (Keep existing or reset the rating)
-- [ ] [DIS] App Store Connect: Update changelogs
-- [ ] [DIS] App Store Connect: Submit for review
-
-Git
-
+- [ ] [DOC] Update owncloud.org/download version numbers (notify #wordpress)
 - [ ] [GIT] Merge branch `release/[major].[minor].[patch]` in master
 - [ ] [GIT] Create tag and sign it `[major].[minor].[patch]`
 - [ ] [GIT] Add the new release on [GitHub ios-app](https://github.com/owncloud/ios-app/releases)
 
-If it is required to update third party:
-
-- [ ] [DIS] Update THIRD_PARTY.txt
-
 If it is required to update the iOS-SDK version:
 
 - [ ] [GIT] Create branch library `release/[major].[minor].[patch]`(freeze the code) 
-- [ ] [mail] inform john@owncloud.com and emil@owncloud.com about the new release.
+- [ ] [mail] inform #marketing about the new release.
 - [ ] [DIS] Update README.md (version number, third party, supported versions of iOS, Xcode)
 - [ ] [DIS] Update [changelog](https://github.com/owncloud/ios-sdk/blob/master/CHANGELOG.md)
 - [ ] [GIT] Merge branch `release/[major].[minor].[patch]` in `master`
 - [ ] [GIT] Create tag and sign it `[major].[minor].[patch]`
 - [ ] [GIT] Add the new release on [GitHub ios-sdk](https://github.com/owncloud/ios-sdk/releases)
 
+If it is required to update third party:
+
+- [ ] [DIS] Update THIRD_PARTY.txt
+
+## App Store
+
+- [ ] [DIS] App Store Connect: Create a new version following the `[major].[minor].[patch]`
+- [ ] [DIS] App Store Connect: Trigger Fastlane screenshots generation and upload
+- [ ] [DIS] Upload the binary to the App Store
+- [ ] [DIS] App Store Connect: Trigger release (manually)
+- [ ] [DIS] App Store Connect: Decide reset of iOS summary rating (Default: keep)
+- [ ] [DIS] App Store Connect: Update description if necessary (coordinated with #marketing)
+- [ ] [DIS] App Store Connect: Update changelogs
+- [ ] [DIS] App Store Connect: Submit for review
 
 ## BUGS & IMPROVEMENTS:


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/owncloud/ios-app/issues/368

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The checklist in the release issue got improved over time. Now, changes should be added to the `release_template.md` to make future releases more efficient.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with [1.0.1 release](https://github.com/owncloud/ios-app/issues/368)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

