### PR TITLE
[feature/directory-picker-favorites] Show Favorite Items in Directory Picker

### DIFF
--- a/ownCloudAppShared/Client/File Lists/ClientDirectoryPickerViewController.swift
+++ b/ownCloudAppShared/Client/File Lists/ClientDirectoryPickerViewController.swift
@@ -251,6 +251,7 @@ open class ClientDirectoryPickerViewController: ClientQueryViewController {
 
 			let customFileListController = QueryFileListTableViewController(core: core, query: favoriteQuery)
 			customFileListController.title = "Favorites".localized
+			customFileListController.isFolderSelectionOnlyMode = true
 			customFileListController.pullToRefreshAction = { [weak self] (completion) in
 				self?.core?.refreshFavorites(completionHandler: { (_, _) in
 					completion()

--- a/ownCloudAppShared/Client/File Lists/QueryFileListTableViewController.swift
+++ b/ownCloudAppShared/Client/File Lists/QueryFileListTableViewController.swift
@@ -67,6 +67,8 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 	public var copyMultipleBarButtonItem: UIBarButtonItem?
 	public var openMultipleBarButtonItem: UIBarButtonItem?
 
+	public var didSelectCellAction: ((_ completion: @escaping () -> Void) -> Void)?
+
 	public init(core inCore: OCCore, query inQuery: OCQuery) {
 		query = inQuery
 
@@ -455,7 +457,11 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 	open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		// If not in multiple-selection mode, just navigate to the file or folder (collection)
 		if !self.tableView.isEditing {
-			super.tableView(tableView, didSelectRowAt: indexPath)
+			if didSelectCellAction != nil {
+				didSelectCellAction?({ })
+			} else {
+				super.tableView(tableView, didSelectRowAt: indexPath)
+			}
 		} else {
 			if let multiSelectionSupport = self as? MultiSelectSupport {
 				if let item = itemAt(indexPath: indexPath), let itemLocalID = item.localID {

--- a/ownCloudAppShared/Client/File Lists/QueryFileListTableViewController.swift
+++ b/ownCloudAppShared/Client/File Lists/QueryFileListTableViewController.swift
@@ -66,7 +66,7 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 	public var duplicateMultipleBarButtonItem: UIBarButtonItem?
 	public var copyMultipleBarButtonItem: UIBarButtonItem?
 	public var openMultipleBarButtonItem: UIBarButtonItem?
-
+	public var isFolderSelectionOnlyMode: Bool = false
 	public var didSelectCellAction: ((_ completion: @escaping () -> Void) -> Void)?
 
 	public init(core inCore: OCCore, query inQuery: OCQuery) {
@@ -409,6 +409,13 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 			if let localID = newItem.localID as OCLocalID?, self.selectedItemIds.contains(localID) {
 				cell?.setSelected(true, animated: false)
 			}
+
+			if isFolderSelectionOnlyMode {
+				if newItem.type == .file {
+					cell?.isActive = false
+				}
+				cell?.isMoreButtonPermanentlyHidden = true
+			}
 		}
 
 		return cell!
@@ -457,6 +464,9 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 	open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		// If not in multiple-selection mode, just navigate to the file or folder (collection)
 		if !self.tableView.isEditing {
+			if let item = itemAt(indexPath: indexPath), item.type != .collection, isFolderSelectionOnlyMode {
+				return
+			}
 			if didSelectCellAction != nil {
 				didSelectCellAction?({ })
 			} else {
@@ -485,6 +495,14 @@ open class QueryFileListTableViewController: FileListTableViewController, SortBa
 				multiSelectionSupport.updateMultiselection()
 			}
 		}
+	}
+
+	override open func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+		if let item = itemAt(indexPath: indexPath), item.type != .collection, isFolderSelectionOnlyMode {
+			return false
+		}
+
+		return true
 	}
 }
 


### PR DESCRIPTION
## Description
This PR adds a new Item `Favorites` to the Directory Picker to easily select folders from Favorites with less navigating throw a folder structure.

## Related Issue
#814 

## Motivation and Context
Faster selecting folders in Directory Picker

## How Has This Been Tested?
- Save a file via Share Sheet
- Move, Duplicate a file from more menu
- be sure the item `Favorites` is only available in the root view of the directory picker
- be sure only folders are selectable from Favorites

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-15 at 16 54 14](https://user-images.githubusercontent.com/736109/96146920-1b2c2e00-0f07-11eb-942d-bc97c4940ca3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

