### PR TITLE
[feature/log-info] Log device, version and locale info

### DIFF
--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "You need to configure an email account first to be able to send emails." = "You need to configure an email account first to be able to send emails.";
 "Do you want to open the following URL?" = "Do you want to open the following URL?";
 
-"%@ %@ version %@ build %@ (%@)" = "%@ %@ version %@ build %@ (%@)";
+"%@ %@ version %@ build %@ (app: %@, sdk: %@)" = "%@ %@ version %@ build %@ (app: %@, sdk: %@)";
 "beta" = "beta";
 "release" = "release";
 

--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -41,8 +41,8 @@ class MoreSettingsSection: SettingsSection {
 			buildType = "beta".localized
 		}
 
-		let localizedFooter = "%@ %@ version %@ build %@ (%@)".localized
-		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName!, buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit)
+		let localizedFooter = "%@ %@ version %@ build %@ (app: %@, sdk: %@)".localized
+		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName ?? "App", buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit, OCAppIdentity.shared.sdkCommit ?? "unknown")
 
 		self.footerTitle = footerTitle
 

--- a/ownCloud/Tools/Log.swift
+++ b/ownCloud/Tools/Log.swift
@@ -77,3 +77,13 @@ class Log {
 		return OCLogger.applyPrivacyMask(obj) ?? "(null)"
 	}
 }
+
+extension OCLogger : OCLogIntroFormat {
+	public func logIntroFormat() -> String {
+		return "{{stdIntro}}; Log options: \(Log.logOptionStatus)"
+	}
+
+	public func logHostCommit() -> String? {
+		return LastGitCommit()
+	}
+}


### PR DESCRIPTION
## Description
- Log device, version and locale information at the beginning of every log file using new SDK protocol
- Show SDK commit hash in Settings

## Example
A line like this is included near the top of every log file:

`2019-07-08 23:08:38.667000+0200 ownCloud[1253:538893] [info] | [LogIntro] Host: com.owncloud.ios-app 1.0.2 (125) #ea6c365; SDK: 1.0 (1) #49664d1; OS: iOS 12.3.1; Device: iPhone (iPhone8,1); Localizations: [de-DE, de]; Log options: level=Debug, destinations=["writer.stderr", "writer.file"], options=["option.log-requests-and-responses"], maskPrivateData=false [OCLogFileWriter.m:103|FULL]`

## Related Issue
#444 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Bugs & improvements

- [X] (1) Reset files do not create new headers https://github.com/owncloud/ios-app/pull/446#issuecomment-514127207
- [ ] (2) Header missing after switching log level to warning/error https://github.com/owncloud/ios-app/pull/446#issuecomment-514246941