### PR TITLE
Fixes for markup and PDF viewer

### DIFF
--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -97,8 +97,9 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
 		// Activate editing mode by faking a tap on pencil icon. Unfortunately that's the only way to do it apparently
-		if let items = self.navigationItem.rightBarButtonItems, items.count == 1, let editButton = items.first?.customView as? UIButton {
-			editButton.sendActions(for: .touchUpInside)
+		OnMainThread(after:0.5) {
+			guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
+			markupButton.sendActions(for: .touchUpInside)
 		}
 	}
 

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -94,6 +94,14 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		}
 	}
 
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		// Activate editing mode by faking a tap on pencil icon. Unfortunately that's the only way to do it apparently
+		if let items = self.navigationItem.rightBarButtonItems, items.count == 1, let editButton = items.first?.customView as? UIButton {
+			editButton.sendActions(for: .touchUpInside)
+		}
+	}
+
 	@objc func dismissAnimated() {
 		self.setEditing(false, animated: false)
 

--- a/ownCloud/Client/Viewer/DisplayViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayViewController.swift
@@ -282,6 +282,16 @@ class DisplayViewController: UIViewController {
 				iconImageView.image = item.icon(fitInSize:iconImageSize)
 			}
 		}
+
+		if self.source != nil, item.locallyModified == true {
+			OnMainThread {
+				self.renderSpecificView(completion: { (success) in
+					if !success {
+						self.state = .previewFailed
+					}
+				})
+			}
+		}
 	}
 
 	// MARK: - Actions which can be triggered by the user

--- a/ownCloud/Client/Viewer/DisplayViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayViewController.swift
@@ -45,6 +45,8 @@ class DisplayViewController: UIViewController {
 	var item: OCItem?
 	var itemIndex: Int?
 
+	private let moreButtonTag = 777
+
 	private let iconImageSize: CGSize = CGSize(width: 200.0, height: 200.0)
 	private let bottomMargin: CGFloat = 60.0
 	private let verticalSpacing: CGFloat = 10.0
@@ -372,16 +374,38 @@ class DisplayViewController: UIViewController {
 	// MARK: - UI management
 
 	func updateNavigationBarItems() {
+
 		if let parent = parent, let itemName = item?.name {
+
+			func checkActionsButtonPresence() -> Bool {
+				if let items = parent.navigationItem.rightBarButtonItems {
+					return items.filter({$0.tag == moreButtonTag}).count > 0
+				}
+				return false
+			}
+
 			parent.navigationItem.title = itemName
 
 			if shallDisplayMoreButtonInToolbar, let queryState = query?.state {
 				if queryState != .targetRemoved {
-					let actionsBarButtonItem = UIBarButtonItem(image: UIImage(named: "more-dots"), style: .plain, target: self, action: #selector(optionsBarButtonPressed))
-					actionsBarButtonItem.accessibilityLabel = itemName + " " + "Actions".localized
-					parent.navigationItem.rightBarButtonItem = actionsBarButtonItem
+
+					if checkActionsButtonPresence() == false {
+						let actionsBarButtonItem = UIBarButtonItem(image: UIImage(named: "more-dots"), style: .plain, target: self, action: #selector(optionsBarButtonPressed))
+						actionsBarButtonItem.tag = moreButtonTag
+						actionsBarButtonItem.accessibilityLabel = itemName + " " + "Actions".localized
+
+						var items = [UIBarButtonItem]()
+						if let previousItems = parent.navigationItem.rightBarButtonItems {
+							items.append(contentsOf: previousItems)
+						}
+						items.insert(actionsBarButtonItem, at: 0)
+						parent.navigationItem.rightBarButtonItems = items
+					}
+
 				} else {
-					parent.navigationItem.rightBarButtonItem = nil
+					parent.navigationItem.rightBarButtonItems?.removeAll(where: { (buttonItem) -> Bool in
+						return buttonItem.tag == moreButtonTag
+					})
 				}
 			}
 		}

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -173,8 +173,6 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 	// MARK: - View lifecycle management
 
 	override func viewDidLoad() {
-		shallDisplayMoreButtonInToolbar = false
-
 		super.viewDidLoad()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(handlePageChanged), name: .PDFViewPageChanged, object: nil)


### PR DESCRIPTION
## Description
- When opening markup editor, it is immediately changing into editing mode eliminating the need for an extra tap on pencil icon
- When markup is opened from the file preview, file preview is re-rendered in case file was changed (by scribbling on PDF or image file for example)
- More button is added to PDF view allowing to take actions from within the PDF viewer

## Related Issue
#729 
#698 

## Motivation and Context
Adding more convenience and improving user experience

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

