### PR TITLE
[fix/mime-type-uti] Added missing third party app UTIs

### DIFF
--- a/ownCloud File Provider/OCItem+FileProviderItem.m
+++ b/ownCloud File Provider/OCItem+FileProviderItem.m
@@ -132,16 +132,21 @@ static NSMutableDictionary<OCLocalID, NSError *> *sOCItemUploadingErrors;
 			// at the time of writing, so these entries take care of correctly
 			// mapping suffixes to UTIs
 
-			@"odc" 	: @"org.oasis-open.opendocument.chart",
-			@"otc" 	: @"org.oasis-open.opendocument.chart-template",
+			@"odc" 		: @"org.oasis-open.opendocument.chart",
+			@"otc" 		: @"org.oasis-open.opendocument.chart-template",
 
-			@"odi" 	: @"org.oasis-open.opendocument.image",
-			@"oti" 	: @"org.oasis-open.opendocument.image-template",
+			@"odi" 		: @"org.oasis-open.opendocument.image",
+			@"oti" 		: @"org.oasis-open.opendocument.image-template",
 
-			@"odm" 	: @"org.oasis-open.opendocument.text-master",
-			@"oth" 	: @"org.oasis-open.opendocument.text-web",
+			@"odm" 		: @"org.oasis-open.opendocument.text-master",
+			@"oth" 		: @"org.oasis-open.opendocument.text-web",
 
-			@"m"	: @"public.objective-c-source"
+			@"m"		: @"public.objective-c-source",
+
+			@"mindnode"	: @"com.mindnode.mindnode.mindmap",
+			@"itmz"		: @"com.toketaware.uti.ithoughts.itmz",
+			
+			@"pdf"		: @"com.adobe.pdf"
 		};
 	});
 


### PR DESCRIPTION
## Description
Mime-Type to UTI fix for MindNode and iThoughtX documents in FileProvider. These file types were greyed out, because of a missing UTI.
Furthermore there is a fallback for file items with `pdf` extension, because a tester reported a problem, that pdf files are greyed out.

## Related Issue
#747 

## Motivation and Context
Access all file types inside the FileProvider

## How Has This Been Tested?
- Install MindNode, iThoughtX and create a document inside, save it to the FileProvider
- Close document
- Try to reopen this document inside the MindNode, iThoughtX app from FileProvider

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

