### PR TITLE
 Change behaviour of default expiration date

### DIFF
--- a/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
+++ b/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
@@ -443,6 +443,13 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateStyle = .long
 		dateFormatter.timeStyle = .none
+
+		var maximumSelectableDate: Date?
+
+		if core.connection.capabilities?.publicSharingExpireDateEnforced == true, let defaultDays = self.core.connection.capabilities?.publicSharingDefaultExpireDateDays {
+			maximumSelectableDate = Calendar.current.date(byAdding: .day, value: defaultDays.intValue, to: Date())
+		}
+
 		let expireDateRow = StaticTableViewRow(buttonWithAction: { [weak self, weak expireSection] (_, _) in
 			guard let expireSection = expireSection else { return }
 
@@ -483,7 +490,7 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 							}
 						})
 					}
-				}, date: expireDate, identifier: "date-picker-row")
+				}, date: expireDate, maximumDate: maximumSelectableDate, identifier: "date-picker-row")
 				expireSection.add(row: datePickerRow, animated: true)
 				if let indexPath = datePickerRow.indexPath {
 					self?.tableView.scrollToRow(at: indexPath, at: .middle, animated: true)

--- a/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
+++ b/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
@@ -359,9 +359,14 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 
 	func addExpireDateSection() {
 		var hasExpireDate = false
-		if share.expirationDate != nil || core.connection.capabilities?.publicSharingExpireDateEnforced == true || self.core.connection.capabilities?.publicSharingDefaultExpireDateDays != nil {
+		if share.expirationDate != nil || core.connection.capabilities?.publicSharingExpireDateEnforced == true {
 			hasExpireDate = true
 		}
+
+		if self.createLink && self.core.connection.capabilities?.publicSharingDefaultExpireDateDays != nil {
+			hasExpireDate = true
+		}
+
 		var needsExpireDate = false
 		if self.core.connection.capabilities?.publicSharingExpireDateEnforced == true {
 			needsExpireDate = true
@@ -490,6 +495,7 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 			}
 		}, title: dateFormatter.string(from: expireDate), style: .plain, alignment: .left, identifier: "expire-date-row")
 
+		expireDateRow.representedObject = expireDate
 		expireSection.add(row: expireDateRow)
 	}
 

--- a/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
+++ b/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
@@ -359,7 +359,7 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 
 	func addExpireDateSection() {
 		var hasExpireDate = false
-		if share.expirationDate != nil || core.connection.capabilities?.publicSharingExpireDateEnforced == true {
+		if share.expirationDate != nil || core.connection.capabilities?.publicSharingExpireDateEnforced == true || self.core.connection.capabilities?.publicSharingDefaultExpireDateDays != nil {
 			hasExpireDate = true
 		}
 		var needsExpireDate = false

--- a/ownCloud/UI Elements/StaticTableViewRow.swift
+++ b/ownCloud/UI Elements/StaticTableViewRow.swift
@@ -588,7 +588,7 @@ class StaticTableViewRow : NSObject, UITextFieldDelegate {
 
 	// MARK: - Date Picker
 
-	convenience init(datePickerWithAction action: StaticTableViewRowAction?, date dateValue: Date, identifier: String? = nil) {
+	convenience init(datePickerWithAction action: StaticTableViewRowAction?, date dateValue: Date, maximumDate:Date? = nil, identifier: String? = nil) {
 		self.init()
 		type = .datePicker
 
@@ -598,6 +598,7 @@ class StaticTableViewRow : NSObject, UITextFieldDelegate {
 		datePickerView.date = dateValue
 		datePickerView.datePickerMode = .date
 		datePickerView.minimumDate = Date()
+		datePickerView.maximumDate = maximumDate
 		datePickerView.accessibilityIdentifier = identifier
 		datePickerView.addTarget(self, action: #selector(datePickerValueChanged(_:)), for: UIControl.Event.valueChanged)
 		datePickerView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Description
Checking`files_sharing.public.expire_date.expire_date.days` server capability. If it is set then it is used as default date and the switch is enabled even if the expiration date is not enforced.

## Related Issue
#415 

## Motivation and Context
See the issue description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA

- [x] (1) Expiration not sent in the request  https://github.com/owncloud/ios-app/pull/476#issuecomment-519488821 [FIXED]
- [x] (2) improvement: set a maximum date to date picker when expiration date is enforced https://github.com/owncloud/ios-app/pull/476#issuecomment-519489820 [FIXED]
- [x] (3) Enforced expiration date with one day less https://github.com/owncloud/ios-app/pull/476#issuecomment-519803680 -> moved to https://github.com/owncloud/ios-app/issues/482