### PR TITLE
[fix/uti-conversion] work around broken MIMEType->UTI conversions in iOS

### DIFF
--- a/ownCloud File Provider/OCItem+FileProviderItem.m
+++ b/ownCloud File Provider/OCItem+FileProviderItem.m
@@ -89,6 +89,12 @@ static NSMutableDictionary<OCLocalID, NSError *> *sOCItemUploadingErrors;
 
 	dispatch_once(&onceToken, ^{
 		utiBySuffix = @{
+			// These suffix -> UTI mappings are currently not needed as the OC server
+			// already returns correct MIME-Types for these, so the MIMEType -> UTI
+			// mapping already takes care of it. Decided to let them still stay here
+			// as a reference and to document the thinking behind not including these
+			// five file types in this conversion dictionary.
+
 			// @"odt" : @"org.oasis-open.opendocument.text",
 			// @"ott" : @"org.oasis-open.opendocument.text-template",
 
@@ -101,17 +107,22 @@ static NSMutableDictionary<OCLocalID, NSError *> *sOCItemUploadingErrors;
 			// @"ods" : @"org.oasis-open.opendocument.spreadsheet",
 			// @"ots" : @"org.oasis-open.opendocument.spreadsheet-template",
 
+			// @"odf" : @"org.oasis-open.opendocument.formula",
+			// @"otf" : @"org.oasis-open.opendocument.formula-template",
+
+
+			// OC server does not seem to return MIME Types for these types
+			// at the time of writing, so these entries take care of correctly
+			// mapping suffixes to UTIs
+
 			@"odc" : @"org.oasis-open.opendocument.chart",
 			@"otc" : @"org.oasis-open.opendocument.chart-template",
 
 			@"odi" : @"org.oasis-open.opendocument.image",
 			@"oti" : @"org.oasis-open.opendocument.image-template",
 
-			// @"odf" : @"org.oasis-open.opendocument.formula",
-			// @"otf" : @"org.oasis-open.opendocument.formula-template",
-
 			@"odm" : @"org.oasis-open.opendocument.text-master",
-			@"oth" : @"org.oasis-open.opendocument.text-web",
+			@"oth" : @"org.oasis-open.opendocument.text-web"
 		};
 	});
 


### PR DESCRIPTION
## Description
Overrides UTIs for file formats where OS-based MIMEType conversion fails.

## Related Issue
#557 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
