### PR TITLE
Temporarily remove "Shortcuts" from MDM docs

### DIFF
--- a/docs/modules/ROOT/pages/ios_mdm.adoc
+++ b/docs/modules/ROOT/pages/ios_mdm.adoc
@@ -82,11 +82,13 @@ Settings allowing to configure OAuth2 based authentication.
 
 include::./ios_mdm_tables.adoc[tag=oauth2]
 
+////
 ==== Shortcuts
 
 Shortcuts are a very powerful way to build automated workflows in iOS. Apps can provide shortcut intents for certain actions. ownCloud app provides certain actions as shortcuts as well (e.g. allowing to get account information, create folder and so on). However in some cases it might make sense to disable shortcuts to minimize security risks. It can be done using following option:
 
 include::./ios_mdm_tables.adoc[tag=shortcuts]
+////
 
 ==== Logging
 Logging settings control the ammount and type of app internal log messages stored as text files and accessible via settings menu.


### PR DESCRIPTION
(table with Shortcuts parameter isn't autogenerated yet)


Fixes `asciidoctor: WARNING`:

```
% yarn antora
yarn run v1.22.10
$ antora --stacktrace generate --cache-dir cache --redirect-facility disabled --clean site.yml
asciidoctor: WARNING: ios_mdm.adoc: line 89: tag 'shortcuts' not found in include file: modules/ROOT/pages/ios_mdm_tables.adoc
✨  Done in 8.56s.
```
