### PR TITLE
[fix/save-file-intent-completion] Fix for Save File Shortcut Completion

### DIFF
--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -235,7 +235,7 @@
 
 			[self.core downloadItem:(OCItem *)item options:@{
 
-				OCCoreOptionAddFileClaim : [OCClaim claimForLifetimeOfCore:core explicitIdentifier:OCClaimExplicitIdentifierFileProvider]
+				OCCoreOptionAddFileClaim : [OCClaim claimForLifetimeOfCore:core explicitIdentifier:OCClaimExplicitIdentifierFileProvider withLockType:OCClaimLockTypeRead]
 
 			} resultHandler:^(NSError *error, OCCore *core, OCItem *item, OCFile *file) {
 				OCLogDebug(@"Starting to provide file:\nPAU: %@\nFURL: %@\nID: %@\nErr: %@\nlocalRelativePath: %@", provideAtURL, file.url, item.itemIdentifier, error, item.localRelativePath);

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -141,19 +141,19 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		switch savingMode {
 		case .createCopy:
 			if let core = core, let parentItem = item.parentItem(from: core) {
-				self.core?.importFileNamed(item.name, at: parentItem, from: url, isSecurityScoped: true, options: [ .automaticConflictResolutionNameStyle : OCCoreDuplicateNameStyle.bracketed.rawValue, OCCoreOption.importByCopying : true], placeholderCompletionHandler: nil, resultHandler: { (error, _ core, _ item, _) in
+				self.core?.importFileNamed(item.name, at: parentItem, from: url, isSecurityScoped: true, options: [ .automaticConflictResolutionNameStyle : OCCoreDuplicateNameStyle.bracketed.rawValue, OCCoreOption.importByCopying : true], placeholderCompletionHandler: { (error, item) in
 					if let error = error {
 						self.present(error: error, title: "Saving edited file failed".localized)
 					}
-				})
+				}, resultHandler: nil)
 			}
 		case .updateContents:
 			if let core = core, let parentItem = item.parentItem(from: core) {
-				core.reportLocalModification(of: item, parentItem: parentItem, withContentsOfFileAt: url, isSecurityScoped: true, options: [OCCoreOption.importByCopying : true], placeholderCompletionHandler: nil, resultHandler: { (error, _ core, _ item, _) in
+				core.reportLocalModification(of: item, parentItem: parentItem, withContentsOfFileAt: url, isSecurityScoped: true, options: [OCCoreOption.importByCopying : true], placeholderCompletionHandler: { (error, item) in
 					if let error = error {
 						self.present(error: error, title: "Saving edited file failed".localized)
 					}
-				})
+				}, resultHandler: nil)
 			}
 		default:
 			break

--- a/ownCloudAppShared/Intent/SaveFileIntentHandler.swift
+++ b/ownCloudAppShared/Intent/SaveFileIntentHandler.swift
@@ -76,13 +76,13 @@ public class SaveFileIntentHandler: NSObject, SaveFileIntentHandling {
 						if error == nil, let core = core, let fileItem = fileItem, let parentItem = fileItem.parentItem(from: core) {
 							// File already exists
 							if intent.shouldOverwrite?.boolValue == true {
-								core.reportLocalModification(of: fileItem, parentItem: parentItem, withContentsOfFileAt: fileURL, isSecurityScoped: true, options: [OCCoreOption.importByCopying : true], placeholderCompletionHandler: nil,
-															 resultHandler: { (error, _ core, _ item, _) in
-																if error != nil {
-																	completion(SaveFileIntentResponse(code: .failure, userActivity: nil))
-																} else {	completion(SaveFileIntentResponse.success(filePath: item?.path ?? ""))
-																}
-								})
+								core.reportLocalModification(of: fileItem, parentItem: parentItem, withContentsOfFileAt: fileURL, isSecurityScoped: true, options: [OCCoreOption.importByCopying : true], placeholderCompletionHandler: { (error, item) in
+									if error != nil {
+										completion(SaveFileIntentResponse(code: .failure, userActivity: nil))
+									} else {	completion(SaveFileIntentResponse.success(filePath: item?.path ?? ""))
+									}
+								},
+															 resultHandler: nil)
 							} else {
 								completion(SaveFileIntentResponse(code: .overwriteFailure, userActivity: nil))
 							}
@@ -93,13 +93,13 @@ public class SaveFileIntentHandler: NSObject, SaveFileIntentHandling {
 												  from: fileURL,
 												  isSecurityScoped: true,
 												  options: [OCCoreOption.importByCopying : true],
-												  placeholderCompletionHandler: nil,
-												  resultHandler: { (error, _ core, _ item, _) in
+												  placeholderCompletionHandler: { (error, item) in
 													if error != nil {
 														completion(SaveFileIntentResponse(code: .failure, userActivity: nil))
 													} else {	completion(SaveFileIntentResponse.success(filePath: item?.path ?? ""))
 													}
-							}
+							},
+												  resultHandler: nil
 							)
 						} else {
 							completion(SaveFileIntentResponse(code: .failure, userActivity: nil))


### PR DESCRIPTION
## Description
Fixes a problem, that completion handler may not be called and shortcut action finish with an error.

## Related Issue
#651 

## Motivation and Context
Correct handling of shortcut action

## How Has This Been Tested?
Look at issue description

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

