### PR TITLE
[feature/drag-drop-setting] Setting to disable dragging files inside the app

### DIFF
--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -734,6 +734,10 @@ extension ClientQueryViewController: UITableViewDragDelegate {
 
 	func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
 
+		if !DisplaySettings.shared.dragFiles {
+			return [UIDragItem]()
+		}
+
 		if !self.tableView.isEditing {
 			self.populateToolbar()
 		}

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -734,7 +734,7 @@ extension ClientQueryViewController: UITableViewDragDelegate {
 
 	func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
 
-		if !DisplaySettings.shared.dragFiles {
+		if DisplaySettings.shared.preventDraggingFiles {
 			return [UIDragItem]()
 		}
 

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -237,7 +237,7 @@
 /* Display settings */
 "Advanced settings" = "Advanced settings";
 "Show hidden files and folders" = "Show hidden files and folders";
-"Drag files enabled" = "Drag files enabled";
+"Prevent dragging of files and folders" = "Prevent dragging of files and folders";
 
 /* Passcode Messages */
 

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -235,8 +235,9 @@
 "Increase Slider Value" = "Increase Slider Value";
 
 /* Display settings */
-"Display settings" = "Display settings";
+"Advanced settings" = "Advanced settings";
 "Show hidden files and folders" = "Show hidden files and folders";
+"Drag files enabled" = "Drag files enabled";
 
 /* Passcode Messages */
 

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -24,12 +24,18 @@ class DisplaySettingsSection: SettingsSection {
 	override init(userDefaults: UserDefaults) {
 		super.init(userDefaults: userDefaults)
 
-		self.headerTitle = "Display settings".localized
+		self.headerTitle = "Advanced settings".localized
 
 		self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
 			if let newShowHiddenFiles = row.value as? Bool {
 				DisplaySettings.shared.showHiddenFiles = newShowHiddenFiles
 			}
 		}, title: "Show hidden files and folders".localized, value: DisplaySettings.shared.showHiddenFiles, identifier: "show-hidden-files-switch"))
+
+		self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
+			if let disableDragging = row.value as? Bool {
+				DisplaySettings.shared.dragFiles = disableDragging
+			}
+		}, title: "Drag files enabled".localized, value: DisplaySettings.shared.dragFiles, identifier: "drag-files-switch"))
 	}
 }

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -34,8 +34,8 @@ class DisplaySettingsSection: SettingsSection {
 
 		self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
 			if let disableDragging = row.value as? Bool {
-				DisplaySettings.shared.dragFiles = disableDragging
+				DisplaySettings.shared.preventDraggingFiles = disableDragging
 			}
-		}, title: "Prevent dragging of files and folders".localized, value: DisplaySettings.shared.dragFiles, identifier: "drag-files-switch"))
+		}, title: "Prevent dragging of files and folders".localized, value: DisplaySettings.shared.preventDraggingFiles, identifier: "prevent-dragging-files-switch"))
 	}
 }

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -36,6 +36,6 @@ class DisplaySettingsSection: SettingsSection {
 			if let disableDragging = row.value as? Bool {
 				DisplaySettings.shared.dragFiles = disableDragging
 			}
-		}, title: "Drag files enabled".localized, value: DisplaySettings.shared.dragFiles, identifier: "drag-files-switch"))
+		}, title: "Prevent dragging of files and folders".localized, value: DisplaySettings.shared.dragFiles, identifier: "drag-files-switch"))
 	}
 }

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.h
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.h
@@ -29,17 +29,22 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Show hidden files
 @property(assign,nonatomic) BOOL showHiddenFiles;
 
+#pragma mark - Drag files
+@property(assign,nonatomic) BOOL dragFiles;
+
 #pragma mark - Query updating
 - (void)updateQueryWithDisplaySettings:(OCQuery *)query;
 
 @end
 
 extern NSString *DisplaySettingsShowHiddenFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .showHiddenFiles
+extern NSString *DisplaySettingsDragFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .dragFiles
 
 extern OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged; 	//!< Posted when display settings changed (internal use only)
 extern NSNotificationName DisplaySettingsChanged;				//!< Posted when display settings changed (for use by app + File Provider)
 
 extern OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay; 		//!< The class settings identifier for the Display Settings
 extern OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles;		//!< The class settings key for Show Hidden Files
+extern OCClassSettingsKey OCClassSettingsKeyDisplayDragFiles;			//!< The class settings key if Drag Files is enabled
 
 NS_ASSUME_NONNULL_END

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.h
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign,nonatomic) BOOL showHiddenFiles;
 
 #pragma mark - Drag files
-@property(assign,nonatomic) BOOL dragFiles;
+@property(assign,nonatomic) BOOL preventDraggingFiles;
 
 #pragma mark - Query updating
 - (void)updateQueryWithDisplaySettings:(OCQuery *)query;
