### PR TITLE
Fixed mission icons for ‘moreFolder’ location

### DIFF
--- a/ownCloud/Client/Actions/Actions+Extensions/CopyAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/CopyAction.swift
@@ -68,7 +68,7 @@ class CopyAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "copy-file")
 		}
 

--- a/ownCloud/Client/Actions/Actions+Extensions/DeleteAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DeleteAction.swift
@@ -100,7 +100,7 @@ class DeleteAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "trash")
 		}
 

--- a/ownCloud/Client/Actions/Actions+Extensions/DuplicateAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DuplicateAction.swift
@@ -71,7 +71,7 @@ class DuplicateAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "duplicate-file")
 		}
 

--- a/ownCloud/Client/Actions/Actions+Extensions/MoveAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/MoveAction.swift
@@ -71,7 +71,7 @@ class MoveAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "folder")
 		}
 

--- a/ownCloud/Client/Actions/Actions+Extensions/RenameAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/RenameAction.swift
@@ -83,7 +83,7 @@ class RenameAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "folder")
 		}
 

--- a/ownCloud/Client/Actions/Actions+Extensions/UnshareAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/UnshareAction.swift
@@ -129,7 +129,7 @@ class UnshareAction : Action {
 	}
 
 	override class func iconForLocation(_ location: OCExtensionLocationIdentifier) -> UIImage? {
-		if location == .moreItem {
+		if location == .moreItem || location == .moreFolder {
 			return UIImage(named: "trash")
 		}
 


### PR DESCRIPTION
## Description
It was forgotten to return valid icon images for 'moreFolder' menu location.

## Related Issue
#511 

## Motivation and Context
Fixes inconsistency in the actions UI

## How Has This Been Tested?
Using the steps to reproduce described in the aforementioned issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

