### PR TITLE
[fix/ios12-swift-crash] Fix iOS 12 Swift Crash

### DIFF
--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -32,7 +32,96 @@
 	// Provide hook to allow Swift extensions in the app to register defaults and metadata
 	if ([self conformsToProtocol:@protocol(BrandingInitialization)])
 	{
-		[((Class<BrandingInitialization>)self) initializeBranding];
+		if (@available(iOS 13, *))
+		{
+			[((Class<BrandingInitialization>)self) initializeBranding];
+		}
+		else
+		{
+			// BEGIN: Workaround for iOS 12 Swift crash bug - this code is usually in +initializeBranding in ownCloudAppShared.framework - remove when dropping iOS 12 support
+			[self registerOCClassSettingsDefaults:@{
+				@"url-documentation" 	: @"https://doc.owncloud.com/ios-app/",
+				@"url-help" 	  	: @"https://www.owncloud.com/help",
+				@"url-privacy" 	  	: @"https://owncloud.org/privacy-policy/",
+				@"url-terms-of-use" 	: @"https://raw.githubusercontent.com/owncloud/ios-app/master/LICENSE",
+
+				@"send-feedback-address" : @"ios-app@owncloud.com",
+
+				@"can-add-account" : @(YES),
+				@"can-edit-account" : @(YES)
+			} metadata:@{
+				@"url-documentation" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeURLString,
+					OCClassSettingsMetadataKeyDescription 	: @"URL to documentation for the app. Opened when selecting \"Documentation\" in the settings.",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+					OCClassSettingsMetadataKeyCategory	: @"Branding"
+				},
+
+				@"url-help" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeURLString,
+					OCClassSettingsMetadataKeyDescription 	: @"URL to help for the app. Opened when selecting \"Help\" in the settings.",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+					OCClassSettingsMetadataKeyCategory	: @"Branding"
+				},
+
+				@"url-privacy" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeURLString,
+					OCClassSettingsMetadataKeyDescription 	: @"URL to privacy information for the app. Opened when selecting \"Privacy\" in the settings.",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+					OCClassSettingsMetadataKeyCategory	: @"Branding"
+				},
+
+				@"url-terms-of-use" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeURLString,
+					OCClassSettingsMetadataKeyDescription 	: @"URL to terms of use for the app. Opened when selecting \"Terms Of Use\" in the settings.",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+					OCClassSettingsMetadataKeyCategory	: @"Branding"
+				},
+
+				@"send-feedback-address" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeString,
+					OCClassSettingsMetadataKeyDescription	: @"Email address to send feedback to. Set to `null` to disable this feature.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"can-add-account" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeBoolean,
+					OCClassSettingsMetadataKeyDescription	: @"Controls whether the user can add accounts.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"can-edit-account" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeBoolean,
+					OCClassSettingsMetadataKeyDescription	: @"Controls whether the user can edit accounts.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"profile-definitions" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeDictionaryArray,
+					OCClassSettingsMetadataKeyDescription	: @"Array of dictionaries, each specifying a static profile.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"theme-generic-colors" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeDictionary,
+					OCClassSettingsMetadataKeyDescription	: @"Dictionary defining generic colors that can be used in the definitions.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"theme-definitions" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeDictionaryArray,
+					OCClassSettingsMetadataKeyDescription	: @"Array of dictionaries, each specifying a theme.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				}
+			}];
+			// END: Workaround for iOS 12 Swift crash bug - this code is usually in +initializeBranding in ownCloudAppShared.framework - remove when dropping iOS 12 support
+		}
 	}
 }
 