@@ -38,13 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern NSString *DisplaySettingsShowHiddenFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .showHiddenFiles
-extern NSString *DisplaySettingsDragFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .dragFiles
+extern NSString *DisplaySettingsPreventDraggingFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .preventDraggingFiles
 
 extern OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged; 	//!< Posted when display settings changed (internal use only)
 extern NSNotificationName DisplaySettingsChanged;				//!< Posted when display settings changed (for use by app + File Provider)
 
 extern OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay; 		//!< The class settings identifier for the Display Settings
 extern OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles;		//!< The class settings key for Show Hidden Files
-extern OCClassSettingsKey OCClassSettingsKeyDisplayDragFiles;			//!< The class settings key if Drag Files is enabled
+extern OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles;			//!< The class settings key if Drag Files is enabled
 
 NS_ASSUME_NONNULL_END

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.m
@@ -32,7 +32,7 @@
 	{
 		return (@{
 			OCClassSettingsKeyDisplayShowHiddenFiles : @(NO),
-			OCClassSettingsKeyDisplayDragFiles : @(NO)
+			OCClassSettingsKeyDisplayPreventDraggingFiles : @(NO)
 		});
 	}
 
@@ -60,7 +60,7 @@
 		}];
 
 		_showHiddenFiles = [self _showHiddenFilesValue];
-		_dragFiles = [self _dragFilesValue];
+		_preventDraggingFiles = [self _preventDraggingFilesValue];
 	}
 
 	return (self);
@@ -78,9 +78,9 @@
 	_showHiddenFiles = [self _showHiddenFilesValue];
 	[self didChangeValueForKey:@"showHiddenFiles"];
 
-	[self willChangeValueForKey:@"dragFiles"];
-	_dragFiles = [self _dragFilesValue];
-	[self didChangeValueForKey:@"dragFiles"];
+	[self willChangeValueForKey:@"preventDraggingFiles"];
+	_preventDraggingFiles = [self _preventDraggingFilesValue];
+	[self didChangeValueForKey:@"preventDraggingFiles"];
 
 	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
 }
@@ -108,23 +108,23 @@
 }
 
 #pragma mark - Drag files
-- (BOOL)_dragFilesValue
+- (BOOL)_preventDraggingFilesValue
 {
-	NSNumber *dragFilesNumber;
+	NSNumber *preventDraggingFilesNumber;
 
-	if ((dragFilesNumber = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsDragFilesPrefsKey]) != nil)
+	if ((preventDraggingFilesNumber = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsPreventDraggingFilesPrefsKey]) != nil)
 	{
-		return (dragFilesNumber.boolValue);
+		return (preventDraggingFilesNumber.boolValue);
 	}
 
-	return ([[self classSettingForOCClassSettingsKey:OCClassSettingsKeyDisplayDragFiles] boolValue]);
+	return ([[self classSettingForOCClassSettingsKey:OCClassSettingsKeyDisplayPreventDraggingFiles] boolValue]);
 }
 
-- (void)setDragFiles:(BOOL)dragFiles
+- (void)setPreventDraggingFiles:(BOOL)preventDraggingFiles
 {
-	_dragFiles = dragFiles;
+	_preventDraggingFiles = preventDraggingFiles;
 
-	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:dragFiles forKey:DisplaySettingsDragFilesPrefsKey];
+	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:preventDraggingFiles forKey:DisplaySettingsPreventDraggingFilesPrefsKey];
 
 	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
 }
@@ -163,7 +163,7 @@
 @end
 
 NSString *DisplaySettingsShowHiddenFilesPrefsKey = @"display-show-hidden-files";
-NSString *DisplaySettingsDragFilesPrefsKey = @"display-drag-files";
+NSString *DisplaySettingsPreventDraggingFilesPrefsKey = @"display-prevent-dragging-files";
 
 OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged = @"org.owncloud.display-settings-changed";
 
@@ -171,4 +171,4 @@ NSNotificationName DisplaySettingsChanged = @"org.owncloud.display-settings-chan
 
 OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay = @"display";
 OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles = @"show-hidden-files";
-OCClassSettingsKey OCClassSettingsKeyDisplayDragFiles = @"drag-files";
+OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles = @"prevent-dragging-files";

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.m
@@ -31,7 +31,8 @@
 	if ([identifier isEqual:OCClassSettingsIdentifierDisplay])
 	{
 		return (@{
-			OCClassSettingsKeyDisplayShowHiddenFiles : @(NO)
+			OCClassSettingsKeyDisplayShowHiddenFiles : @(NO),
+			OCClassSettingsKeyDisplayDragFiles : @(YES)
 		});
 	}
 
