### PR TITLE
Fixing Media Player Behaviour

### DIFF
--- a/ownCloud/Client/Viewer/DisplayHostViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayHostViewController.swift
@@ -19,19 +19,6 @@
 import UIKit
 import ownCloudSDK
 import ownCloudAppShared
-import CoreServices
-
-extension OCItem {
-	var isPlayable: Bool {
-		guard let mime = self.mimeType else { return false }
-
-		guard let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mime as CFString, nil) else {
-			return false
-		}
-
-		return UTTypeConformsTo(uti.takeUnretainedValue(), kUTTypeAudiovisualContent)
-	}
-}
 
 class DisplayHostViewController: UIPageViewController {
 

--- a/ownCloudAppShared/SDK Extensions/OCItem+Extension.swift
+++ b/ownCloudAppShared/SDK Extensions/OCItem+Extension.swift
@@ -18,8 +18,20 @@
 
 import UIKit
 import ownCloudSDK
+import CoreServices
 
 extension OCItem {
+    
+    public var isPlayable: Bool {
+        guard let mime = self.mimeType else { return false }
+
+        guard let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mime as CFString, nil) else {
+            return false
+        }
+
+        return UTTypeConformsTo(uti.takeUnretainedValue(), kUTTypeAudiovisualContent)
+    }
+    
 	static private let iconNamesByMIMEType : [String:String] = {
 		var mimeTypeToIconMap :  [String:String] = [
 			// List taken from https://github.com/owncloud/core/blob/master/core/js/mimetypelist.js


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
Fix for an issue when playing multiple items in the same directory. If e.g. image item is the next one, multi media playback would stop.

## Related Issue
n/a

## Motivation and Context
User would like to play all audio-visual files in a row without interruption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

