### PR TITLE
[fix/subscription-ui] Equalize subscription UI font size.

### DIFF
--- a/ownCloud/Licensing/Offers/LicenseOfferView.swift
+++ b/ownCloud/Licensing/Offers/LicenseOfferView.swift
@@ -73,7 +73,7 @@ class LicenseOfferView: UIView, Themeable {
 	private let titleLabelSize : CGFloat = 20
 	private let descriptionLabelSize : CGFloat = 17
 	private let tryLabelSize : CGFloat = 17
-	private let priceLabelSize : CGFloat = 15
+	private let priceLabelSize : CGFloat = 17
 
 	func buildView() {
 		titleLabel = UILabel()


### PR DESCRIPTION
## Description
Ensure equal font size for trial and subscription price in IAP/subscription card UI.

## Screenshots (if appropriate):
| Before | After |
----|----
![Bildschirmfoto 2019-12-12 um 14 47 28](https://user-images.githubusercontent.com/639669/70717351-77726000-1cee-11ea-9ce5-f5de98f80011.png) | ![Bildschirmfoto 2020-03-09 um 09 45 45](https://user-images.githubusercontent.com/639669/76196711-022e0280-61eb-11ea-9b7f-c9623618460e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)