### PR TITLE
[fix/markup-edit-mode-iOS14] Automatically enable Markup Edit Mode on iOS 14

### DIFF
--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -100,7 +100,7 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
 		OnMainThread(after:0.5) {
 			if #available(iOS 14.0, *) {
-				if UIDevice.current.isIpad() {
+				if UIDevice.current.isIpad {
 					guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
 				 _ = markupButton.target?.perform(markupButton.action, with: markupButton)
 				} else {

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -97,10 +97,20 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
-		// Activate editing mode by faking a tap on pencil icon. Unfortunately that's the only way to do it apparently
+		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
 		OnMainThread(after:0.5) {
-			guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
-			markupButton.sendActions(for: .touchUpInside)
+			if #available(iOS 14.0, *) {
+				if UIDevice.current.isIpad() {
+					guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
+				 _ = markupButton.target?.perform(markupButton.action, with: markupButton)
+				} else {
+					guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
+					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+				}
+			} else { // action and target is nil on iOS 13
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
+				markupButton.sendActions(for: .touchUpInside)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Markup edit mode is not enabling automatically on iOS 14 devices.
iOS 13 and iOS 14 needs to be handled different in code.

## Related Issue
#783 

## Motivation and Context
Working functionality for early iOS 14 users

## How Has This Been Tested?
- Tap `Markup` for a document on iOS 13 iPhone
- Tap `Markup` for a document on iOS 13 iPad
- Tap `Markup` for a document on iOS 14 iPhone
- Tap `Markup` for a document on iOS 14 iPad

Result: Edit mode should be appear automatically

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

