### PR TITLE
[fix/fastlane-badge-icon] Fix for failing Bitrise builds on badge icon creation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -180,14 +180,24 @@ platform :ios do
     )
 
     # Add a badge with the latest short commit hash to the app icon
+    build_number = app_version(
+      xcodeproj: "ownCloud.xcodeproj",
+      version_key: "APP_VERSION"
+    )
+
+    version = app_version(
+      xcodeproj: "ownCloud.xcodeproj",
+      version_key: "APP_SHORT_VERSION"
+    )
+
     commit = last_git_commit
     short_hash = commit[:abbreviated_commit_hash] # short sha of commit
-    sh "curl https://badgen.net/badge/Bitrise/" + short_hash + "/blue > badge.svg"
     sh "brew install librsvg"
     sh "brew unlink pango"
     sh "brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7cf3b63be191cb2ce4cd86f4406915128ec97432/Formula/pango.rb"
     sh "brew switch pango 1.42.4_1 "
-    sh "rsvg-convert badge.svg > badge.png"
+    sh "sed -e \"s/\#version#/" + version + "/\" -e \"s/\#githash#/" + short_hash + "/\" badge.svg > badge_tmp.svg"
+    sh "rsvg-convert badge_tmp.svg > badge.png"
     sh "badge --custom badge.png --glob /../**/*.appiconset/*.{png,PNG}"
 
     #Create the build
@@ -208,5 +218,4 @@ platform :ios do
       }
     )
   end
-
 end

--- a/fastlane/actions/app_version.rb
+++ b/fastlane/actions/app_version.rb
@@ -1,0 +1,79 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      APP_VERSION_CUSTOM_VALUE = :APP_VERSION_VALUE
+    end
+
+    class AppVersionAction < Action
+      def self.run(params)
+        require 'xcodeproj'
+
+        # Load .xcodeproj
+        project_path = params[:xcodeproj]
+        project = Xcodeproj::Project.open(project_path)
+
+        # Fetch the build configuration objects
+        configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration'}
+        UI.user_error!("Not found XCBuildConfiguration from xcodeproj") unless configs.count > 0
+
+        configs.each do |c|
+          if c.build_settings[params[:version_key]] != ''
+            app_version = c.build_settings[params[:version_key]]
+            UI.success("Found #{params[:version_key]} #{app_version}")
+            Actions.lane_context[SharedValues::APP_VERSION_CUSTOM_VALUE] = app_version
+            return app_version
+          end
+        end
+
+        UI.error("Could not found #{params[:version_key]} in XCBuildConfiguration")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Reads the key stored in the Build Configuration"
+      end
+
+      def self.details
+        "Reads the key stored in the Build Configuration (APP_VERSION, APP_SHORT_VERSION)"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_UPDATE_APPICON_PROJECT_PATH",
+                                       description: "Path to your Xcode project",
+                                       default_value: Dir['*.xcodeproj'].first,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass the path to the project, not the workspace") unless value.end_with?(".xcodeproj")
+                                         UI.user_error!("Could not find Xcode project") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :version_key,
+                                       env_name: 'FL_APPVERSION_KEY',
+                                       description: 'Key in XCBuildConfiguration for the version string')
+        ]
+      end
+
+      def self.output
+        [
+          ['APP_VERSION_CUSTOM_VALUE', 'App Version String e.g. 1.1.2, 154']
+        ]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["Matthias Hühne"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/badge.svg
+++ b/fastlane/badge.svg
@@ -1,0 +1,19 @@
+<svg width="102.6" height="20" viewBox="0 0 1026 200" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="1026" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="448" height="200" fill="#555"/>
+    <rect width="578" height="200" fill="#08C" x="448"/>
+    <rect width="1026" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="60" y="148" textLength="348" fill="#000" opacity="0.25">#version#</text>
+    <text x="50" y="138" textLength="348">#version#</text>
+    <text x="503" y="148" textLength="478" fill="#000" opacity="0.25">#githash#</text>
+    <text x="493" y="138" textLength="478">#githash#</text>
+  </g>
+
+</svg>


### PR DESCRIPTION
Fixed broken badge icon creation for fastlane builds. Added own action to set the build number and last git hash in the SVG image. Values are read from the project file.

## Related Issue
#644 


## How Has This Been Tested?
Check Bitrise build for this branch, if it does not fail with the error message in the issue.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

