### PR TITLE
[fix/fastlane-set-keychain-group] Set Keychain Group for all targets in Fastlane Builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -501,21 +501,37 @@ end
       entitlements_file: "ownCloud/ownCloud.entitlements",
       app_group_identifiers: [APP_GROUP_IDENTIFIERS]
     )
+    update_keychain_access_groups(
+      entitlements_file: "ownCloud/ownCloud.entitlements",
+      identifiers: [ENTERPRISE_TEAM + "." + APP_GROUP_IDENTIFIERS]
+	)
 
     update_app_group_identifiers(
       entitlements_file: "ownCloud File Provider/ownCloud_File_Provider.entitlements",
       app_group_identifiers: [APP_GROUP_IDENTIFIERS]
     )
+    update_keychain_access_groups(
+      entitlements_file: "ownCloud File Provider/ownCloud_File_Provider.entitlements",
+      identifiers: [ENTERPRISE_TEAM + "." + APP_GROUP_IDENTIFIERS]
+	)
 
     update_app_group_identifiers(
       entitlements_file: "ownCloud Intents/ownCloud Intents.entitlements",
       app_group_identifiers: [APP_GROUP_IDENTIFIERS]
     )
+    update_keychain_access_groups(
+      entitlements_file: "ownCloud Intents/ownCloud Intents.entitlements",
+      identifiers: [ENTERPRISE_TEAM + "." + APP_GROUP_IDENTIFIERS]
+	)
 
     update_app_group_identifiers(
       entitlements_file: "ownCloud Share Extension/ownCloud Share Extension.entitlements",
       app_group_identifiers: [APP_GROUP_IDENTIFIERS]
     )
+    update_keychain_access_groups(
+      entitlements_file: "ownCloud Share Extension/ownCloud Share Extension.entitlements",
+      identifiers: [ENTERPRISE_TEAM + "." + APP_GROUP_IDENTIFIERS]
+	)
 
     set_info_plist_value(path: "ownCloud File Provider/Info.plist", key: "OCAppGroupIdentifier", value: APP_GROUP_IDENTIFIERS)
 
@@ -601,12 +617,9 @@ end
       commit = last_git_commit
       short_hash = commit[:abbreviated_commit_hash] # short sha of commit
       sh "brew install librsvg"
-      sh "brew unlink pango"
-      sh "brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7cf3b63be191cb2ce4cd86f4406915128ec97432/Formula/pango.rb"
-      sh "brew switch pango 1.42.4_1 "
       sh "sed -e \"s/\#version#/" + version + "/\" -e \"s/\#githash#/" + short_hash + "/\" badge.svg > badge_tmp.svg"
       sh "rsvg-convert badge_tmp.svg > badge.png"
-      sh "badge --custom badge.png --glob /../**/*.appiconset/*.{png,PNG}"
+      add_badge(custom: "fastlane/badge.png")
     end
 
     #Create the build


### PR DESCRIPTION
## Description
Set the Keychain Group for all targets when building with fastlane.

As an addition the badge creation was replaced with a fastlane action

## Related Issue
https://github.com/owncloud/enterprise/issues/4272

## Motivation and Context
Authentication error when performing actions via file provider because of wrong keychain group.

## How Has This Been Tested?
- create enterprise fastlane build `fastlane owncloud_enterprise_build`
- install IPA
- configure an basic auth account
- upload a file via app
- no authentication error should appear

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

