### PR TITLE
[fix/blank-screen] Fix issue where a blank screen is shown after selecting a bookmark

### DIFF
--- a/ownCloud/Client/ClientRootViewController.swift
+++ b/ownCloud/Client/ClientRootViewController.swift
@@ -191,6 +191,8 @@ class ClientRootViewController: UITabBarController, BookmarkContainer, ToolAndTa
 						self?.updateConnectionStatusSummary()
 					})
 				}
+			} else {
+				Log.error("Error requesting/starting core: \(String(describing: error))")
 			}
 
 			OnMainThread {

--- a/ownCloud/Client/ClientRootViewController.swift
+++ b/ownCloud/Client/ClientRootViewController.swift
@@ -163,7 +163,7 @@ class ClientRootViewController: UITabBarController, BookmarkContainer, ToolAndTa
 	}
 
 	// MARK: - Startup
-	func afterCoreStart(_ lastVisibleItemId: String?, completionHandler: @escaping (() -> Void)) {
+	func afterCoreStart(_ lastVisibleItemId: String?, completionHandler: @escaping ((_ error: Error?) -> Void)) {
 		OCCoreManager.shared.requestCore(for: bookmark, setup: { (core, _) in
 			self.coreRequested = true
 			self.core = core
@@ -182,18 +182,19 @@ class ClientRootViewController: UITabBarController, BookmarkContainer, ToolAndTa
 			core?.vault.keyValueStore?.storeObject(nil, forKey: .coreSkipAvailableOfflineKey)
 		}, completionHandler: { (core, error) in
 			if error == nil {
+				// Core is ready
 				self.coreReady(lastVisibleItemId)
-			}
 
-			// Start showing connection status
-			OnMainThread { [weak self] () in
-				self?.connectionStatusObservation = core?.observe(\OCCore.connectionStatus, options: [.initial], changeHandler: { [weak self] (_, _) in
-					self?.updateConnectionStatusSummary()
-				})
+				// Start showing connection status
+				OnMainThread { [weak self] () in
+					self?.connectionStatusObservation = core?.observe(\OCCore.connectionStatus, options: [.initial], changeHandler: { [weak self] (_, _) in
+						self?.updateConnectionStatusSummary()
+					})
+				}
 			}
 
 			OnMainThread {
-				completionHandler()
+				completionHandler(error)
 			}
 		})
 	}

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,8 @@
 "Certificate may have issues, but was accepted by user.\nOpen 'Certificate Details' for more informations." = "Certificate may have issues, but was accepted by user.\nOpen 'Certificate Details' for more informations.";
 "If you 'Continue', you will be prompted to allow the '%@' App to open OAuth2 login where you can enter your credentials." = "If you 'Continue', you will be prompted to allow the '%@' App to open OAuth2 login where you can enter your credentials.";
 
+"Error opening %@" = "Error opening %@";
+
 "Contacting server…" = "Contacting server…";
 "Authenticating…" = "Authenticating…";
 

--- a/ownCloud/Server List/ServerListTableViewController.swift
+++ b/ownCloud/Server List/ServerListTableViewController.swift
@@ -539,34 +539,42 @@ class ServerListTableViewController: UITableViewController, Themeable {
 		clientRootViewController.authDelegate = self
 		clientRootViewController.modalPresentationStyle = .overFullScreen
 
-		clientRootViewController.afterCoreStart(lastVisibleItemId) {
+		clientRootViewController.afterCoreStart(lastVisibleItemId, completionHandler: { (error) in
 			if self.lastSelectedBookmark?.uuid == bookmark.uuid, // Make sure only the UI for the last selected bookmark is actually presented (in case of other bookmarks facing a huge delay and users selecting another bookmark in the meantime)
 			   self.activeClientRootViewController == nil { // Make sure we don't present this ClientRootViewController while still presenting another
-				OCBookmarkManager.lastBookmarkSelectedForConnection = bookmark
-
-				self.activeClientRootViewController = clientRootViewController // save this ClientRootViewController as the active one (only weakly referenced)
-
-				// Set up custom push transition for presentation
-
 				if let fromViewController = self.pushFromViewController ?? self.navigationController {
-					let transitionDelegate = PushTransitionDelegate()
+				   	if let error = error {
+						let alert = UIAlertController(title: NSString(format: "Error opening %@".localized as NSString, bookmark.shortName) as String, message: error.localizedDescription, preferredStyle: .alert)
+						alert.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: nil))
 
-					clientRootViewController.pushTransition = transitionDelegate // Keep a reference, so it's still around on dismissal
-					clientRootViewController.transitioningDelegate = transitionDelegate
-					clientRootViewController.modalPresentationStyle = .custom
+						fromViewController.present(alert, animated: true)
 
-					fromViewController.present(clientRootViewController, animated: animated, completion: {
 						self.resetPreviousBookmarkSelection(bookmark)
+					} else {
+						OCBookmarkManager.lastBookmarkSelectedForConnection = bookmark
 
-						// Present message if one was provided
-						if let message = message {
-							self.presentInClient(message: message)
-						}
-					})
+						self.activeClientRootViewController = clientRootViewController // save this ClientRootViewController as the active one (only weakly referenced)
+
+						// Set up custom push transition for presentation
+						let transitionDelegate = PushTransitionDelegate()
+
+						clientRootViewController.pushTransition = transitionDelegate // Keep a reference, so it's still around on dismissal
+						clientRootViewController.transitioningDelegate = transitionDelegate
+						clientRootViewController.modalPresentationStyle = .custom
+
+						fromViewController.present(clientRootViewController, animated: animated, completion: {
+							self.resetPreviousBookmarkSelection(bookmark)
+
+							// Present message if one was provided
+							if let message = message {
+								self.presentInClient(message: message)
+							}
+						})
+					}
 				}
 			}
 			self.didUpdateServerList()
-		}
+		})
 	}
 
 	func didUpdateServerList() {

--- a/ownCloud/Static Login/Interface/StaticLoginViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginViewController.swift
@@ -315,21 +315,27 @@ class StaticLoginViewController: UIViewController, Themeable {
 		let clientRootViewController = ClientRootViewController(bookmark: bookmark)
 		clientRootViewController.modalPresentationStyle = .overFullScreen
 
-		clientRootViewController.afterCoreStart(nil) {
-			OCBookmarkManager.lastBookmarkSelectedForConnection = bookmark
-
+		clientRootViewController.afterCoreStart(nil, completionHandler: { (error) in
 			// Set up custom push transition for presentation
 			if let navigationController = self.navigationController {
-				let transitionDelegate = PushTransitionDelegate()
+				if let error = error {
+					let alert = UIAlertController(title: NSString(format: "Error opening %@".localized as NSString, bookmark.shortName) as String, message: error.localizedDescription, preferredStyle: .alert)
+					alert.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: nil))
 
-				clientRootViewController.pushTransition = transitionDelegate // Keep a reference, so it's still around on dismissal
-				clientRootViewController.transitioningDelegate = transitionDelegate
-				clientRootViewController.modalPresentationStyle = .custom
+					navigationController.present(alert, animated: true)
+				} else {
+					OCBookmarkManager.lastBookmarkSelectedForConnection = bookmark
 
-				navigationController.present(clientRootViewController, animated: true, completion: {
-				})
+					let transitionDelegate = PushTransitionDelegate()
+
+					clientRootViewController.pushTransition = transitionDelegate // Keep a reference, so it's still around on dismissal
+					clientRootViewController.transitioningDelegate = transitionDelegate
+					clientRootViewController.modalPresentationStyle = .custom
+
+					navigationController.present(clientRootViewController, animated: true)
+				}
 			}
 			self.showFirstScreen()
-		}
+		})
 	}
 }

