### PR TITLE
[fix/offline] Fix various offline use bugs

### DIFF
--- a/ownCloud/Client/ClientRootViewController.swift
+++ b/ownCloud/Client/ClientRootViewController.swift
@@ -99,7 +99,7 @@ class ClientRootViewController: UITabBarController, UINavigationControllerDelega
 		if let connectionStatus = core?.connectionStatus {
 			var connectionShortDescription = core?.connectionStatusShortDescription
 
-			connectionShortDescription = connectionShortDescription != nil ? (connectionShortDescription! + ". ") : ""
+			connectionShortDescription = connectionShortDescription != nil ? (connectionShortDescription!.hasSuffix(".") ? connectionShortDescription! + " " : connectionShortDescription! + ". ") : ""
 
 			switch connectionStatus {
 				case .online:

--- a/ownCloud/UI Elements/Progress/ProgressSummarizer.swift
+++ b/ownCloud/UI Elements/Progress/ProgressSummarizer.swift
@@ -415,7 +415,7 @@ class ProgressSummarizer: NSObject {
 											multiMessage = NSString(format:"Updating %ld items…".localized as NSString, sameTypeCount) as String
 
 										case .createShare, .updateShare, .deleteShare, .decideOnShare: break
-										case .none, .retrieveThumbnail, .retrieveItemList, .retrieveShares, .issueResponse, .filterFiles: break
+										case .none, .retrieveThumbnail, .retrieveItemList, .retrieveShares, .issueResponse, .filterFiles, .wakeupSyncRecord: break
 									}
 
 									if multiMessage != nil {

--- a/ownCloud/UIKit Extensions/UIImageView+Thumbnails.swift
+++ b/ownCloud/UIKit Extensions/UIImageView+Thumbnails.swift
@@ -50,12 +50,10 @@ extension UIImageView {
 				types = [.lowQualityThumbnail, .thumbnail]
 
 				if let itemURL = weakCore?.localURL(for: item) {
-					let thumbnailRequest = QLThumbnailGenerator.Request(fileAt: itemURL,
-																		size: size,
-																		scale: UIScreen.main.scale,
-																		representationTypes:types!)
-					QLThumbnailGenerator.shared.generateBestRepresentation(for: thumbnailRequest) { (representation, error) in
-						if let representation = representation, error == nil {
+					let thumbnailRequest = QLThumbnailGenerator.Request(fileAt: itemURL, size: size, scale: UIScreen.main.scale, representationTypes:types!)
+
+					QLThumbnailGenerator.shared.generateBestRepresentation(for: thumbnailRequest) { [weak self] (representation, error) in
+						if let representation = representation, let self = self, let core = weakCore, error == nil {
 							self.cacheThumbnail(image: representation.uiImage, size:size, for: item, in: core)
 							OnMainThread {
 								self.image = representation.uiImage


### PR DESCRIPTION
# Description
Fixes for a variety of offline issues:

### [#3828 Av. Offline folders does not show the content in plane mode](https://github.com/owncloud/enterprise/issues/3828)
How it could be reproduced:
- launch the app while in airplane mode
- log into an account
- open a folder, content is shown
- navigate back
- open the folder again, no content is shown

### Loss of queued background folder scan queue
How it could be reproduced:
- create bookmark for large account
- log in and let the app start scanning the folders
- enable airplane mode
- go to "Status" tab and see the queue emptying
- log out
- disable airplane mode
- re-log in to the account
- see the lack of queued available offline items - or, if you're lucky - a slow, partial re-discovery

### OAuth2 token refresh loop while offline
How it could be reproduced:
- create an account for an OAuth2 server with low token expiry time
- log in and log out
- enable airplane mode
- wait for the OAuth2 token to expire
- log back into the account while in airplane mode
- see high CPU usage and an endless loop of failed attempts to renew the token, because the internet connection is not available

### Fix stalled PROPFIND jobs
How it could be reproduced:
- log into an account while airplane mode is enabled
- enter any folder
- switch to "Status" and see the tasks for retrieving those directories' contents
- turn off airplane mode
- the tasks never finish or progress, leaving the app only partially functional

### Improve misleading "Connection refused" error message
The actual connectivity error is now shown. Previously:
- log into an account while airplane mode is enabled
- see "Connection refused. Contents from cache." in the progress area at the bottom

### Fix retain loop for `OCCore` in `QuickLook` thumbnail generation
How it could be reproduced:
- log into an account while airplane mode is enabled
- browse to directories with images
- log out
- check the debug log and see the core never logs its own deallocation, as well as errors related to the continued use of a zombie core

# Related Issue
https://github.com/owncloud/enterprise/issues/3828

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
