### PR TITLE
[feature/quick-access-collections ] Expand Quick Access Collections

### DIFF
--- a/ownCloud/Client/Library/LibraryTableViewController.swift
+++ b/ownCloud/Client/Library/LibraryTableViewController.swift
@@ -23,6 +23,12 @@ protocol LibraryShareList: UIViewController {
 	func updateWith(shares: [OCShare])
 }
 
+struct QuickAccessQuery {
+	var name : String
+	var mimeType : String
+	var imageName : String
+}
+
 class LibraryShareView {
 	enum Identifier : String {
 		case sharedWithYou
@@ -393,11 +399,19 @@ class LibraryTableViewController: StaticTableViewController {
 				completion()
 			})
 
-			let imageQuery = OCQuery(condition: .where(.mimeType, contains: "image"), inputFilter:nil)
-			addCollectionRow(to: section, title: "Images".localized, themeImageName: "image", query: imageQuery, actionHandler: nil)
+			let queries = [
+				QuickAccessQuery(name: "PDF Documents".localized, mimeType: "pdf", imageName: "application-pdf"),
+				QuickAccessQuery(name: "Documents".localized, mimeType: "doc", imageName: "x-office-document"),
+				QuickAccessQuery(name: "Text".localized, mimeType: "text/plain", imageName: "text"),
+				QuickAccessQuery(name: "Images".localized, mimeType: "image", imageName: "image"),
+				QuickAccessQuery(name: "Videos".localized, mimeType: "video", imageName: "video"),
+				QuickAccessQuery(name: "Audio".localized, mimeType: "audio", imageName: "audio")
+			]
 
-			let pdfQuery = OCQuery(condition: .where(.mimeType, contains: "pdf"), inputFilter:nil)
-			addCollectionRow(to: section, title: "PDF Documents".localized, themeImageName: "application-pdf", query: pdfQuery, actionHandler: nil)
+			for query in queries {
+				let customQuery = OCQuery(condition: .where(.mimeType, contains: query.mimeType), inputFilter:nil)
+				addCollectionRow(to: section, title: query.name, image: Theme.shared.image(for: query.imageName, size: CGSize(width: 25, height: 25))!, query: customQuery, actionHandler: nil)
+			}
 		}
 	}
 

--- a/ownCloud/Client/Library/LibraryTableViewController.swift
+++ b/ownCloud/Client/Library/LibraryTableViewController.swift
@@ -401,7 +401,7 @@ class LibraryTableViewController: StaticTableViewController {
 
 			let queries = [
 				QuickAccessQuery(name: "PDF Documents".localized, mimeType: ["pdf"], imageName: "application-pdf"),
-				QuickAccessQuery(name: "Documents".localized, mimeType: ["doc", "application/vnd", "application/msword", "text/rtf"], imageName: "x-office-document"),
+				QuickAccessQuery(name: "Documents".localized, mimeType: ["doc", "application/vnd", "application/msword", "application/ms-doc", "text/rtf", "application/rtf", "application/mspowerpoint", "application/powerpoint", "application/x-mspowerpoint", "application/excel", "application/x-excel", "application/x-msexcel"], imageName: "x-office-document"),
 				QuickAccessQuery(name: "Text".localized, mimeType: ["text/plain"], imageName: "text"),
 				QuickAccessQuery(name: "Images".localized, mimeType: ["image"], imageName: "image"),
 				QuickAccessQuery(name: "Videos".localized, mimeType: ["video"], imageName: "video"),

--- a/ownCloud/Client/Library/LibraryTableViewController.swift
+++ b/ownCloud/Client/Library/LibraryTableViewController.swift
@@ -25,7 +25,7 @@ protocol LibraryShareList: UIViewController {
 
 struct QuickAccessQuery {
 	var name : String
-	var mimeType : String
+	var mimeType : [String]
 	var imageName : String
 }
 
@@ -400,16 +400,20 @@ class LibraryTableViewController: StaticTableViewController {
 			})
 
 			let queries = [
-				QuickAccessQuery(name: "PDF Documents".localized, mimeType: "pdf", imageName: "application-pdf"),
-				QuickAccessQuery(name: "Documents".localized, mimeType: "doc", imageName: "x-office-document"),
-				QuickAccessQuery(name: "Text".localized, mimeType: "text/plain", imageName: "text"),
-				QuickAccessQuery(name: "Images".localized, mimeType: "image", imageName: "image"),
-				QuickAccessQuery(name: "Videos".localized, mimeType: "video", imageName: "video"),
-				QuickAccessQuery(name: "Audio".localized, mimeType: "audio", imageName: "audio")
+				QuickAccessQuery(name: "PDF Documents".localized, mimeType: ["pdf"], imageName: "application-pdf"),
+				QuickAccessQuery(name: "Documents".localized, mimeType: ["doc", "application/vnd", "application/msword", "text/rtf"], imageName: "x-office-document"),
+				QuickAccessQuery(name: "Text".localized, mimeType: ["text/plain"], imageName: "text"),
+				QuickAccessQuery(name: "Images".localized, mimeType: ["image"], imageName: "image"),
+				QuickAccessQuery(name: "Videos".localized, mimeType: ["video"], imageName: "video"),
+				QuickAccessQuery(name: "Audio".localized, mimeType: ["audio"], imageName: "audio")
 			]
 
 			for query in queries {
-				let customQuery = OCQuery(condition: .where(.mimeType, contains: query.mimeType), inputFilter:nil)
+				let conditions = query.mimeType.map { (mimeType) -> OCQueryCondition in
+					return .where(.mimeType, contains: mimeType)
+				}
+
+				let customQuery = OCQuery(condition: .any(of: conditions), inputFilter:nil)
 				addCollectionRow(to: section, title: query.name, image: Theme.shared.image(for: query.imageName, size: CGSize(width: 25, height: 25))!, query: customQuery, actionHandler: nil)
 			}
 		}

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -429,6 +429,9 @@
 "Favorites"= "Favorites";
 "Images" = "Images";
 "PDF Documents" = "PDF Documents";
+"Text" = "Text";
+"Documents" = "Documents";
+"Audio" = "Audio";
 
 /* Media files settings */
 "Media Files" = "Media Files";


### PR DESCRIPTION
## Description
This PR will add more famous mime types for the quick access collection

### New Mime-Types
- `doc` as "Documents"
- `text/plain` as "Text"
- `video` as "Videos"
- `audio` as "Audio"

## Motivation and Context
Quickly access files for special mime types

## How Has This Been Tested?
- add files with the mime type above to your oC account
- open account and navigate to "Quick Access"
- select collection with mime type and files will be inside

## Screenshots (if appropriate):

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-21 at 14 11 46](https://user-images.githubusercontent.com/736109/72807581-03fe2f80-3c58-11ea-8150-95d1d8b09ed2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

