### PR TITLE
[fix/filename-truncate-tail] Truncate middle of file name instead of tail

### DIFF
--- a/ownCloud/Client/ClientItemCell.swift
+++ b/ownCloud/Client/ClientItemCell.swift
@@ -117,6 +117,7 @@ class ClientItemCell: ThemeTableViewCell {
 
 		titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
 		titleLabel.adjustsFontForContentSizeCategory = true
+		titleLabel.lineBreakMode = .byTruncatingMiddle
 
 		detailLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
 		detailLabel.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
## Description
As an user I want to see the end of a file name for a better differentiation for file name with the same prefix and which have a long file name.

## Related Issue
#516 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