--- a/ownCloudAppShared/Branding/Branding+App.swift
+++ b/ownCloudAppShared/Branding/Branding+App.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import ownCloudApp
+import ownCloudSDK
 
 extension OCClassSettingsKey {
 	// URLs
@@ -33,91 +34,93 @@ extension OCClassSettingsKey {
 
 extension Branding : BrandingInitialization {
 	public static func initializeBranding() {
-		self.registerOCClassSettingsDefaults([
-			.documentationURL : "https://doc.owncloud.com/ios-app/",
-			.helpURL 	  : "https://www.owncloud.com/help",
-			.privacyURL 	  : "https://owncloud.org/privacy-policy/",
-			.termsOfUseURL 	  : "https://raw.githubusercontent.com/owncloud/ios-app/master/LICENSE",
+		if #available(iOS 13, *) {
+			self.registerOCClassSettingsDefaults([
+				.documentationURL : "https://doc.owncloud.com/ios-app/",
+				.helpURL 	  : "https://www.owncloud.com/help",
+				.privacyURL 	  : "https://owncloud.org/privacy-policy/",
+				.termsOfUseURL 	  : "https://raw.githubusercontent.com/owncloud/ios-app/master/LICENSE",
 
-			.sendFeedbackAddress : "ios-app@owncloud.com",
+				.sendFeedbackAddress : "ios-app@owncloud.com",
 
-			.canAddAccount : true,
-			.canEditAccount : true
+				.canAddAccount : true,
+				.canEditAccount : true
 
-//			.profileDefinitions : [],
-//			.themeGenericColors : [:],
-//			.themeDefinitions : [:]
-		], metadata: [
-			.documentationURL : [
-				.type 		: OCClassSettingsMetadataType.urlString,
-				.description 	: "URL to documentation for the app. Opened when selecting \"Documentation\" in the settings.",
-				.status		: OCClassSettingsKeyStatus.advanced,
-				.category	: "Branding"
-			],
+	//			.profileDefinitions : [],
+	//			.themeGenericColors : [:],
+	//			.themeDefinitions : [:]
+			], metadata: [
+				.documentationURL : [
+					.type 		: OCClassSettingsMetadataType.urlString,
+					.description 	: "URL to documentation for the app. Opened when selecting \"Documentation\" in the settings.",
+					.status		: OCClassSettingsKeyStatus.advanced,
+					.category	: "Branding"
+				],
 
-			.helpURL : [
-				.type 		: OCClassSettingsMetadataType.urlString,
-				.description 	: "URL to help for the app. Opened when selecting \"Help\" in the settings.",
-				.status		: OCClassSettingsKeyStatus.advanced,
-				.category	: "Branding"
-			],
+				.helpURL : [
+					.type 		: OCClassSettingsMetadataType.urlString,
+					.description 	: "URL to help for the app. Opened when selecting \"Help\" in the settings.",
+					.status		: OCClassSettingsKeyStatus.advanced,
+					.category	: "Branding"
+				],
 
-			.privacyURL : [
-				.type 		: OCClassSettingsMetadataType.urlString,
-				.description 	: "URL to privacy information for the app. Opened when selecting \"Privacy\" in the settings.",
-				.status		: OCClassSettingsKeyStatus.advanced,
-				.category	: "Branding"
-			],
+				.privacyURL : [
+					.type 		: OCClassSettingsMetadataType.urlString,
+					.description 	: "URL to privacy information for the app. Opened when selecting \"Privacy\" in the settings.",
+					.status		: OCClassSettingsKeyStatus.advanced,
+					.category	: "Branding"
+				],
 
-			.termsOfUseURL : [
-				.type 		: OCClassSettingsMetadataType.urlString,
-				.description 	: "URL to terms of use for the app. Opened when selecting \"Terms Of Use\" in the settings.",
-				.status		: OCClassSettingsKeyStatus.advanced,
-				.category	: "Branding"
-			],
+				.termsOfUseURL : [
+					.type 		: OCClassSettingsMetadataType.urlString,
+					.description 	: "URL to terms of use for the app. Opened when selecting \"Terms Of Use\" in the settings.",
+					.status		: OCClassSettingsKeyStatus.advanced,
+					.category	: "Branding"
+				],
 
-			.sendFeedbackAddress : [
-				.type 		: OCClassSettingsMetadataType.string,
-				.description	: "Email address to send feedback to. Set to `null` to disable this feature.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			],
+				.sendFeedbackAddress : [
+					.type 		: OCClassSettingsMetadataType.string,
+					.description	: "Email address to send feedback to. Set to `null` to disable this feature.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				],
 
-			.canAddAccount : [
-				.type 		: OCClassSettingsMetadataType.boolean,
-				.description	: "Controls whether the user can add accounts.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			],
+				.canAddAccount : [
+					.type 		: OCClassSettingsMetadataType.boolean,
+					.description	: "Controls whether the user can add accounts.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				],
 
-			.canEditAccount : [
-				.type 		: OCClassSettingsMetadataType.boolean,
-				.description	: "Controls whether the user can edit accounts.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			],
+				.canEditAccount : [
+					.type 		: OCClassSettingsMetadataType.boolean,
+					.description	: "Controls whether the user can edit accounts.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				],
 
-			.profileDefinitions : [
-				.type 		: OCClassSettingsMetadataType.dictionaryArray,
-				.description	: "Array of dictionaries, each specifying a static profile.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			],
+				.profileDefinitions : [
+					.type 		: OCClassSettingsMetadataType.dictionaryArray,
+					.description	: "Array of dictionaries, each specifying a static profile.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				],
 
-			.themeGenericColors : [
-				.type 		: OCClassSettingsMetadataType.dictionary,
-				.description	: "Dictionary defining generic colors that can be used in the definitions.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			],
+				.themeGenericColors : [
+					.type 		: OCClassSettingsMetadataType.dictionary,
+					.description	: "Dictionary defining generic colors that can be used in the definitions.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				],
 
-			.themeDefinitions : [
-				.type 		: OCClassSettingsMetadataType.dictionaryArray,
-				.description	: "Array of dictionaries, each specifying a theme.",
-				.category	: "Branding",
-				.status		: OCClassSettingsKeyStatus.advanced
-			]
-		])
+				.themeDefinitions : [
+					.type 		: OCClassSettingsMetadataType.dictionaryArray,
+					.description	: "Array of dictionaries, each specifying a theme.",
+					.category	: "Branding",
+					.status		: OCClassSettingsKeyStatus.advanced
+				]
+			])
+		}
 	}
 
 	public func initializeSharedBranding() {


### PR DESCRIPTION
## Description
Fix iOS 12 crash bug caused by Swift crashing upon initialization of a dictionary; add temporary ObjC replacement for iOS 12.

Tested to work in the iOS 12.4 Simulator.

## Related Issue
#896 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
