### PR TITLE
[fix/new-review-request] Improved AppStore Review Request Time

### DIFF
--- a/ownCloudAppShared/Tools/AppStatistics.swift
+++ b/ownCloudAppShared/Tools/AppStatistics.swift
@@ -80,16 +80,16 @@ public class AppStatistics {
 			}
 
 			// Reset update launch date if current version is different compared to stored ones
-			if let lastVersion = userDefaults.object(forKey: UserDefaultsKeys.lastInstalledVersion.rawValue) as? String {
-				if lastVersion != appVersion {
+			if let lastInstalledVersion = userDefaults.object(forKey: UserDefaultsKeys.lastInstalledVersion.rawValue) as? String {
+				if lastInstalledVersion != appVersion {
 					self.updateDate = Date()
 				}
 			}
 
 			// Update user defaults except for review prompt time stamp updated separately
-			userDefaults.set(self.launchDate, forKey:  UserDefaultsKeys.firstLaunchDate.rawValue)
+			userDefaults.set(self.launchDate, forKey: UserDefaultsKeys.firstLaunchDate.rawValue)
+			userDefaults.set(self.updateDate, forKey: UserDefaultsKeys.updateDate.rawValue)
 			userDefaults.set(self.appVersion, forKey: UserDefaultsKeys.lastInstalledVersion.rawValue)
-			userDefaults.set(self.updateDate, forKey:  UserDefaultsKeys.firstLaunchDate.rawValue)
 
 			// Persist user defaults
 			userDefaults.synchronize()

--- a/ownCloudAppShared/Tools/VendorServices.swift
+++ b/ownCloudAppShared/Tools/VendorServices.swift
@@ -260,14 +260,14 @@ public class VendorServices : NSObject {
 		// Make sure there is at least one bookmark configured, to not bother users who have never configured any accounts
 		guard OCBookmarkManager.shared.bookmarks.count > 0 else { return }
 
-		// Make sure at least 14 days have elapsed since the first launch of the app
-		guard AppStatistics.shared.timeIntervalSinceFirstLaunch.days >= 14 else { return }
+		// Make sure at least 7 days have elapsed since the first launch of the app
+		guard AppStatistics.shared.timeIntervalSinceFirstLaunch.days >= 7 else { return }
 
 		// Make sure at least 7 days have elapsed since first launch of current version
 		guard AppStatistics.shared.timeIntervalSinceUpdate.days >= 7 else { return }
 
-		// Make sure at least 230 have elapsed since last prompting
-		AppStatistics.shared.requestAppStoreReview(onceInDays: 230)
+		// Make sure at least 122 have elapsed since last prompting (Apple allows to show the dialog 3 times per 365 days)
+		AppStatistics.shared.requestAppStoreReview(onceInDays: 122)
 	}
 }
 


### PR DESCRIPTION
## Description
- the first AppStore review request was changed from 14 days to 7 days after app installation
- the time interval between the next review request was changed from 230 days to 122 days

## Motivation and Context
Present the App Store review panel more often to the user.

## How Has This Been Tested?
- please simulate the test like mentioned here: https://github.com/owncloud/ios-app/pull/728#issuecomment-645841323
- please test it on a device in real time (install app and check if the dialog appears after 7 days.)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

