### PR TITLE
Added an activity indicator for deleting offline copies

### DIFF
--- a/ownCloud/Bookmarks/BookmarkInfoViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkInfoViewController.swift
@@ -44,14 +44,21 @@ class BookmarkInfoViewController: StaticTableViewController {
 		let deviceFreeTitle = String(format: "Free on %@".localized, UIDevice.current.name)
 		deviceAvailableStorageInfoRow = StaticTableViewRow(valueRowWithAction: nil, title: deviceFreeTitle, value: "uknown".localized)
 
-		deleteLocalFilesRow = StaticTableViewRow(buttonWithAction: { [weak self] (_, _) in
+		deleteLocalFilesRow = StaticTableViewRow(buttonWithAction: { [weak self] (row, _) in
 			if let bookmark  = self?.bookmark {
 
 				OCCoreManager.shared.scheduleOfflineOperation({ (bookmark, completionHandler) in
 					let vault : OCVault = OCVault(bookmark: bookmark)
 
+					OnMainThread {
+						let progressView = UIActivityIndicatorView(style: Theme.shared.activeCollection.activityIndicatorViewStyle)
+						progressView.startAnimating()
+						row.cell?.accessoryView = progressView
+					}
+
 					vault.compact(completionHandler: { (_, error) in
 						OnMainThread {
+							row.cell?.accessoryView = nil
 							if error != nil {
 								// Inform user if vault couldn't be comp acted
 								let alertController = UIAlertController(title: NSString(format: "Compacting of '%@' failed".localized as NSString, bookmark.shortName as NSString) as String,


### PR DESCRIPTION
## Description
Give the user a feedback, when offline copies will be deleted

## Related Issue
#393 

## Motivation and Context
Better user feedback

## How Has This Been Tested?
Account > Manage > Delete Offline Copies
Activity Indicator should appear right beside "Delete Offline Copies"

## Screenshots (if appropriate):
![Activity-Indicator](https://user-images.githubusercontent.com/736109/60578200-1890de00-9d81-11e9-9489-79293a5be46f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

