### PR TITLE
[fix/branded-login-ipad-UI] Fixed Branded UI on iPad

### DIFF
--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -81,11 +81,11 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 			}, placeholder: "https://", value: self.urlString ?? "", keyboardType: .asciiCapable, autocorrectionType: .no, autocapitalizationType: .none, returnKeyType: .continue, identifier: "url"))
 
 		if VendorServices.shared.canAddAccount, OCBookmarkManager.shared.bookmarks.count > 0 {
-			let (proceedButton, cancelButton) = urlSection.addButtonFooter(proceedLabel: "Continue".localized, cancelLabel: "Cancel".localized)
+			let (proceedButton, cancelButton) = urlSection.addButtonFooter(proceedLabel: "Continue".localized, proceedItemStyle: .welcome, cancelLabel: "Cancel".localized)
 			proceedButton?.addTarget(self, action: #selector(self.proceedWithURL), for: .touchUpInside)
 			cancelButton?.addTarget(self, action: #selector(self.cancel(_:)), for: .touchUpInside)
 		} else {
-		let (proceedButton, _) = urlSection.addButtonFooter(proceedLabel: "Continue".localized, cancelLabel: nil)
+		let (proceedButton, _) = urlSection.addButtonFooter(proceedLabel: "Continue".localized, proceedItemStyle: .welcome, cancelLabel: nil)
 			proceedButton?.addTarget(self, action: #selector(self.proceedWithURL), for: .touchUpInside)
 		}
 
@@ -132,11 +132,11 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 		}
 
 		if VendorServices.shared.canAddAccount, OCBookmarkManager.shared.bookmarks.count > 0 {
-			let (proceedButton, cancelButton) = loginMaskSection.addButtonFooter(proceedLabel: "Login".localized, cancelLabel: "Cancel".localized)
+			let (proceedButton, cancelButton) = loginMaskSection.addButtonFooter(proceedLabel: "Login".localized, proceedItemStyle: .welcome, cancelLabel: "Cancel".localized)
 			proceedButton?.addTarget(self, action: #selector(self.startAuthentication), for: .touchUpInside)
 			cancelButton?.addTarget(self, action: #selector(self.cancel(_:)), for: .touchUpInside)
 		} else {
-			let (proceedButton, _) = loginMaskSection.addButtonFooter(proceedLabel: "Login".localized, cancelLabel: nil)
+			let (proceedButton, _) = loginMaskSection.addButtonFooter(proceedLabel: "Login".localized, proceedItemStyle: .welcome, cancelLabel: nil)
 			proceedButton?.addTarget(self, action: #selector(self.startAuthentication), for: .touchUpInside)
 		}
 
@@ -154,7 +154,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 			proceedButton?.addTarget(self, action: #selector(self.startAuthentication), for: .touchUpInside)
 			cancelButton?.addTarget(self, action: #selector(self.cancel(_:)), for: .touchUpInside)
 		} else {
-			let (proceedButton, _) = tokenMaskSection.addButtonFooter(proceedLabel: "Continue", cancelLabel: nil)
+			let (proceedButton, _) = tokenMaskSection.addButtonFooter(proceedLabel: "Continue", proceedItemStyle: .welcome, cancelLabel: nil)
 			proceedButton?.addTarget(self, action: #selector(self.startAuthentication), for: .touchUpInside)
 		}
 
@@ -400,7 +400,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 
 		messageSection.addStaticHeader(title: "Setup complete".localized)
 
-		let (proceedButton, showAccountsList) = messageSection.addButtonFooter(proceedLabel: "Connect".localized, cancelLabel: "Show accounts".localized)
+		let (proceedButton, showAccountsList) = messageSection.addButtonFooter(proceedLabel: "Connect".localized, proceedItemStyle: .welcome, cancelLabel: "Show accounts".localized)
 
 		proceedButton?.addTarget(self, action: #selector(self.connectToBookmark), for: .touchUpInside)
 		showAccountsList?.addTarget(loginViewController, action: #selector(loginViewController?.showFirstScreen), for: .touchUpInside)

--- a/ownCloud/Static Login/Interface/StaticLoginViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginViewController.swift
@@ -21,6 +21,7 @@ import ownCloudSDK
 import ownCloudAppShared
 
 class StaticLoginViewController: UIViewController, Themeable {
+	private let maximumContentWidth : CGFloat = 400
 	let loginBundle : StaticLoginBundle
 
 	var backgroundImageView : UIImageView?
@@ -153,10 +154,22 @@ class StaticLoginViewController: UIViewController, Themeable {
 			// Content
 				// Content container
 				contentContainerView!.topAnchor.constraint(equalTo: headerContainerView!.bottomAnchor),
-				contentContainerView!.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
-				contentContainerView!.leftAnchor.constraint(equalTo: rootView.leftAnchor),
-				contentContainerView!.rightAnchor.constraint(equalTo: rootView.rightAnchor)
+				contentContainerView!.bottomAnchor.constraint(equalTo: rootView.bottomAnchor)
 		])
+
+		if UIDevice.current.isIpad {
+			NSLayoutConstraint.activate([
+				contentContainerView!.leadingAnchor.constraint(equalTo: rootView.leadingAnchor).with(priority: .defaultLow),
+				contentContainerView!.trailingAnchor.constraint(equalTo: rootView.trailingAnchor).with(priority: .defaultLow),
+				contentContainerView!.widthAnchor.constraint(lessThanOrEqualToConstant: maximumContentWidth).with(priority: .defaultHigh),
+				contentContainerView!.centerXAnchor.constraint(equalTo: rootView.centerXAnchor)
+			])
+		} else {
+			NSLayoutConstraint.activate([
+				contentContainerView!.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+				contentContainerView!.trailingAnchor.constraint(equalTo: rootView.trailingAnchor)
+			])
+		}
 
 		self.view = rootView
 

--- a/ownCloudAppShared/User Interface/Theme/NSObject+ThemeApplication.swift
+++ b/ownCloudAppShared/User Interface/Theme/NSObject+ThemeApplication.swift
@@ -41,6 +41,7 @@ public enum ThemeItemStyle {
 	case bigMessage
 
 	case purchase
+	case welcome
 }
 
 public enum ThemeItemState {
@@ -84,6 +85,9 @@ public extension NSObject {
 
 				case .purchase:
 					themeButton.themeColorCollection = collection.purchaseColors
+
+				case .welcome:
+					themeButton.themeColorCollection = collection.loginColors.filledColorPairCollection
 
 				default:
 					themeButton.themeColorCollection = collection.lightBrandColors.filledColorPairCollection


### PR DESCRIPTION
## Description
1. UI fix for branded login on the iPad
2. Fill color for branded button was not used

## Related Issue
1. https://github.com/owncloud/enterprise/issues/4367
2. https://github.com/owncloud/enterprise/issues/4366

## Motivation and Context
Better UI experience

## How Has This Been Tested?
- Use a branded Client
- Test UI on iPad
- Test UI on iPhone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

