### PR TITLE
[feature/folders-first] Option to show folders at the top

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -17,7 +17,35 @@ This document provides an overview over the available sections and variables.
 	- `is-beta-build`: Controls if the app is built for beta or release purposes.
 		- type: Bool
 		- default: `false`
-	
+		
+## Bookmarks
+
+- **Section ID**: `bookmark`
+
+- **Variables**:
+	- `default-url`: Set a default server URL.
+		- type: String
+		- default: `""`
+	- `url-editable`: Being able to edit the server URL in the URL TextField.
+		- type: Bool
+		- default: `true`
+
+
+## Display Settings
+
+- **Section ID**: `display`
+
+- **Variables**:
+	- `show-hidden-files`: Controls whether hidden files (i.e. files starting with `.` ) should also be shown
+		- type: Bool
+		- default: `false`
+	- `sort-folders-first`: Controls whether folders are shown at the top
+		- type: Bool
+		- default: `false`
+	- `prevent-dragging-files`: Controls whether drag and drop should be prevented for items inside the app 
+		- type: Bool
+		- default: `false`
+
 ## Feedback
 
 - **Section ID**: `feedback`
@@ -35,16 +63,12 @@ This document provides an overview over the available sections and variables.
 	- send-feedback-enabled : Send an email to feedback-email with some feedback.
 		- type: Bool
 		-default: `true`
-		
-## Bookmarks
 
-- **Section ID**: `bookmark`
+## Shortcuts
+
+- **Section ID**: `shortcuts`
 
 - **Variables**:
-	- `default-url`: Set a default server URL.
-		- type: String
-		- default: `""`
-	- `url-editable`: Being able to edit the server URL in the URL TextField.
+	- `enabled`: Controls whether Shortcuts support is enabled
 		- type: Bool
 		- default: `true`
-

--- a/ownCloud/FileLists/QueryFileListTableViewController.swift
+++ b/ownCloud/FileLists/QueryFileListTableViewController.swift
@@ -57,6 +57,7 @@ class QueryFileListTableViewController: FileListTableViewController, SortBarDele
 
 	// MARK: - Display settings
 	@objc func displaySettingsChanged() {
+		query.sortComparator = sortMethod.comparator(direction: sortDirection)
 		DisplaySettings.shared.updateQuery(withDisplaySettings: query)
 	}
 

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 /* Display settings */
 "Advanced settings" = "Advanced settings";
 "Show hidden files and folders" = "Show hidden files and folders";
+"Show folders at the top" = "Show folders at the top";
 "Prevent dragging of files and folders" = "Prevent dragging of files and folders";
 
 /* Passcode Messages */

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -33,6 +33,12 @@ class DisplaySettingsSection: SettingsSection {
 		}, title: "Show hidden files and folders".localized, value: DisplaySettings.shared.showHiddenFiles, identifier: "show-hidden-files-switch"))
 
 		self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
+			if let newSortFolderFirst = row.value as? Bool {
+				DisplaySettings.shared.sortFoldersFirst = newSortFolderFirst
+			}
+		}, title: "Show folders at the top".localized, value: DisplaySettings.shared.sortFoldersFirst, identifier: "sort-folders-first"))
+
+		self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
 			if let disableDragging = row.value as? Bool {
 				DisplaySettings.shared.preventDraggingFiles = disableDragging
 			}

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.h
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Show hidden files
 @property(assign,nonatomic) BOOL showHiddenFiles;
 
+#pragma mark - Folders first
+@property(assign,nonatomic) BOOL sortFoldersFirst;
+
 #pragma mark - Drag files
 @property(assign,nonatomic) BOOL preventDraggingFiles;
 
@@ -38,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 extern NSString *DisplaySettingsShowHiddenFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .showHiddenFiles
+extern NSString *DisplaySettingsSortFoldersFirstPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .sortFoldersFirst
 extern NSString *DisplaySettingsPreventDraggingFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .preventDraggingFiles
 
 extern OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged; 	//!< Posted when display settings changed (internal use only)
@@ -45,6 +49,7 @@ extern NSNotificationName DisplaySettingsChanged;				//!< Posted when display se
 
 extern OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay; 		//!< The class settings identifier for the Display Settings
 extern OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles;		//!< The class settings key for Show Hidden Files
