### PR TITLE
iOS13 gesture based multiple selection

### DIFF
--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -528,22 +528,20 @@ class ClientQueryViewController: QueryFileListTableViewController, UIDropInterac
 	// MARK: - Navigation Bar Actions
 	@objc func multipleSelectionButtonPressed() {
 
-		if !self.tableView.isEditing {
-			if #available(iOS 13, *) {
-				self.tableView.overrideUserInterfaceStyle = Theme.shared.activeCollection.interfaceStyle.userInterfaceStyle
-			}
-
-			updateMultiSelectionUI()
-			self.tableView.setEditing(true, animated: true)
-			sortBar?.showSelectButton = false
-
-			populateToolbar()
-
-			self.navigationItem.leftBarButtonItem = selectDeselectAllButtonItem!
-			self.navigationItem.rightBarButtonItems = [exitMultipleSelectionBarButtonItem!]
-
-			updateMultiSelectionUI()
+		if #available(iOS 13, *) {
+			self.tableView.overrideUserInterfaceStyle = Theme.shared.activeCollection.interfaceStyle.userInterfaceStyle
 		}
+
+		updateMultiSelectionUI()
+		self.tableView.setEditing(true, animated: true)
+		sortBar?.showSelectButton = false
+
+		populateToolbar()
+
+		self.navigationItem.leftBarButtonItem = selectDeselectAllButtonItem!
+		self.navigationItem.rightBarButtonItems = [exitMultipleSelectionBarButtonItem!]
+
+		updateMultiSelectionUI()
 	}
 
 	@objc func exitMultipleSelection() {
@@ -785,6 +783,16 @@ extension ClientQueryViewController: UITableViewDropDelegate {
 				}
 			}
 		}
+	}
+}
+
+@available(iOS 13, *) extension ClientQueryViewController {
+	override func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
+		return true
+	}
+
+	override func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
+		multipleSelectionButtonPressed()
 	}
 }
 

--- a/ownCloud/Client/ClientQueryViewController.swift
+++ b/ownCloud/Client/ClientQueryViewController.swift
@@ -788,7 +788,7 @@ extension ClientQueryViewController: UITableViewDropDelegate {
 
 @available(iOS 13, *) extension ClientQueryViewController {
 	override func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-		return true
+		return !DisplaySettings.shared.preventDraggingFiles
 	}
 
 	override func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {

--- a/ownCloud/Client/PhotoSelectionViewController.swift
+++ b/ownCloud/Client/PhotoSelectionViewController.swift
@@ -345,6 +345,14 @@ class PhotoSelectionViewController: UICollectionViewController, Themeable {
 
 }
 
+// MARK: - iOS13 gesture based multiple selection
+
+@available(iOS 13, *) extension PhotoSelectionViewController {
+	override func collectionView(_ collectionView: UICollectionView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
+		return true
+	}
+}
+
 // MARK: - PHPhotoLibraryChangeObserver
 
 extension PhotoSelectionViewController: PHPhotoLibraryChangeObserver {

--- a/ownCloud/Client/PhotoSelectionViewController.swift
+++ b/ownCloud/Client/PhotoSelectionViewController.swift
@@ -19,6 +19,7 @@
 import UIKit
 import Photos
 import PhotosUI
+import ownCloudApp
 
 private extension UICollectionView {
 	func indexPathsForElements(in rect: CGRect) -> [IndexPath] {
@@ -349,7 +350,7 @@ class PhotoSelectionViewController: UICollectionViewController, Themeable {
 
 @available(iOS 13, *) extension PhotoSelectionViewController {
 	override func collectionView(_ collectionView: UICollectionView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-		return true
+		return !DisplaySettings.shared.preventDraggingFiles
 	}
 }
 

--- a/ownCloud/Resources/en.lproj/InfoPlist.strings
+++ b/ownCloud/Resources/en.lproj/InfoPlist.strings
@@ -20,4 +20,4 @@
 "NSAppleMusicUsageDescription" = "This permission is needed for uploading media files to your server.";
 "NSPhotoLibraryAddUsageDescription" = "This permission is needed to upload photos and videos from your photo library.";
 "NSPhotoLibraryUsageDescription" = "This permission is needed to upload photos and videos from your photo library.";
-"NSMicrophoneUsageDescription" = "This permission is needed to record videos"
+"NSMicrophoneUsageDescription" = "This permission is needed to record videos";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -239,7 +239,7 @@
 "Show hidden files and folders" = "Show hidden files and folders";
 "Show folders at the top" = "Show folders at the top";
 "Prevent gestures" = "Prevent gestures";
-"Prevent dragging of files and folders and multiselection with fingers" = "Prevent dragging of files and folders and multiselection with fingers";
+"Prevent dragging of files and folders and multiselection using system defined gestures" = "Prevent dragging of files and folders and multiselection using system defined gestures";
 
 /* Passcode Messages */
 

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -238,7 +238,8 @@
 "Advanced settings" = "Advanced settings";
 "Show hidden files and folders" = "Show hidden files and folders";
 "Show folders at the top" = "Show folders at the top";
-"Prevent dragging of files and folders" = "Prevent dragging of files and folders";
+"Prevent gestures" = "Prevent gestures";
+"Prevent dragging of files and folders and multiselection with fingers" = "Prevent dragging of files and folders and multiselection with fingers";
 
 /* Passcode Messages */
 

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -42,6 +42,6 @@ class DisplaySettingsSection: SettingsSection {
 			if let disableDragging = row.value as? Bool {
 				DisplaySettings.shared.preventDraggingFiles = disableDragging
 			}
-		}, title: "Prevent gestures".localized, subtitle: "Prevent dragging of files and folders and multiselection with fingers".localized, value: DisplaySettings.shared.preventDraggingFiles, identifier: "prevent-dragging-files-switch"))
+		}, title: "Prevent gestures".localized, subtitle: "Prevent dragging of files and folders and multiselection using system defined gestures".localized, value: DisplaySettings.shared.preventDraggingFiles, identifier: "prevent-dragging-files-switch"))
 	}
 }

