### PR TITLE
[fix/share-sheet-mail-attachments] Correctly save attachments from iOS Mail.app

### DIFF
--- a/ownCloud Share Extension/ShareViewController.swift
+++ b/ownCloud Share Extension/ShareViewController.swift
@@ -282,12 +282,16 @@ class ShareViewController: MoreStaticTableViewController {
 							break
 						}
 
-						if let type = attachment.registeredTypeIdentifiers.first, attachment.hasItemConformingToTypeIdentifier(kUTTypeItem as String) {
-							if type == "public.plain-text" || type == "public.url" {
+						if var type = attachment.registeredTypeIdentifiers.first, attachment.hasItemConformingToTypeIdentifier(kUTTypeItem as String) {
+							if type == "public.plain-text" || type == "public.url" || attachment.registeredTypeIdentifiers.contains("public.file-url") {
 								asyncQueue.async({ (jobDone) in
 									if progressViewController?.cancelled == true {
 										jobDone()
 										return
+									}
+									// Workaround for saving attachements from Mail.app. Attachments from Mail.app contains two types e.g. "com.adobe.pdf" AND "public.file-url". For loading the file the type "public.file-url" is needed. Otherwise the resource could not be accessed (NSItemProviderSandboxedResource)
+									if attachment.registeredTypeIdentifiers.contains("public.file-url") {
+										type = "public.file-url"
 									}
 
 									attachment.loadItem(forTypeIdentifier: type, options: nil, completionHandler: { (item, error) -> Void in


### PR DESCRIPTION
## Description
Saving attachments from iOS Mail.app was broken via the ownCloud share sheet, because of using the wrong type identifier when loading the file representation.

## Related Issue
#816 

## Motivation and Context
Correctly save any kind of attachment in iOS Mail.app via the ownCloud share sheet.

## How Has This Been Tested?
- try to save and kind of attachment from a mail via the share sheet (PDF, ZIP, ...)
- try to save the same file type from Files.app, to check this is not broken after the fix

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

