### PR TITLE
[fix/files-duplicate] Fix infinite loop when duplicating a Folder in Files app

### DIFF
--- a/ownCloud File Provider/FileProviderEnumerator.h
+++ b/ownCloud File Provider/FileProviderEnumerator.h
@@ -22,7 +22,7 @@
 
 @class FileProviderExtension;
 
-@interface FileProviderEnumerator : NSObject <NSFileProviderEnumerator, OCQueryDelegate>
+@interface FileProviderEnumerator : NSObject <NSFileProviderEnumerator, OCQueryDelegate, OCLogTagging>
 {
 	__weak FileProviderExtension *_fileProviderExtension;
 

--- a/ownCloud File Provider/FileProviderEnumerator.m
+++ b/ownCloud File Provider/FileProviderEnumerator.m
@@ -178,7 +178,7 @@
 				{
 					// Start query
 					self->_query = [OCQuery queryForPath:queryPath];
-					self->_query.includeRootItem = YES;
+					self->_query.includeRootItem = queryPath.isRootPath; // Include the root item only for the root folder. If it's not included, no folder can be created in the root directory. If a non-root folder is included in a query result for its content, the Files Duplicate action will loop infinitely.
 					self->_query.delegate = self;
 
 					[DisplaySettings.sharedDisplaySettings updateQueryWithDisplaySettings:self->_query];
@@ -322,9 +322,11 @@
 
 - (void)queryHasChangesAvailable:(OCQuery *)query
 {
-	OCLogDebug(@"##### Query for %@ has changes. Query state: %lu", query.queryPath, (unsigned long)query.state);
+	OCLogDebug(@"##### Query for %@ has changes. Query state: %lu, SinceSyncAnchor: %@, Changes available: %d", query.queryPath, (unsigned long)query.state, query.querySinceSyncAnchor, query.hasChangesAvailable);
 
-	if ((query.state == OCQueryStateContentsFromCache) || ((query.state == OCQueryStateWaitingForServerReply) && (query.queryResults.count > 0)) || (query.state == OCQueryStateIdle))
+	if ( (query.state == OCQueryStateContentsFromCache) ||
+	    ((query.state == OCQueryStateWaitingForServerReply) && (query.queryResults.count > 0)) ||
+	     (query.state == OCQueryStateIdle))
 	{
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@synchronized(self)
@@ -421,5 +423,15 @@
 	*/
 	// - (void)finishEnumeratingWithError:(NSError *)error;
 // }
+
++ (NSArray<OCLogTagName> *)logTags
+{
+	return (@[ @"FPEnum" ]);
+}
+
+- (NSArray<OCLogTagName> *)logTags
+{
+	return (@[ @"FPEnum", OCLogTagInstance(self)]);
+}
 
 @end

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -396,8 +396,14 @@
 		if ((existingItem = [self.core cachedItemInParent:parentItem withName:directoryName isDirectory:YES error:NULL]) != nil)
 		{
 			FPLogCmd(@"Completed with collission with existingItem=%@ (locally detected)", existingItem);
-			// completionHandler(nil, [NSError fileProviderErrorForCollisionWithItem:existingItem]); // This is what we should do according to docs
-			completionHandler(nil, [OCError(OCErrorItemAlreadyExists) translatedError]); // This is what we need to do to avoid users running into issues using the broken Files "Duplicate" action
+			if (@available(iOS 13.3, *))
+			{
+				completionHandler(nil, [NSError fileProviderErrorForCollisionWithItem:existingItem]); // This is what we should do according to docs
+			}
+			else
+			{
+				completionHandler(nil, [OCError(OCErrorItemAlreadyExists) translatedError]); // This is what we need to do to avoid users running into issues using the broken Files "Duplicate" action
+			}
 			return;
 		}
 

--- a/ownCloud/FileLists/QueryFileListTableViewController.swift
+++ b/ownCloud/FileLists/QueryFileListTableViewController.swift
@@ -201,7 +201,7 @@ class QueryFileListTableViewController: FileListTableViewController, SortBarDele
 
 	func queryHasChangesAvailable(_ query: OCQuery) {
 		queryRefreshRateLimiter.runRateLimitedBlock {
-			query.requestChangeSet(withFlags: OCQueryChangeSetRequestFlag(rawValue: 0)) { (query, changeSet) in
+			query.requestChangeSet(withFlags: .onlyResults) { (query, changeSet) in
 				OnMainThread {
 					if query.state.isFinal {
 						OnMainThread {


### PR DESCRIPTION
## Description
This PR fixes an infinite loop when duplicating a folder in Files app. It also allows folder duplication via the Files app for the first time.

## Related Issue
#550 (8)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)