### PR TITLE
[fix/sharingview-ipad] Broken Sharing View on iPad

### DIFF
--- a/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
+++ b/ownCloud/Client/Sharing/PublicLinkEditTableViewController.swift
@@ -77,7 +77,7 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 			self.navigationItem.title = linkName
 		}
 
-		let shareBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareLinkURL))
+		let shareBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareLinkURL(sender:)))
 		if item.type == .collection {
 			let infoButton = UIButton(type: .infoLight)
 			infoButton.addTarget(self, action: #selector(showInfoSubtitles), for: .touchUpInside)
@@ -588,7 +588,7 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 		addPermissionsSection()
 	}
 
-	@objc func shareLinkURL() {
+	@objc func shareLinkURL(sender: UIBarButtonItem) {
 		guard let shareURL = share.url, let capabilities = self.core.connection.capabilities else { return }
 
 		let activityViewController = UIActivityViewController(activityItems: [shareURL], applicationActivities: nil)
@@ -603,7 +603,9 @@ class PublicLinkEditTableViewController: StaticTableViewController {
 				UIActivity.ActivityType("com.facebook.Facebook")
 			]
 		}
-		activityViewController.popoverPresentationController?.sourceView = self.view
+
+		activityViewController.popoverPresentationController?.barButtonItem = sender
+		activityViewController.popoverPresentationController?.permittedArrowDirections = .down
 		self.present(activityViewController, animated: true, completion: nil)
 	}
 

--- a/ownCloud/Settings/LogFilesViewController.swift
+++ b/ownCloud/Settings/LogFilesViewController.swift
@@ -140,7 +140,7 @@ class LogFilesViewController : UITableViewController, Themeable {
 
 		cell?.shareAction = { [weak self] (cell) in
 			if let indexPath = self?.tableView.indexPath(for: cell) {
-				self?.shareLogRecord(at: indexPath)
+				self?.shareLogRecord(at: indexPath, sender: cell)
 			}
 		}
 
@@ -149,7 +149,10 @@ class LogFilesViewController : UITableViewController, Themeable {
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		tableView.deselectRow(at: indexPath, animated: true)
-		self.shareLogRecord(at: indexPath)
+		let cell = tableView.cellForRow(at: indexPath)
+		if let cell = cell {
+			self.shareLogRecord(at: indexPath, sender: cell)
+		}
 	}
 
 	override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
@@ -176,8 +179,7 @@ class LogFilesViewController : UITableViewController, Themeable {
 		}
 	}
 
-	private func shareLogRecord(at indexPath:IndexPath) {
-
+	private func shareLogRecord(at indexPath:IndexPath, sender: UITableViewCell) {
 		let logRecord = self.logRecords[indexPath.row]
 
 		// Create a file name for sharing with format ownCloud_<date>_<time>.log.txt
@@ -210,7 +212,8 @@ class LogFilesViewController : UITableViewController, Themeable {
 		}
 
 		if UIDevice.current.isIpad() {
-			shareViewController.popoverPresentationController?.sourceView = self.view
+			shareViewController.popoverPresentationController?.sourceView = sender
+			shareViewController.popoverPresentationController?.sourceRect = sender.frame
 		}
 		self.present(shareViewController, animated: true, completion: nil)
 	}


### PR DESCRIPTION
## Description
Fixing sharing view on iPad for logfiles and public links

## Related Issue
#606 

## Motivation and Context
Sharing view on iPad was not fully visible

## How Has This Been Tested?
- Share a log file on the iPad
- Share a log file on the iPhone
- Share a public link on the iPad (in edit view from the toolbar item)
- Share a public link on the iPhone (in edit view from the toolbar item)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
