### PR TITLE
Fix for table view updates in the activity screen

### DIFF
--- a/ownCloud/Client/ClientActivityCell.swift
+++ b/ownCloud/Client/ClientActivityCell.swift
@@ -34,6 +34,7 @@ class ClientActivityCell: ThemeTableViewCell {
 	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: style, reuseIdentifier: reuseIdentifier)
 		prepareViewAndConstraints()
+        self.accessoryType = .none
 	}
 
 	required init?(coder aDecoder: NSCoder) {
@@ -70,11 +71,10 @@ class ClientActivityCell: ThemeTableViewCell {
 			statusLabel.rightAnchor.constraint(equalTo: statusCircle.leftAnchor, constant: -20),
 
 			statusCircle.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-			statusCircle.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-			statusCircle.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
 			statusCircle.widthAnchor.constraint(equalToConstant: 50),
 			statusCircle.rightAnchor.constraint(equalTo: self.contentView.rightAnchor)
 		])
+        
 	}
 
 	// MARK: - Present item
@@ -91,7 +91,6 @@ class ClientActivityCell: ThemeTableViewCell {
 		statusLabel.text = activity.localizedStatusMessage
 		statusCircle.progress = activity.progress
 
-		self.accessoryType = .none
 	}
 
 	// MARK: - Themeing


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
- Fixes jumping of progress view
- Updating only changed parts of the activity list instead of reloading complete tableview 

## Related Issue
#550 Issue Nr. 12

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