@@ -59,6 +60,7 @@
 		}];
 
 		_showHiddenFiles = [self _showHiddenFilesValue];
+		_dragFiles = [self _dragFilesValue];
 	}
 
 	return (self);
@@ -75,6 +77,10 @@
 	[self willChangeValueForKey:@"showHiddenFiles"];
 	_showHiddenFiles = [self _showHiddenFilesValue];
 	[self didChangeValueForKey:@"showHiddenFiles"];
+
+	[self willChangeValueForKey:@"dragFiles"];
+	_dragFiles = [self _dragFilesValue];
+	[self didChangeValueForKey:@"dragFiles"];
 
 	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
 }
@@ -97,6 +103,28 @@
 	_showHiddenFiles = showHiddenFiles;
 
 	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:showHiddenFiles forKey:DisplaySettingsShowHiddenFilesPrefsKey];
+
+	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
+}
+
+#pragma mark - Drag files
+- (BOOL)_dragFilesValue
+{
+	NSNumber *dragFilesNumber;
+
+	if ((dragFilesNumber = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsDragFilesPrefsKey]) != nil)
+	{
+		return (dragFilesNumber.boolValue);
+	}
+
+	return ([[self classSettingForOCClassSettingsKey:OCClassSettingsKeyDisplayDragFiles] boolValue]);
+}
+
+- (void)setDragFiles:(BOOL)dragFiles
+{
+	_dragFiles = dragFiles;
+
+	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:dragFiles forKey:DisplaySettingsDragFilesPrefsKey];
 
 	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
 }
@@ -135,6 +163,7 @@
 @end
 
 NSString *DisplaySettingsShowHiddenFilesPrefsKey = @"display-show-hidden-files";
+NSString *DisplaySettingsDragFilesPrefsKey = @"display-drag-files";
 
 OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged = @"org.owncloud.display-settings-changed";
 
@@ -142,3 +171,4 @@ NSNotificationName DisplaySettingsChanged = @"org.owncloud.display-settings-chan
 
 OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay = @"display";
 OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles = @"show-hidden-files";
+OCClassSettingsKey OCClassSettingsKeyDisplayDragFiles = @"drag-files";

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.m
@@ -32,7 +32,7 @@
 	{
 		return (@{
 			OCClassSettingsKeyDisplayShowHiddenFiles : @(NO),
-			OCClassSettingsKeyDisplayDragFiles : @(YES)
+			OCClassSettingsKeyDisplayDragFiles : @(NO)
 		});
 	}
 

--- a/ownCloudTests/SettingsTests.swift
+++ b/ownCloudTests/SettingsTests.swift
@@ -45,7 +45,7 @@ class SettingsTests: XCTestCase {
 
 		//Assert
 		EarlGrey.selectElement(with: grey_accessibilityID("show-hidden-files-switch")).assert(grey_sufficientlyVisible())
-		EarlGrey.selectElement(with: grey_accessibilityID("drag-files-switch")).assert(grey_sufficientlyVisible())
+		EarlGrey.selectElement(with: grey_accessibilityID("prevent-dragging-files-switch")).assert(grey_sufficientlyVisible())
 	}
 	
 	/*

--- a/ownCloudTests/SettingsTests.swift
+++ b/ownCloudTests/SettingsTests.swift
@@ -37,14 +37,15 @@ class SettingsTests: XCTestCase {
 		EarlGrey.selectElement(with: grey_accessibilityID("theme")).assert(grey_sufficientlyVisible())
 		EarlGrey.selectElement(with: grey_accessibilityID("logging")).assert(grey_sufficientlyVisible())
 	}
-	
+
 	/*
-	* PASSED if: Show hidden files and folders are displayed as part of the "Display Settings" section of Settings
+	* PASSED if: Show hidden files and folders, Drag Files are displayed as part of the "Advanced Settings" section of Settings
 	*/
 	func testCheckDisplaySettings () {
-		
+
 		//Assert
 		EarlGrey.selectElement(with: grey_accessibilityID("show-hidden-files-switch")).assert(grey_sufficientlyVisible())
+		EarlGrey.selectElement(with: grey_accessibilityID("drag-files-switch")).assert(grey_sufficientlyVisible())
 	}
 	
 	/*


### PR DESCRIPTION
## Description
Added a new setting to disable dragging inside the app. Changed the section name to `Advanced` to group more _advanced_ settings in this group.

## Related Issue
#581 

## Motivation and Context
Some users do not want to drag files inside the app. Also for accessibility it makes sense to disable this action for some users.

## How Has This Been Tested?
- Open Settings
- Scroll to `Advanced` section
- Disable `Drag files enabled`
- Open file list and try to drag a file

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

