### PR TITLE
[fix/markup-saving] Fixes markup saving

### DIFF
--- a/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
@@ -27,7 +27,7 @@ class DocumentEditingAction : Action {
 	override class var keyModifierFlags: UIKeyModifierFlags? { return [.command] }
 	override class var locations : [OCExtensionLocationIdentifier]? { return [.moreItem, .moreFolder, .keyboardShortcut] }
 	class var supportedMimeTypes : [String] { return ["image", "pdf"] }
-	class var excludedMimeTypes : [String] { return ["image/x-dcraw"] }
+	class var excludedMimeTypes : [String] { return ["image/x-dcraw", "image/heic"] }
 	override class var licenseRequirements: LicenseRequirements? { return LicenseRequirements(feature: .documentMarkup) }
 
 	// MARK: - Extension matching

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -28,6 +28,7 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 	var savingMode: QLPreviewItemEditingMode?
 	var itemTracker: OCCoreItemTracking?
 	var modifiedContentsURL: URL?
+	var dismissedViewWithoutSaving: Bool = false
 
 	var source: URL {
 		didSet {
@@ -89,6 +90,8 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 						self.saveModifiedContents(at: modifiedContentsURL, savingMode: savingMode)
 					} else if let savingMode = self.savingMode, savingMode == .createCopy {
 						self.saveModifiedContents(at: self.source, savingMode: savingMode)
+					} else {
+						self.dismissedViewWithoutSaving = true
 					}
 				}
 			}
@@ -98,6 +101,8 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 					self.saveModifiedContents(at: modifiedContentsURL, savingMode: savingMode)
 				} else if let savingMode = self.savingMode, savingMode == .createCopy {
 					self.saveModifiedContents(at: self.source, savingMode: savingMode)
+				} else {
+					self.dismissedViewWithoutSaving = true
 				}
 			}
 		}
@@ -204,5 +209,8 @@ extension EditDocumentViewController: QLPreviewControllerDataSource, QLPreviewCo
 
     func previewController(_ controller: QLPreviewController, didSaveEditedCopyOf previewItem: QLPreviewItem, at modifiedContentsURL: URL) {
 		self.modifiedContentsURL = modifiedContentsURL
+		if self.dismissedViewWithoutSaving, let savingMode = self.savingMode {
+			self.saveModifiedContents(at: modifiedContentsURL, savingMode: savingMode)
+		}
 	}
 }


### PR DESCRIPTION
## Description
Fixes saving an edited markup file. When editing mode was not ended by the user, the delegate call with the changed file will be fired after the view was already dismissed.
Now will save this file, when it was not saved before.

## Related Issue
#617 
#618 

## Motivation and Context
Correct saving the edited file

## How Has This Been Tested?

- Markup a file
- Do not end editing mode
- Tap on `Done`
- Select a saving mode
- Changes are saved

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

