### PR TITLE
Docs-only: fix "section title out of sequence" for table

### DIFF
--- a/docs/modules/ROOT/pages/ios_settings.adoc
+++ b/docs/modules/ROOT/pages/ios_settings.adoc
@@ -74,7 +74,6 @@ image:84_Settings_themes.png[84_Settings_themes.png]
 a|image:themes/classic.png[ownCloud iOS App - Classic theme]
 a|image:themes/dark.png[ownCloud iOS App - Dark theme]
 a|image:themes/light.png[ownCloud iOS App - Light theme]
-
 |===
 
 === System Appearance (up from iOS 13)


### PR DESCRIPTION
## Description
This fixes a warning when compiling the docs:
```
asciidoctor: WARNING: ios_settings.adoc: line 78:
section title out of sequence: expected level 1, got level 2
```
The warning most likely appears because there is a blank line between the last cell and table end marker. Antora seems to gets confused by the blank line and thinks it is a new section which is out of sequence. It renders correct, but creates a warning. The blank line at the end in the table definition is now removed.

## Related Issue

## Motivation and Context
No warnings when compiling IOS docs

## How Has This Been Tested?
Compiling the docs locally

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Docs change only.
