### PR TITLE
[feature/cookies] Cookie support

### DIFF
--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -166,6 +166,11 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "oc:log.log-only-tags"
+            value = "[Request,Response]"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "oc:log.log-omit-tags"
             value = "[Request,Response]"
             isEnabled = "NO">

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -168,7 +168,7 @@
          <EnvironmentVariable
             key = "oc:log.log-only-tags"
             value = "[Request,Response]"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "oc:log.log-omit-tags"

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -131,6 +131,11 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "oc:core.cookie-support-enabled"
+            value = "true"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "oc:core.override-reachability-signal"
             value = "true"
             isEnabled = "NO">

--- a/ownCloud/Client/ClientRootViewController.swift
+++ b/ownCloud/Client/ClientRootViewController.swift
@@ -237,11 +237,6 @@ class ClientRootViewController: UITabBarController, UINavigationControllerDelega
 		OnMainThread {
 			if let core = self.core {
 				let query = OCQuery(forPath: "/")
-//				let query = OCQuery(condition: OCQueryCondition.require([
-//					.where(.name, contains: "i"),
-//					.where(.type, isEqualTo: OCItemType.file.rawValue),
-//					.where(.size, isGreaterThan: 220000)
-//				]).sorted(by: .size, ascending: true), inputFilter:nil)
 
 				let queryViewController = ClientQueryViewController(core: core, query: query)
 				// Because we have nested UINavigationControllers (first one from ServerListTableViewController and each item UITabBarController needs it own UINavigationController), we have to fake the UINavigationController logic. Here we insert the emptyViewController, because in the UI should appear a "Back" button if the root of the queryViewController is shown. Therefore we put at first the emptyViewController inside and at the same time the queryViewController. Now, the back button is shown and if the users push the "Back" button the ServerListTableViewController is shown. This logic can be found in navigationController(_: UINavigationController, willShow: UIViewController, animated: Bool) below.
@@ -261,8 +256,29 @@ class ClientRootViewController: UITabBarController, UINavigationControllerDelega
 				}
 				self.activityViewController?.core = core
 				self.libraryViewController?.core = core
-				self.libraryViewController?.setupQueries()
+
+				self.connectionInitializedObservation = core.observe(\OCCore.connection.connectionInitializationPhaseCompleted, options: [.initial], changeHandler: { [weak self] (core, _) in
+					if core.connection.connectionInitializationPhaseCompleted {
+						self?.connectionInitialized()
+					}
+				})
 			}
+		}
+	}
+
+	private var connectionInitializedObservation : NSKeyValueObservation?
+
+	func connectionInitialized() {
+		OCSynchronized(self) {
+			if connectionInitializedObservation == nil {
+				return
+			}
+
+			connectionInitializedObservation = nil
+		}
+
+		OnMainThread {
+			self.libraryViewController?.setupQueries()
 		}
 	}
 


### PR DESCRIPTION
## Description
Adds support for cookies. Currently, cookies are stored only in memory.

### Known issue
It's possible that several requests are sent to the OC server in parallel before the first response with a session cookie is received, so that the OC server ends up issuing more than one session cookie for a single session.

_If_ this is a problem, the solution could be to make a request to the OC server that's known to return a session cookie and wait for its response before sending any other requests.

## Related Issue
#475

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
