### PR TITLE
[fix/ack-headers] Add paragraph on top of Acknowledgements page

### DIFF
--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		DC66F3AD2396630100CF4812 /* AppleIncRootCertificate.cer in Resources */ = {isa = PBXBuildFile; fileRef = DC66F3A823965BF400CF4812 /* AppleIncRootCertificate.cer */; };
 		DC680576212DF548006C3B1F /* CertificateManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC680575212DF548006C3B1F /* CertificateManagementViewController.swift */; };
 		DC68057A212EAB5E006C3B1F /* ThemeCertificateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC680579212EAB5E006C3B1F /* ThemeCertificateViewController.swift */; };
+		DC6C68362574FD0400E46BD4 /* PLCrashReporter.LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DC6C68352574FD0400E46BD4 /* PLCrashReporter.LICENSE */; };
 		DC6CF7FB219446050013B9F9 /* LogSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6CF7FA219446050013B9F9 /* LogSettingsViewController.swift */; };
 		DC774E5F22F44E57000B11A1 /* ZIPArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = DC774E5D22F44E4A000B11A1 /* ZIPArchive.m */; };
 		DC774E6022F44E57000B11A1 /* ZIPArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = DC774E5C22F44E4A000B11A1 /* ZIPArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1242,6 +1243,7 @@
 		DC66F3AA23965C9C00CF4812 /* OCLicenseAppStoreReceiptInAppPurchase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCLicenseAppStoreReceiptInAppPurchase.m; sourceTree = "<group>"; };
 		DC680575212DF548006C3B1F /* CertificateManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateManagementViewController.swift; sourceTree = "<group>"; };
 		DC680579212EAB5E006C3B1F /* ThemeCertificateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCertificateViewController.swift; sourceTree = "<group>"; };
+		DC6C68352574FD0400E46BD4 /* PLCrashReporter.LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = PLCrashReporter.LICENSE; sourceTree = "<group>"; };
 		DC6CF7FA219446050013B9F9 /* LogSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSettingsViewController.swift; sourceTree = "<group>"; };
 		DC774E5C22F44E4A000B11A1 /* ZIPArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZIPArchive.h; sourceTree = "<group>"; };
 		DC774E5D22F44E4A000B11A1 /* ZIPArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZIPArchive.m; sourceTree = "<group>"; };
@@ -2435,6 +2437,7 @@
 				233BDEAB204FEFE500C06732 /* Info.plist */,
 				59D4895420C83F2E00369C2E /* InfoPlist.strings */,
 				593A821320C7D4C5000E2A90 /* Localizable.strings */,
+				DC6C68352574FD0400E46BD4 /* PLCrashReporter.LICENSE */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -3522,6 +3525,7 @@
 				DCE684F6241BD4E800799C30 /* Branding.plist in Resources */,
 				DC9BFBB320A19AF4007064B5 /* doc in Resources */,
 				233BDEA7204FEFE500C06732 /* Assets.xcassets in Resources */,
+				DC6C68362574FD0400E46BD4 /* PLCrashReporter.LICENSE in Resources */,
 				39F48A6A24D89D7E0000E3F9 /* branding-bookmark-icon.png in Resources */,
 				595E2CA821EE501400F0E95D /* PropfindResponseNewFolder.xml in Resources */,
 				59B09E6521AD61DD007827B8 /* test_certificate.cer in Resources */,