-extern OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles;			//!< The class settings key if Drag Files is enabled
+extern OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst;		//!< The class settings key for sorting folders first
+extern OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles;	//!< The class settings key if Drag Files is enabled
 
 NS_ASSUME_NONNULL_END

--- a/ownCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/ownCloudAppFramework/Display Settings/DisplaySettings.m
@@ -32,7 +32,8 @@
 	{
 		return (@{
 			OCClassSettingsKeyDisplayShowHiddenFiles : @(NO),
-			OCClassSettingsKeyDisplayPreventDraggingFiles : @(NO)
+			OCClassSettingsKeyDisplayPreventDraggingFiles : @(NO),
+			OCClassSettingsKeyDisplaySortFoldersFirst : @(NO)
 		});
 	}
 
@@ -60,6 +61,7 @@
 		}];
 
 		_showHiddenFiles = [self _showHiddenFilesValue];
+		_sortFoldersFirst = [self _sortFoldersFirst];
 		_preventDraggingFiles = [self _preventDraggingFilesValue];
 	}
 
@@ -78,10 +80,20 @@
 	_showHiddenFiles = [self _showHiddenFilesValue];
 	[self didChangeValueForKey:@"showHiddenFiles"];
 
+	[self willChangeValueForKey:@"sortFoldersFirst"];
+	_sortFoldersFirst = [self _sortFoldersFirst];
+	[self didChangeValueForKey:@"sortFoldersFirst"];
+
 	[self willChangeValueForKey:@"preventDraggingFiles"];
 	_preventDraggingFiles = [self _preventDraggingFilesValue];
 	[self didChangeValueForKey:@"preventDraggingFiles"];
 
+	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
+}
+
+- (void)postChangeNotifications
+{
+	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
 	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
 }
 
@@ -104,7 +116,29 @@
 
 	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:showHiddenFiles forKey:DisplaySettingsShowHiddenFilesPrefsKey];
 
-	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
+	[self postChangeNotifications];
+}
+
+#pragma mark - Folders first
+- (BOOL)_sortFoldersFirst
+{
+	NSNumber *sortFoldersFirstNumber;
+
+	if ((sortFoldersFirstNumber = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsSortFoldersFirstPrefsKey]) != nil)
+	{
+		return (sortFoldersFirstNumber.boolValue);
+	}
+
+	return ([[self classSettingForOCClassSettingsKey:OCClassSettingsKeyDisplaySortFoldersFirst] boolValue]);
+}
+
+- (void)setSortFoldersFirst:(BOOL)sortFoldersFirst
+{
+	_sortFoldersFirst = sortFoldersFirst;
+
+	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:sortFoldersFirst forKey:DisplaySettingsSortFoldersFirstPrefsKey];
+
+	[self postChangeNotifications];
 }
 
 #pragma mark - Drag files
@@ -126,7 +160,7 @@
 
 	[OCAppIdentity.sharedAppIdentity.userDefaults setBool:preventDraggingFiles forKey:DisplaySettingsPreventDraggingFilesPrefsKey];
 
-	[OCIPNotificationCenter.sharedNotificationCenter postNotificationForName:OCIPCNotificationNameDisplaySettingsChanged ignoreSelf:YES];
+	[self postChangeNotifications];
 }
 
 #pragma mark - Query updating
@@ -163,6 +197,7 @@
 @end
 
 NSString *DisplaySettingsShowHiddenFilesPrefsKey = @"display-show-hidden-files";
+NSString *DisplaySettingsSortFoldersFirstPrefsKey = @"display-sort-folders-first";
 NSString *DisplaySettingsPreventDraggingFilesPrefsKey = @"display-prevent-dragging-files";
 
 OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged = @"org.owncloud.display-settings-changed";
@@ -171,4 +206,5 @@ NSNotificationName DisplaySettingsChanged = @"org.owncloud.display-settings-chan
 
 OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay = @"display";
 OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles = @"show-hidden-files";
+OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst = @"sort-folders-first";
 OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles = @"prevent-dragging-files";


### PR DESCRIPTION
## Description
A new option in Settings to allow showing folders at the top of file lists.

## Related Issue
#431

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## QA

Test plan:

https://github.com/owncloud/QA/blob/master/Mobile/iOS-app/Version%2011.4.0/Folders%20at%20the%20top.md