### PR TITLE
[feature/scan-filename-selection] Selecting the Filename in Scan View

### DIFF
--- a/ownCloud/Client/Actions/Scanner/ScanViewController.swift
+++ b/ownCloud/Client/Actions/Scanner/ScanViewController.swift
@@ -345,8 +345,22 @@ class ScanViewController: StaticTableViewController {
 		// Save section
 
 		// - Name
-		fileNameRow = StaticTableViewRow(textFieldWithAction: { [weak self] (row, _, _) in
+		fileNameRow = StaticTableViewRow(textFieldWithAction: { [weak self] (row, textField, type) in
 			self?.navigationItem.rightBarButtonItem?.isEnabled = ((row.value as? String)?.count ?? 0) > 0
+
+			if type == .didBegin, let nameTextField = textField as? UITextField {
+				if let name = nameTextField.text,
+					let self = self,
+					let exportFormat = self.exportFormat,
+					let range = name.range(of: ".\(exportFormat.suffix)"),
+					let position: UITextPosition = nameTextField.position(from: nameTextField.beginningOfDocument, offset: range.lowerBound.utf16Offset(in: name)) {
+
+					nameTextField.selectedTextRange = nameTextField.textRange(from: nameTextField.beginningOfDocument, to:position)
+
+				} else {
+					nameTextField.selectedTextRange = nameTextField.textRange(from: nameTextField.beginningOfDocument, to: nameTextField.endOfDocument)
+				}
+			}
 		}, placeholder: "Name".localized, value: fileName ?? "", keyboardType: .default, autocorrectionType: .no, enablesReturnKeyAutomatically: true, returnKeyType: .default, identifier: "name", accessibilityLabel: "Name".localized)
 		saveSection.add(row: fileNameRow!)
 		self.addSection(saveSection)


### PR DESCRIPTION
## Description

## Related Issue
#822 

## Motivation and Context
Faster change a file name in scan view, without deleting the file extension

## How Has This Been Tested?
- Scan document
- Save scanned page
- tap inside the filename text field
- (only) the filename should be selected

## Screenshots (if appropriate):

![IMG_627F995F7ED0-1](https://user-images.githubusercontent.com/736109/96618836-bce7bc80-1305-11eb-99aa-48bf5bdfb8d3.jpeg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

