### PR TITLE
[fix/stuck-in-blank-screen] UI for blank screen, when loading file list

### DIFF
--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -138,6 +138,7 @@
 "Sign in" = "Sign in";
 "Continue offline" = "Continue offline";
 "Media upload in the previous session was incomplete since the application was terminated" = "Media upload in the previous session was incomplete since the application was terminated";
+"Starting up…" = "Starting up…";
 
 "All done" = "All done";
 "No pending messages or ongoing actions." = "No pending messages or ongoing actions.";


### PR DESCRIPTION
## Description
In some cases the file list does not came up and the UI stuck in a blank screen without a possibility to switch back to the account list.
This implementation adds a loading message and a cancel button.

## Related Issue
#786 

## Motivation and Context
Solve a UI deadlock

## How Has This Been Tested?
It is hard to test, because the stuck state happening only very rarely. This UI elements will be removed after the core was loaded successfully.

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 11 Pro - 2020-09-22 at 11 13 56](https://user-images.githubusercontent.com/736109/93888177-f23dc200-fce7-11ea-8bdc-877800101903.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

