### PR TITLE
[fix/fp-offline-browsing] Allow offline browsing of folders in the File Provider

### DIFF
--- a/ownCloud File Provider/OCItem+FileProviderItem.m
+++ b/ownCloud File Provider/OCItem+FileProviderItem.m
@@ -123,6 +123,14 @@ static NSMutableDictionary<OCLocalID, NSError *> *sOCItemUploadingErrors;
 		return (YES);
 	}
 
+	if (self.type == OCItemTypeCollection)
+	{
+		// Needs to return YES for folders in order to allow browsing while offline
+		// Otherwise Files.app will bring up an alert "You're not connected to the Internet"
+		// (big thanks to @palmin who pointed me to this possibility)
+		return (YES);
+	}
+
 	return (NO);
 }
 


### PR DESCRIPTION
## Description
Allows browsing of folders in the File Provider while in Airplane mode, with Files app no longer bringing up the "You're not connected to the Internet" error.

## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)