### PR TITLE
[fix/bookmark-name] Fix bookmark name editing

### DIFF
--- a/ownCloud/Bookmarks/BookmarkViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkViewController.swift
@@ -131,7 +131,7 @@ class BookmarkViewController: StaticTableViewController {
 			if let textField = sender as? UITextField, action == .changed {
 				self?.bookmark?.name = (textField.text?.count == 0) ? nil : textField.text
 			}
-		}, placeholder: "Name".localized, identifier: "row-name-name", accessibilityLabel: "Server name".localized)
+		}, placeholder: "Name".localized, value: editBookmark?.name ?? "", identifier: "row-name-name", accessibilityLabel: "Server name".localized)
 
 		nameSection = StaticTableViewSection(headerTitle: "Name".localized, footerTitle: nil, identifier: "section-name", rows: [ nameRow! ])
 
@@ -576,8 +576,8 @@ class BookmarkViewController: StaticTableViewController {
 							case .edit:
 								// Update original bookmark
 								self?.originalBookmark?.setValuesFrom(bookmark)
-								if !OCBookmarkManager.shared.updateBookmark(bookmark) {
-									Log.error("Changes to \(bookmark) not saved as it's not tracked by OCBookmarkManager!")
+								if let originalBookmark = self?.originalBookmark, !OCBookmarkManager.shared.updateBookmark(originalBookmark) {
+									Log.error("Changes to \(originalBookmark) not saved as it's not tracked by OCBookmarkManager!")
 								}
 							}
 


### PR DESCRIPTION
## Description
When editing bookmarks: 
- if a name was set, it wasn't shown in the edit interface
- bookmark name edits/additions would get lost
- bookmark name edits would not be presented in the list unless scrolling out of view and back in

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
