### PR TITLE
[fix/round-shape-button] Fix round shape for pin code buttons

### DIFF
--- a/ownCloud/Licensing/Offers/LicenseOfferButton.swift
+++ b/ownCloud/Licensing/Offers/LicenseOfferButton.swift
@@ -30,7 +30,7 @@ class LicenseOfferButton: ThemeButton {
 		self.buttonFont = UIFont.systemFont(ofSize: UIFont.labelFontSize)
 		self.buttonVerticalPadding = -5
 		self.buttonHorizontalPadding = 23
-		self.buttonCornerRadius = -1
+		self.buttonCornerRadius = .round
 
 		originalTitle = title
 		self.setTitle(title, for: .normal)
@@ -47,7 +47,7 @@ class LicenseOfferButton: ThemeButton {
 		self.buttonFont = UIFont.systemFont(ofSize: UIFont.labelFontSize)
 
 		self.buttonVerticalPadding = 15
-		self.buttonCornerRadius = 10
+		self.buttonCornerRadius = .medium
 
 		self.setTitle(title, for: .normal)
 

--- a/ownCloud/Theming/UI/ThemeButton.swift
+++ b/ownCloud/Theming/UI/ThemeButton.swift
@@ -18,6 +18,12 @@
 
 import UIKit
 
+enum ThemeButtonCornerRadiusStyle : CGFloat {
+	case round = -1
+	case small = 5
+	case medium = 10
+}
+
 @IBDesignable
 class ThemeButton : UIButton {
 	internal var _themeColorCollection : ThemeColorPairCollection?
@@ -101,14 +107,14 @@ class ThemeButton : UIButton {
 		       invalidateIntrinsicContentSize()
 	       }
 	}
-	var buttonCornerRadius : CGFloat = 5 {
+	var buttonCornerRadius : ThemeButtonCornerRadiusStyle = .medium {
 		didSet {
 			adjustCornerRadius()
 		}
 	}
 
 	func adjustCornerRadius() {
-		self.layer.cornerRadius = (buttonCornerRadius < 0) ? bounds.size.height/2 : buttonCornerRadius
+		self.layer.cornerRadius = (buttonCornerRadius == .round) ? bounds.size.height/2 : buttonCornerRadius.rawValue
 	}
 
 	override var bounds: CGRect {

--- a/ownCloud/Theming/UI/ThemeRoundedButton.swift
+++ b/ownCloud/Theming/UI/ThemeRoundedButton.swift
@@ -23,13 +23,13 @@ class ThemeRoundedButton: ThemeButton {
 	override init(frame: CGRect) {
 		super.init(frame: frame)
 
-		self.buttonCornerRadius = -1
+		self.buttonCornerRadius = .round
 	}
 
 	required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 
-		self.buttonCornerRadius = -1
+		self.buttonCornerRadius = .round
 	}
 
 }

--- a/ownCloud/Theming/UI/ThemeRoundedButton.swift
+++ b/ownCloud/Theming/UI/ThemeRoundedButton.swift
@@ -22,20 +22,14 @@ class ThemeRoundedButton: ThemeButton {
 
 	override init(frame: CGRect) {
 		super.init(frame: frame)
-		styleButton()
+
+		self.buttonCornerRadius = -1
 	}
 
 	required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
-		styleButton()
-	}
 
-	private func styleButton() {
-		if self.frame.size.height < self.frame.size.width {
-			self.layer.cornerRadius = round(self.frame.size.height / 2)
-		} else {
-			self.layer.cornerRadius = round(self.frame.size.width / 2)
-		}
+		self.buttonCornerRadius = -1
 	}
 
 }


### PR DESCRIPTION
## Description
Round shape for pin code buttons was lost after changes in superclass. Adopted the code to this changes.

## Related Issue
#654

## How Has This Been Tested?
- set a pin code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

