### PR TITLE
[fix/acknowledgement-colors] Fix legibility of Acknowledgements in dark mode

### DIFF
--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -103,8 +103,7 @@ class MoreSettingsSection: SettingsSection {
 						]
 
 						let textAttributes : [NSAttributedString.Key : Any] = [
-							.font : UIFont.systemFont(ofSize: UIFont.systemFontSize),
-							.foregroundColor : UIColor.darkGray
+							.font : UIFont.systemFont(ofSize: UIFont.systemFontSize)
 						]
 
 					   	// Preamble

--- a/ownCloud/UI Elements/TextViewController.swift
+++ b/ownCloud/UI Elements/TextViewController.swift
@@ -7,18 +7,19 @@
 //
 
 /*
-* Copyright (C) 2018, ownCloud GmbH.
-*
-* This code is covered by the GNU Public License Version 3.
-*
-* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
-* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
-*
-*/
+ * Copyright (C) 2018, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
 
 import UIKit
+import ownCloudAppShared
 
-class TextViewController: UIViewController {
+class TextViewController: UIViewController, Themeable {
 	var textView : UITextView?
 
 	var attributedText : NSAttributedString? {
@@ -30,6 +31,10 @@ class TextViewController: UIViewController {
 		didSet {
 			textView?.text = plainText
 		}
+	}
+
+	deinit {
+		Theme.shared.unregister(client: self)
 	}
 
 	override func loadView() {
@@ -45,5 +50,12 @@ class TextViewController: UIViewController {
 		} else {
 			textView?.text = plainText
 		}
+
+		Theme.shared.register(client: self, applyImmediately: true)
+	}
+
+	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
+		textView?.textColor = collection.tableRowColors.labelColor
+		textView?.backgroundColor = collection.tableBackgroundColor
 	}
 }


### PR DESCRIPTION
## Description
Add `Themeable` support to the Acknowledgements, fixing the legibility issue in dark mode

## Related Issue
Reported by @michaelstingl.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
