### PR TITLE
[fix/quick-access-available-offline] Quick Access: Only show available offline items

### DIFF
--- a/ownCloud/Client/Library/Item Policies/ItemPolicyTableViewController.swift
+++ b/ownCloud/Client/Library/Item Policies/ItemPolicyTableViewController.swift
@@ -177,11 +177,9 @@ class ItemPolicyTableViewController : FileListTableViewController {
 
 			switch section {
 				case .all:
-					if let customQueryCondition = policyProcessor?.customQueryCondition {
-						title = policyProcessor?.localizedName ?? "All Files".localized
-						query = OCQuery(condition: customQueryCondition, inputFilter: nil)
-					}
-
+					query = OCQuery(condition: .require([
+						.where(.downloadTrigger, isEqualTo: OCItemDownloadTriggerID.availableOffline)
+					]), inputFilter:nil)
 				case .policies:
 					if let item = self.itemAt(indexPath: indexPath) {
 						if item.type == .collection {


### PR DESCRIPTION
## Description
In `Quick Access` > `Available Offline` > `All Files` there were all locally available files listed.
The correct behavior is, to show only available offline marked files.

## Related Issue
#745 

## Motivation and Context
Correct feedback to the user

## How Has This Been Tested?
- mark one ore more files/folders as `available offline`
- download other file items by viewing/downloading
- open `Quick Access` > `Available Offline` > `All Files`
- only files which are marked as `available offline` should be visible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

