### PR TITLE
[feature/app-version-clipboard] App Version Infos to Clipboard

### DIFF
--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -173,7 +173,7 @@
 "You need to configure an email account first to be able to send emails." = "You need to configure an email account first to be able to send emails.";
 "Do you want to open the following URL?" = "Do you want to open the following URL?";
 
-"%@ %@ version %@ build %@ (app: %@, sdk: %@)" = "%@ %@ version %@ build %@ (app: %@, sdk: %@)";
+"%@%@ %@ version %@ build %@\n(app: %@, sdk: %@)" = "%@%@ %@ version %@ build %@\n(app: %@, sdk: %@)";
 "beta" = "beta";
 "release" = "release";
 "App Version" = "App Version";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -176,6 +176,8 @@
 "%@ %@ version %@ build %@ (app: %@, sdk: %@)" = "%@ %@ version %@ build %@ (app: %@, sdk: %@)";
 "beta" = "beta";
 "release" = "release";
+"App Version" = "App Version";
+"Version informations were copied to the clipboard" = "Version informations were copied to the clipboard";
 
 
 /* User Interface Settings */

--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -129,13 +129,12 @@ class MoreSettingsSection: SettingsSection {
 		}
 
 		let localizedFooter = "%@%@ %@ version %@ build %@\n(app: %@, sdk: %@)".localized
-		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName ?? "App", appSuffix, buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit, OCAppIdentity.shared.sdkCommit ?? "unknown")
+		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName ?? "App", appSuffix, buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit, OCAppIdentity.shared.sdkCommit ?? "unknown".localized)
 
 		appVersionRow = StaticTableViewRow(rowWithAction: { (_, _) in
 			UIPasteboard.general.string = footerTitle
 			guard let viewController = self.viewController else { return }
-			_ = NotificationHUDViewController(on: viewController, title: "App Version".localized, subtitle: "Version informations were copied to the clipboard".localized, completion: {
-			})
+			_ = NotificationHUDViewController(on: viewController, title: "App Version".localized, subtitle: "Version informations were copied to the clipboard".localized, completion: nil)
 		}, title: "App Version".localized, subtitle: footerTitle, identifier: "app-version")
 	}
 

--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -33,25 +33,11 @@ class MoreSettingsSection: SettingsSection {
 	private var privacyPolicyRow: StaticTableViewRow?
 	private var termsOfUseRow: StaticTableViewRow?
 	private var acknowledgementsRow: StaticTableViewRow?
+	private var appVersionRow: StaticTableViewRow?
 
 	override init(userDefaults: UserDefaults) {
 		super.init(userDefaults: userDefaults)
 		self.headerTitle = "More".localized
-
-		var buildType = "release".localized
-		if VendorServices.shared.isBetaBuild {
-			buildType = "beta".localized
-		}
-
-		var appSuffix = ""
-		if OCLicenseEMMProvider.isEMMVersion {
-			appSuffix = "-EMM"
-		}
-
-		let localizedFooter = "%@%@ %@ version %@ build %@ (app: %@, sdk: %@)".localized
-		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName ?? "App", appSuffix, buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit, OCAppIdentity.shared.sdkCommit ?? "unknown")
-
-		self.footerTitle = footerTitle
 
 		self.identifier = "settings-more-section"
 
@@ -131,6 +117,26 @@ class MoreSettingsSection: SettingsSection {
 				}
 			})
 		}, title: "Acknowledgements".localized, accessoryType: .disclosureIndicator, identifier: "acknowledgements")
+
+		var buildType = "release".localized
+		if VendorServices.shared.isBetaBuild {
+			buildType = "beta".localized
+		}
+
+		var appSuffix = ""
+		if OCLicenseEMMProvider.isEMMVersion {
+			appSuffix = "-EMM"
+		}
+
+		let localizedFooter = "%@%@ %@ version %@ build %@\n(app: %@, sdk: %@)".localized
+		let footerTitle = String(format: localizedFooter, OCAppIdentity.shared.appName ?? "App", appSuffix, buildType, VendorServices.shared.appVersion, VendorServices.shared.appBuildNumber, VendorServices.shared.lastGitCommit, OCAppIdentity.shared.sdkCommit ?? "unknown")
+
+		appVersionRow = StaticTableViewRow(rowWithAction: { (_, _) in
+			UIPasteboard.general.string = footerTitle
+			guard let viewController = self.viewController else { return }
+			_ = NotificationHUDViewController(on: viewController, title: "App Version".localized, subtitle: "Version informations were copied to the clipboard".localized, completion: {
+			})
+		}, title: "App Version".localized, subtitle: footerTitle, identifier: "app-version")
 	}
 
 	// MARK: - Update UI
@@ -145,7 +151,7 @@ class MoreSettingsSection: SettingsSection {
 			rows.append(recommendRow!)
 		}
 
-		rows.append(contentsOf: [privacyPolicyRow!, termsOfUseRow!, acknowledgementsRow!])
+		rows.append(contentsOf: [privacyPolicyRow!, termsOfUseRow!, acknowledgementsRow!, appVersionRow!])
 
 		add(rows: rows)
 	}


### PR DESCRIPTION
## Description
Moved the app version informations in the app settings from the footer to a own table row to perform a row action.
If the user tap on this new row, the app informations will be copied to the clipboard. 
The user will see a notification banner, that the infos was copied to the clipboard.

## Related Issue
#740 

## Motivation and Context
This is important for bug reporting, to easily copy all needed informations to the clipboard.

## How Has This Been Tested?
- open app settings
- scroll to bottom
- tap on "App Version" row

## Screenshots (if appropriate):

![Simulator Screen Shot - iPhone 11 Pro - 2020-07-07 at 16 43 07](https://user-images.githubusercontent.com/736109/86798384-02db8600-c071-11ea-88d5-590188ea1180.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