--- a/ownCloud/Settings/DisplaySettingsSection.swift
+++ b/ownCloud/Settings/DisplaySettingsSection.swift
@@ -42,6 +42,6 @@ class DisplaySettingsSection: SettingsSection {
 			if let disableDragging = row.value as? Bool {
 				DisplaySettings.shared.preventDraggingFiles = disableDragging
 			}
-		}, title: "Prevent dragging of files and folders".localized, value: DisplaySettings.shared.preventDraggingFiles, identifier: "prevent-dragging-files-switch"))
+		}, title: "Prevent gestures".localized, subtitle: "Prevent dragging of files and folders and multiselection with fingers".localized, value: DisplaySettings.shared.preventDraggingFiles, identifier: "prevent-dragging-files-switch"))
 	}
 }

--- a/ownCloud/UI Elements/StaticTableViewRow.swift
+++ b/ownCloud/UI Elements/StaticTableViewRow.swift
@@ -503,7 +503,7 @@ class StaticTableViewRow : NSObject, UITextFieldDelegate {
 	}
 
 	// MARK: - Switches
-	convenience init(switchWithAction action: StaticTableViewRowAction?, title: String, value switchValue: Bool = false, identifier: String? = nil) {
+	convenience init(switchWithAction action: StaticTableViewRowAction?, title: String, subtitle: String? = nil, value switchValue: Bool = false, identifier: String? = nil) {
 		self.init()
 		type = .switchButton
 
@@ -511,7 +511,14 @@ class StaticTableViewRow : NSObject, UITextFieldDelegate {
 
 		let switchView = UISwitch()
 
-		self.cell = ThemeTableViewCell(style: .default, reuseIdentifier: nil)
+		if let subtitle = subtitle {
+			self.cell = ThemeTableViewCell(style: .subtitle, reuseIdentifier: nil)
+			self.cell?.detailTextLabel?.text = subtitle
+			self.cell?.detailTextLabel?.numberOfLines = 0
+		} else {
+			self.cell = ThemeTableViewCell(style: .default, reuseIdentifier: nil)
+		}
+
 		self.cell?.selectionStyle = .none
 		self.cell?.textLabel?.text = title
 		self.cell?.accessoryView = switchView


### PR DESCRIPTION
## Description
Added delegate methods added to `UICollectionView` and `UITableView` allowing to enter-multiple selection mode with (two) finger pan.

Gestures:
- Two finger pan to start multiple selection of items in the file list
- In photo upload selection view, you can use one finger and pan over multiple items to select them.
- Gestures are iOS13 only and will work as long as "Prevent dragging of files and folders" option in settings is inactive

## Related Issue
#725 

## Motivation and Context
Saves few taps and allows select multiple items faster

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

