### PR TITLE
[fix/sharing-search] Fixed min length for searching sharing users

### DIFF
--- a/ownCloud/Client/Sharing/GroupSharingTableViewController.swift
+++ b/ownCloud/Client/Sharing/GroupSharingTableViewController.swift
@@ -347,7 +347,7 @@ class GroupSharingTableViewController: SharingTableViewController, UISearchResul
 
 	func updateSearchResults(for searchController: UISearchController) {
 		guard let text = searchController.searchBar.text else { return }
-		if text.count >= core?.connection.capabilities?.sharingSearchMinLength?.intValue ?? 2 {
+		if text.count >= core?.connection.capabilities?.sharingSearchMinLength?.intValue ?? OCCapabilities.defaultSharingSearchMinLength {
 			if let recipients = recipientSearchController?.recipients, recipients.count > 0,
 				recipientSearchController?.searchTerm == text,
 				searchResultsSection == nil {

--- a/ownCloud/Client/Sharing/GroupSharingTableViewController.swift
+++ b/ownCloud/Client/Sharing/GroupSharingTableViewController.swift
@@ -347,7 +347,7 @@ class GroupSharingTableViewController: SharingTableViewController, UISearchResul
 
 	func updateSearchResults(for searchController: UISearchController) {
 		guard let text = searchController.searchBar.text else { return }
-		if text.count > core?.connection.capabilities?.sharingSearchMinLength?.intValue ?? 1 {
+		if text.count >= core?.connection.capabilities?.sharingSearchMinLength?.intValue ?? 2 {
 			if let recipients = recipientSearchController?.recipients, recipients.count > 0,
 				recipientSearchController?.searchTerm == text,
 				searchResultsSection == nil {


### PR DESCRIPTION
## Description
Fixed min length for searching a user or group in sharing view.

## Related Issue
#454 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Share File
- Search for a user or group
- Count letters, when activity indicator will appear for searching
- Check count result with server capability `user.search_min_length`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