--- a/ownCloudTests/File List/FileTests.swift
+++ b/ownCloudTests/File List/FileTests.swift
@@ -46,7 +46,7 @@ class FileTests: XCTestCase {
 
 		let rootViewController: MockClientRootViewController = MockClientRootViewController(core: core, query: query, bookmark: bookmark)
 
-		rootViewController.afterCoreStart(nil) {
+		rootViewController.afterCoreStart(nil, completionHandler: { (_) in
 			let navigationController = UserInterfaceContext.shared.currentWindow?.rootViewController
 			let transitionDelegate = PushTransitionDelegate()
 
@@ -55,7 +55,7 @@ class FileTests: XCTestCase {
 			rootViewController.modalPresentationStyle = .custom
 
 			navigationController?.present(rootViewController, animated: true)
-		}
+		})
 	}
 
 	func dismissFileList() {


### PR DESCRIPTION
## Description
Add error handling for the case where the start of an `OCCore` returns an error by displaying an alert. Previously, a partial UI was pushed - and remained in that state.

Kudos to @hosy for finding this code path!

## Related Issue
#786 

## QA/test notice
To test, insert this code in `OCCoreManager.m:101`:

```objc
completionHandler(nil, OCError(OCErrorInternal));
return;
```

## Screenshots (if appropriate):
Tested with a faked internal error:
Before fix | After fix
-----------|------
![Bildschirmfoto 2020-09-23 um 12 05 18](https://user-images.githubusercontent.com/639669/93998647-202d1000-fd95-11ea-83d4-d06934c2a2df.png) | ![Bildschirmfoto 2020-09-23 um 11 52 18](https://user-images.githubusercontent.com/639669/93998119-6cc41b80-fd94-11ea-9e3b-80f0bfab03de.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