--- a/ownCloud.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ownCloud.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "PLCrashReporter",
+        "repositoryURL": "https://github.com/microsoft/plcrashreporter.git",
+        "state": {
+          "branch": null,
+          "revision": "4637a7854de2cc5c354d46fb931d74bdbc2c043e",
+          "version": "1.7.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/ownCloud/AppDelegate.swift
+++ b/ownCloud/AppDelegate.swift
@@ -137,6 +137,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 		// Licenses
 		OCExtensionManager.shared.addExtension(OCExtension.license(withIdentifier: "license.libzip", bundleOf: Theme.self, title: "libzip", resourceName: "libzip", fileExtension: "LICENSE"))
+		OCExtensionManager.shared.addExtension(OCExtension.license(withIdentifier: "license.plcrashreporter", bundleOf: AppDelegate.self, title: "PLCrashReporter", resourceName: "PLCrashReporter", fileExtension: "LICENSE"))
 
 		// Initially apply theme based on light / dark mode
 		ThemeStyle.considerAppearanceUpdate()

--- a/ownCloud/Resources/PLCrashReporter.LICENSE
+++ b/ownCloud/Resources/PLCrashReporter.LICENSE
@@ -1,0 +1,54 @@
+Except as noted below, PLCrashReporter is provided under the
+following license:
+
+    Copyright (c) Microsoft Corporation.
+    Copyright (c) 2008 - 2014 Plausible Labs Cooperative, Inc.
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+Additional contributions have been made under the same license terms
+as above, with copyright held by their respective authors:
+
+       Damian Morris <damian@moso.com.au>
+       Copyright (c) 2010 MOSO Corporation, Pty Ltd.
+       All rights reserved.
+
+       HockeyApp/Bitstadium
+       Copyright (c) 2012 HockeyApp, Bit Stadium GmbH.
+       All rights reserved.
+
+The protobuf-c library, as well as the PLCrashLogWriterEncoding.c
+file are licensed as follows:
+
+    Copyright 2008, Dave Benson.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with
+    the License. You may obtain a copy of the License
+    at http://www.apache.org/licenses/LICENSE-2.0 Unless
+    required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "Privacy Policy" = "Privacy Policy";
 "Terms Of Use" = "Terms Of Use";
 "Acknowledgements" = "Acknowledgements";
+"Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged." = "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged.";
 "Video upload path" = "Video upload path";
 "Photo upload path" = "Photo upload path";
 "Immediately" = "Immediately";

--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -98,6 +98,19 @@ class MoreSettingsSection: SettingsSection {
 					textViewController.title = "Acknowledgements".localized
 
 					if licenses != nil {
+						let titleAttributes : [NSAttributedString.Key : Any] = [
+							.font : UIFont.boldSystemFont(ofSize: UIFont.systemFontSize * 1.5)
+						]
+
+						let textAttributes : [NSAttributedString.Key : Any] = [
+							.font : UIFont.systemFont(ofSize: UIFont.systemFontSize),
+							.foregroundColor : UIColor.darkGray
+						]
+
+					   	// Preamble
+						licenseText.append(NSAttributedString(string: "Acknowledgements".localized + "\n", attributes: titleAttributes))
+						licenseText.append(NSAttributedString(string: "\n" + "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged.".localized + "\n\n", attributes: textAttributes))
+
 						for licenseExtensionMatch in licenses! {
 							let extensionObject = licenseExtensionMatch.extension.provideObject(for: context)
 
@@ -105,17 +118,14 @@ class MoreSettingsSection: SettingsSection {
 							   let licenseTitle = licenseDict["title"] as? String,
 							   let licenseURL = licenseDict["url"] as? URL {
 							   	// Title
-								licenseText.append(NSAttributedString(string: licenseTitle + "\n", attributes: [.font : UIFont.boldSystemFont(ofSize: UIFont.systemFontSize * 1.5)]))
+								licenseText.append(NSAttributedString(string: licenseTitle + "\n", attributes: titleAttributes))
 
 								// License text
 								do {
 									var encoding : String.Encoding = .utf8
 									let licenseFileContents = try String(contentsOf: licenseURL, usedEncoding: &encoding)
 
-									licenseText.append(NSAttributedString(string: "\n" + licenseFileContents + "\n\n", attributes: [
-										.font : UIFont.systemFont(ofSize: UIFont.systemFontSize),
-										.foregroundColor : UIColor.darkGray
-									]))
+									licenseText.append(NSAttributedString(string: "\n" + licenseFileContents + "\n\n", attributes: textAttributes))
 								} catch {
 								}
 							}


### PR DESCRIPTION
## Description
- adds a paragraph on top of the Acknowledgements to provide additional context
- adds PLCrashReporter license to acknowledgements

## Related Issue
https://github.com/owncloud/enterprise/issues/4284

## Screenshots (if appropriate):
<img width="559" alt="Bildschirmfoto 2020-11-30 um 11 17 25" src="https://user-images.githubusercontent.com/639669/100597342-a158d400-32fd-11eb-86a4-ebb777770af9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
