### PR TITLE
[feature/directory-picker-sort-bar] Show Sort Bar in Directory Picker

### DIFF
--- a/ownCloud/Client/Actions/ClientDirectoryPickerViewController.swift
+++ b/ownCloud/Client/Actions/ClientDirectoryPickerViewController.swift
@@ -93,7 +93,7 @@ class ClientDirectoryPickerViewController: ClientQueryViewController {
 		self.navigationPathFilter = navigationPathFilter
 
 		// Force disable sorting options
-		self.shallShowSortBar = false
+		self.shallShowSortBar = true
 
 		// Disable pull to refresh
 		allowPullToRefresh = false
@@ -120,6 +120,8 @@ class ClientDirectoryPickerViewController: ClientQueryViewController {
 
 		// Cancel button creation
 		cancelBarButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelBarButtonPressed))
+
+		sortBar?.showSelectButton = false
 	}
 
 	override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Description
Fixes to show the sort bar in the directory picker too.

## Related Issue
#590 

## Motivation and Context
Directory picker should also be present in this UI, because user needs this option for a faster navigating in this view.

## How Has This Been Tested?
- Move an item in the file list
- Sort Bar should be present in the Directory Picker, (Multi-)select button not present

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

