### PR TITLE
Add link to information about X-REQUEST-ID

### DIFF
--- a/docs/modules/ROOT/pages/ios_troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/ios_troubleshooting.adoc
@@ -6,7 +6,8 @@
 :charles-web-debugging-proxy-url: https://www.charlesproxy.com/documentation/ios/
 :create-screen-recording-url: https://support.apple.com/en-us/HT207935
 :mitmproxy-url: https://mitmproxy.org/
-:owncloud-logging-url: https://doc.owncloud.com/server/10.0/admin_manual/configuration/server/logging_configuration.html
+:owncloud-logging-url: https://doc.owncloud.com/server/latest/admin_manual/configuration/server/logging_configuration.html
+:owncloud-log-tracing-url: https://doc.owncloud.com/server/latest/admin_manual/configuration/server/request_tracing.html
 
 If you experience problems while using the iOS app, you can use this guide to help find the solution.
 
@@ -57,6 +58,10 @@ image:owncloud-log-configuration.png[Configuring logging in ownCloud server.]
 === Web Server Log Files
 
 It can be helpful to view your web server's error log file to isolate any ownCloud-related problems.
+
+The ownCloud iOS app sends the `X-REQUEST-ID` header with every request. You'll find the `X-REQUEST-ID` in the `owncloud.log`, and you can configure your webserver to add the `X-REQUEST-ID` to the logs. Here you can find more information:
+{owncloud-log-tracing-url}
+
 Some helpful files include the following:
 
 error_logx:: Maintains errors associated with PHP code.


### PR DESCRIPTION


## Description

Just link to a new page in the admin docs.

## Related Issue

https://github.com/owncloud/ios-app/issues/341

## Motivation and Context

Information about `X-REQUEST-ID` got added to the server admin docs in https://github.com/owncloud/docs/pull/1615 . This is very helpful to debug client issues.

## How Has This Been Tested?

```
git checkout docs/x-request-id-logs
git pull
cd docs
yarn install
yarn antora
yarn server
yarn serve
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

