### PR TITLE
[feature/calens-changelog-actions] Automated Calens Changelog Creation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,4 +40,8 @@ Please note that any kind of change first has to be submitted to the master bran
 - [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
+- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
+- [ ] For Milestone PRs:
+	- [ ] Created a folder for the new version like $majorVersion.$minorVersion.$patchVersion_YYYY-MM-DD
+	- [ ] Moved all changelog files from the unreleased folder to the new version folder
 

--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -23,3 +23,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Calens changelog updated
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -18,9 +18,7 @@ jobs:
         with:
           options: -v ${{github.workspace}}:/workspace -w /workspace
           image: toolhippie/calens:latest
-          run: |
-            calens >| CHANGELOG.md
-            ls -la CHANGELOG.md
+          run: calens >| CHANGELOG.md
       - name: Commit files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     name: Generate Calens Changelog
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -1,0 +1,27 @@
+name: Calens Changelog
+# This workflow is triggered on pushes to the repository.
+on:
+  push:
+    branches:
+    - fix/*
+    - feature/*
+    - milestone/*
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    name: Generate Calens Changelog
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Calens Docker
+        uses: addnab/docker-run-action@v1
+        with:
+          options: -v ${{github.workspace}}:/workspace -w /workspace
+          image: toolhippie/calens:latest
+          run: |
+            calens >| CHANGELOG.md
+            ls -la CHANGELOG.md
+      - name: Commit files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Calens changelog updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,20 @@ ownCloud admins and users.
 Summary
 -------
 
+* Change - Full Screen PDF View: [#428](https://github.com/owncloud/ios-app/issues/428)
 * Change - Video upload improvements: [#847](https://github.com/owncloud/ios-app/issues/847)
 * Change - Improved Right-to-Left Language UI-Design: [#861](https://github.com/owncloud/ios-app/issues/861)
 
 Details
 -------
+
+* Change - Full Screen PDF View: [#428](https://github.com/owncloud/ios-app/issues/428)
+
+   - A PDF file can be opened in fullscreen view and hides unnecessary UI elements. (Tap to trigger
+   full screen view) - Thumbnails positioned based on vertical size class after rotating the
+   device to give the displayed document more screen real estate.
+
+   https://github.com/owncloud/ios-app/issues/428
 
 * Change - Video upload improvements: [#847](https://github.com/owncloud/ios-app/issues/847)
 

--- a/changelog/CHANGELOG-Release.tmpl
+++ b/changelog/CHANGELOG-Release.tmpl
@@ -1,0 +1,28 @@
+{{- range $index, $changes := . }}{{ with $changes -}}
+Changelog for ownCloud iOS Client {{ .Version }} ({{ .Date }})
+=======
+
+Summary
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
+{{- end }}{{ end }}
+
+Details
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
+{{ range $par := .Paragraphs }}
+   {{ wrapIndent $par 80 3 }}
+{{ end -}}
+{{ range $url := .IssueURLs }}
+   {{ $url -}}
+{{ end -}}
+{{ range $url := .PRURLs }}
+   {{ $url -}}
+{{ end -}}
+{{ range $url := .OtherURLs }}
+   {{ $url -}}
+{{ end }}
+{{ end }}{{ end }}
+{{ end }}{{ end -}}

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,0 +1,291 @@
+{{ $allVersions := . }}
+{{- range $index, $changes := . }}{{ with $changes -}}
+Changelog for ownCloud iOS Client [{{ .Version }}] ({{ .Date }})
+=======================================
+The following sections list the changes in ownCloud iOS Client {{ .Version }} relevant to
+ownCloud admins and users.
+
+{{/* creating version compare links */ -}}
+{{ $next := add1 $index -}}
+{{ if ne (len $allVersions) $next -}}
+{{ $previousVersion := (index $allVersions $next).Version -}}
+{{ if eq .Version "unreleased" -}}
+[{{ .Version }}]: https://github.com/owncloud/client/compare/v{{ $previousVersion }}...master
+{{- else -}}
+[{{ .Version }}]: https://github.com/owncloud/client/compare/v{{ $previousVersion }}...v{{ .Version }}
+{{- end -}}
+{{ end -}}
+
+{{- /* last version managed by calens, end of the loop */ -}}
+{{ if eq .Version "2.6.2" -}}
+[{{ .Version }}]: https://github.com/owncloud/client/compare/v2.6.1...v{{ .Version }}
+{{- end }}
+
+Summary
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
+{{- end }}{{ end }}
+
+Details
+-------
+{{ range $entry := .Entries }}{{ with $entry }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
+{{ range $par := .Paragraphs }}
+   {{ wrapIndent $par 80 3 }}
+{{ end -}}
+{{ range $url := .IssueURLs }}
+   {{ $url -}}
+{{ end -}}
+{{ range $url := .PRURLs }}
+   {{ $url -}}
+{{ end -}}
+{{ range $url := .OtherURLs }}
+   {{ $url -}}
+{{ end }}
+{{ end }}{{ end }}
+{{ end }}{{ end -}}
+
+{{/* Start of old changelog */ -}}
+
+## Release version 11.4.5 (January 2021)
+
+- Fix: Crash in Detail View (#855)
+- Fix: Upload Improvements (PR #857)
+
+## Release version 11.4.4 (End-November 2020)
+
+- Fix: iPad on iOS 12 (#4293)
+- Fix: Improvements on Apple Silicon macOS
+
+## Release version 11.4.3 (Mid-November 2020)
+
+- Fix: iOS 14 UI Adaptions (#834)
+
+## Release version 11.4.2 (November 2020)
+
+- Support for new Display Sizes
+- Favorites in Directory Picker (#814)
+- Rename Filename in Scan View (#822)
+- Fix: Save Attachments from Mail.app (#816)
+- Fix: Authentication Error in FileProvider (#808)
+- Fix: New Folder in FileProvider (#827)
+
+## Release version 11.4.1 (September 2020)
+
+- Image Metadata (#679)
+- Pro Photo Upload (#685, #688)
+- Fix: Media Upload Path (#784)
+- Fix: File List (#786)
+- Fix: Markup (#783)
+- Fix: Shortcuts (#785)
+- Fix: Share Sheet (#782)
+- Fix: Multiple Selection (#735)
+- Fix: File Provider (#747)
+- Fix: General Improvements (#790, #792, #793)
+- Fix: Create Public Link (#803)
+
+## Release version 11.4 (August 2020)
+
+- Branding Support (#2, #120)
+- Migration (#270)
+- Cellular Options (PR #709)
+- Share Sheet (#539)
+- Camera Access (#615)
+- Better Issue Handling (#362, #505, #513, #585, SDK: #63)
+- Folders on top (#431)
+- Contextual Menu (#717)
+- Multitouch gestures (#725)
+- Inline Authentication (PR #682)
+- Image Upload: Change file name (PR #714)
+- App Version Information (#740)
+- Improved Media Upload (#647)
+- Media Streaming (#766)
+- Public Link Creation (#671)
+- Diagnostics (PR #762)
+- Item Counter (PR #771)
+- Universal Links / Deep Linking (PR #609)
+- Shortcuts: Get File Info
+- Fix: Avoid duplicate photo upload (PR #714)
+- Fix: Markup (#729, 698)
+- Fix: Audio Playback (#683)
+- Fix: Serveral UI Improvements (PR #654, #264)
+- Fix: File Provider (#754, …)
+- Fix: Quick Access (#745)
+- Fix: Sort by Type (#670)
+
+## Release version 1.3.2 (April 2020)
+
+- iPad: Mouse and Trackpad support (#655)
+- Fix: Shortcut - Save Action (#651)
+- Fix: Keep open files up-to-date (#630)
+
+## Release version 1.3.1 (March 2020)
+
+- Fix: Shortcut - Save Action (#622)
+- Fix: Markup Documents (#617, #618)
+- Fix: Offline Usage (#3828)
+- Fix: Available Offline (PR #616)
+- Fix: Permissions (#623)
+
+## Release version 1.3.0 (February 2020)
+
+- Document Scanner on iOS 13 (PR #494)
+- Markup Documents on iOS 13 (#541)
+- Shortcut Support on iOS 13 (#463)
+- New Quick Access Collections (PR #600)
+- Cleaner File List Layout (PR #594)
+- Added Sort Bar in Directory Picker (#590)
+- Fix: Blank File List on UI restoration (#601)
+- Fix: Share Sheet on iPad for log files (#606)
+
+## Release version 1.2.1 (January 2020)
+
+- Fix: Passcode Lock Screen on iOS 13 (#582)
+
+## Release version 1.2.0 (December 2019)
+
+- Multiple Window Support (iPadOS) (#488)
+- Keyboard Commands (iPadOS) (#282)
+- Media Player Improvements (#59, #374)
+- Better File Previews (#481)
+- Arabic Language Support
+- Fix: Sort alphabetically (PR #546)
+- Fix: Share Sheet on iPad (#568)
+- Fix: FileProvider File Type Issue (#557)
+- Fix: FileProvider Offline Browsing (PR #547)
+- Fix: FileProvider Saving from Microsoft Word (PR #574)
+- Fix: Photo Upload (#504)
+
+## Release version 1.1.2 (October 2019)
+
+- Fix for long delays before starting a request on iOS 13.1 (PR #531)
+
+## Release version 1.1.1 (October 2019)
+
+- Dark mode support (PR #489)
+- iOS 13 support (#502)
+- Background media playback fixed (PR #522)
+- Displaying long file name improved (#516)
+- Fixed naming of uploaded edited photos (#520)
+- Fixed crash in File Provider (#502)
+- UI fixes (#511, #502)
+
+## Release version 1.1.0 (September 2019)
+
+- Available Offline Support (#134, #135)
+- Background Sync Support (#386)
+- Background Image Upload (#116)
+- Import Files from Share Sheet (#76)
+- Added "Create Folder" Action in Directory Picker (#443)
+- Added Change Sort Order for all Sort Methods (#470)
+- Added Index Bar in File list (#413)
+- Image Gallery improvements (#322)
+- UI improvements for the Navigation Bar (#477)
+- Added Activity Indicator for deleting Local Copies (#393)
+- Sharing fixes (#439, #415)
+- Fixed min length for searching sharing users (#454)
+
+## Release version 1.0.4 (August 2019)
+
+- Authentication improvements (PR #459)
+- Fixed background crash (PR #462)
+- Log file improvements (#444)
+
+## TestFlight Build 129 (July 2019)
+
+- Import files from Share Sheet (#76)
+- Create Folder in Directory Picker (#443)
+
+## TestFlight Build 126 (July 2019)
+
+- Native Media Player, with support for streaming (#395)
+- Name Conflict Detection (#377)
+- Activity Indicator for deleting offline copies (#393)
+- Improved Log File (#446)
+- Image Gallery improvement (#322)
+- Error handling for corrupted files (#357)
+
+## Release version 1.0.3 (July 2019)
+
+- Add support for local user names with @ inside in sharing (PR #453)
+
+## Release version 1.0.2 (July 2019)
+
+- Favorites crash fixed (#423)
+- Account Auto-Connect
+- Add support for server setting version.hide (#426)
+- OAuth2 improvements (#293)
+
+## Release version 1.0.1 (June 2019)
+- Passcode lock for iOS Files.app
+- Access log files after log session ended
+- Translation fixed
+- Sharing bug fixed
+- Fixed bug when creating a new folder
+
+## TestFlight Build 123 (June 2019)
+- Finally: Sharing !! (#275, #292, #351, #358)
+- Option to convert HEIF/HEVC to JPEG/MP4 before upload (#363)
+- Option to show/hide hidden files in the file list (#390)
+- Debugging: log rotation (#382)
+- Clear cached local files (#376)
+
+## TestFlight Build 119 (May 2019)
+- Drag and drop between apps (iPad Split View) (#48)
+- Drag directly to file actions (#250)
+- Multi-select: more file actions (#250)
+- Swipe to next image (#277)
+- Display quota (#337)
+- Navigation to any parent folder (#354)
+
+## TestFlight Build 111 (March 2019)
+- Upload multiple images and videos in the app (Select all!!!) (#173 )
+- "Open in…" with offline files (#227)
+- Basic appconfig.org implementation (#272)
+
+## TestFlight Build 103 (February 2019)
+- Multi-select files/folders for move and delete (#234)
+- Copy file/folder to another location (#207)
+- Accessibility improvements (#239)
+- Multi Language: cs_CZ, de, de_DE, en_GB, ko, mk, nb_NO, nn_NO, pt_BR, pt_PT, ru, sq, th_TH, zh_CN (#231)
+
+## TestFlight Build 85 (November 2018)
+- Upload (single) images and (multiple) files in the app (#146)
+- Open in another app (#132)
+
+## TestFlight Build 83 (November 2018)
+- PDF viewer with search and TOC (#138)
+
+## TestFlight Build 79 (November 2018)
+- iOS Files app integration (#67)
+  - Upload to Files app
+  - Download in Files app
+  - Edit and save files via Files app
+  - Move, rename, delete in Files app
+- File size and dates in file list (#117)
+- Settings > Logging
+
+## TestFlight Build 73 (October 2018)
+- Menu for file/folder info and actions (#106)
+- Move of individual files/folders from menu (#110)
+- Move multiple files/folders with drag and drop (#110)
+- Basic file preview (#114)
+
+## TestFlight Build Build 54 (August 2018)
+- Touch ID and Face ID (#54)
+- File/folder deletion (#91)
+- File/folder rename (#102)
+- Filtering/search the current folder (#64)
+
+## TestFlight Build 34 (June 2018)
+* Sort options for files and folders (#55)
+* Passcode lock with delay option and brute force (activate in "Settings", no Touch ID and Face ID yet) (#34)
+
+## TestFlight Build 31 (May 2018)
+* Account creation with OAuth 2.0 and basic auth
+* Edit, re-order and delete accounts (#38)
+* Inspect SSL-certificates
+* Folder navigation (online and offline)
+* Thumbnails in file view (#32)
+* Different themes (click "Help" on bottom left)

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,19 @@
+# Changelog
+
+We are using [calens](https://github.com/restic/calens) to properly generate a
+changelog before we are tagging a new release. 
+
+## Create Changelog items
+Create a file according to the [template](TEMPLATE) for each 
+changelog in the [unreleased](./unreleased) folder. The following change types are possible: `Bugfix, Change, Enhancement, Security`.
+
+## Automated Changelog build and commit
+- After each merge to master, the CHANGELOG.md file is automatically updated and the new version will be committed to master while skipping CI.
+
+## Create a new Release
+- copy the files from the [unreleased](./unreleased) folder into a folder matching the
+schema `0.3.0_2020-01-10`
+
+## Test the Changelog generator manually
+- execute `docker run --rm -v $(pwd):$(pwd) -w $(pwd) toolhippie/calens:latest` 
+in the root folder of the project.

--- a/changelog/TEMPLATE.txt
+++ b/changelog/TEMPLATE.txt
@@ -1,0 +1,12 @@
+Bugfix: Fix behavior for foobar (in the present tense, max length 80 chars)
+
+We've fixed the behavior for foobar, a long-standing annoyance for ownCloud
+users.
+
+The text in the paragraphs is written in past tense. The last section is a list
+of issue URLs, PR URLs and other URLs. The first issue ID (or the first PR ID,
+in case there aren't any issue links) is used as the primary ID.
+
+https://github.com/owncloud/ios-app/issues/1234
+https://github.com/owncloud/ios-app/pull/55555
+https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html

--- a/changelog/unreleased/428
+++ b/changelog/unreleased/428
@@ -1,0 +1,6 @@
+Change: Full Screen PDF View
+
+- A PDF file can be opened in fullscreen view and hides unnecessary UI elements. (Tap to trigger full screen view)
+- Thumbnails positioned based on vertical size class after rotating the device to give the displayed document more screen real estate.
+
+https://github.com/owncloud/ios-app/issues/428

--- a/changelog/unreleased/847
+++ b/changelog/unreleased/847
@@ -1,0 +1,6 @@
+Change: Video upload improvements
+
+- Added ability to upload slo-mo videos etc
+- Added option to allow uploading original videos
+
+https://github.com/owncloud/ios-app/issues/847

--- a/changelog/unreleased/861
+++ b/changelog/unreleased/861
@@ -1,0 +1,5 @@
+Change: Improved Right-to-Left Language UI-Design
+
+Fixed missing views, which missed Right-to-Left language support.
+
+https://github.com/owncloud/ios-app/issues/861

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,3 +1,0 @@
-calens >| CHANGELOG.md
-ls -la CHANGELOG.md
-

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,1 +1,0 @@
-calens >| CHANGELOG.md

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,0 +1,3 @@
+calens >| CHANGELOG.md
+ls -la CHANGELOG.md
+

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,0 +1,1 @@
+calens >| CHANGELOG.md


### PR DESCRIPTION
## Description
This PR uses GitHub Actions to automatically generate a changelog file with Calens and commits the new CHANGELOG.md into the current branch.
Furthermore the PR template was updated with new checkboxes to get sure, that a release notes issue file for Calense was added.

## Related Issue

## Motivation and Context
Automatically changelog file creation, with the same structure, as other ownCloud repositories.

## How Has This Been Tested?
- Add an release notes issue file into `changelog/unreleased` with the issue number as file name
- Commit and push to git
- Check GitHub Actions
- As a result the `CHANGELOG.md` file should be updated

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

