### PR TITLE
[feature/flat-mdm-settings] Support for MDM setting hierarchies with flat keys

### DIFF
--- a/ownCloud/AppDelegate.swift
+++ b/ownCloud/AppDelegate.swift
@@ -153,16 +153,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			return true
 		}
 
-        // If the app was re-installed, make sure to wipe keychain data. Since iOS 10.3 keychain entries are not deleted if the app is deleted, but since everything else is lost,
-        // it might lead to some inconsistency in the app state. Nevertheless we shall be careful here and consider that prior versions of the app didn't have the flag created upon
-        // very first app launch in UserDefaults. Thus we will check few more factors: no bookmarks configured and no passcode is set
-        if OCBookmarkManager.shared.bookmarks.count == 0 && AppLockManager.shared.lockEnabled == false {
-            VendorServices.shared.onFirstLaunch {
-                OCAppIdentity.shared.keychain?.wipe()
-            }
-        }
+		// If the app was re-installed, make sure to wipe keychain data. Since iOS 10.3 keychain entries are not deleted if the app is deleted, but since everything else is lost,
+		// it might lead to some inconsistency in the app state. Nevertheless we shall be careful here and consider that prior versions of the app didn't have the flag created upon
+		// very first app launch in UserDefaults. Thus we will check few more factors: no bookmarks configured and no passcode is set
+		if OCBookmarkManager.shared.bookmarks.count == 0 && AppLockManager.shared.lockEnabled == false {
+			VendorServices.shared.onFirstLaunch {
+				OCAppIdentity.shared.keychain?.wipe()
+			}
+		}
 
 		setupAndHandleCrashReports()
+
+		setupMDMPushRelaunch()
 
 		return true
 	}
@@ -269,5 +271,19 @@ extension AppDelegate {
 		}
 
 		crashReporter.enable()
+	}
+}
+
+extension AppDelegate {
+	func setupMDMPushRelaunch() {
+		NotificationCenter.default.addObserver(self, selector: #selector(relaunchAfterMDMPush), name: .OCClassSettingsManagedSettingsChanged, object: nil)
+	}
+
+	@objc func relaunchAfterMDMPush() {
+		UNUserNotificationCenter.postLocalNotification(with: "mdm-relaunch", title: "New settings pushed via MDM".localized, body: "Tap to re-launch.".localized, after: 0.1) { (error) in
+			if error == nil {
+				exit(0)
+			}
+		}
 	}
 }

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -848,5 +848,6 @@
 "No Access to the media selected for upload" = "No Access to the media selected for upload";
 
 /* MDM settings push */
-"New settings pushed via MDM" = "New settings pushed via MDM";
-"Tap to re-launch." = "Tap to re-launch.";
+"New settings received from MDM" = "New settings received from MDM";
+"Tap to quit the app." = "Tap to quit the app.";
+"Tap to launch the app." = "Tap to launch the app.";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -846,3 +846,7 @@
 "Limited Photo Access" = "Limited Photo Access";
 "Access for the media selected for upload is limited" = "Access for the media selected for upload is limited";
 "No Access to the media selected for upload" = "No Access to the media selected for upload";
+
+/* MDM settings push */
+"New settings pushed via MDM" = "New settings pushed via MDM";
+"Tap to re-launch." = "Tap to re-launch.";

--- a/ownCloud/Tasks/UNUserNotificationCenter+Extensions.swift
+++ b/ownCloud/Tasks/UNUserNotificationCenter+Extensions.swift
@@ -7,26 +7,29 @@
 //
 
 /*
-* Copyright (C) 2020, ownCloud GmbH.
-*
-* This code is covered by the GNU Public License Version 3.
-*
-* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
-* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
-*
-*/
+ * Copyright (C) 2020, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
 
 import UserNotifications
 import ownCloudApp
 
 extension UNUserNotificationCenter {
-	class func postLocalNotification(with identifier:String, title:String, body:String, after:TimeInterval = 0.5, completion:((Error?) -> Void)? = nil) {
+	class func postLocalNotification(with identifier:String, title:String, body:String?, after:TimeInterval = 0.5, completion:((Error?) -> Void)? = nil) {
 		NotificationManager.shared.getNotificationSettings(completionHandler: { (settings) in
 			if settings.authorizationStatus == .authorized {
 				let content = UNMutableNotificationContent()
 
 				content.title = title
-				content.body = body
+
+				if let body = body {
+					content.body = body
+				}
 
 				let trigger = UNTimeIntervalNotificationTrigger(timeInterval: after, repeats: false)
 

--- a/ownCloudAppFramework/Notifications/NotificationManager.h
+++ b/ownCloudAppFramework/Notifications/NotificationManager.h
@@ -34,7 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)requestAuthorizationWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError *__nullable error))completionHandler;
 @end
 
-#define ComposeNotificationIdentifier(aClass,identifier) [NSStringFromClass(aClass.class) stringByAppendingFormat:@":%@", identifier]
+NSString *NotificationManagerComposeIdentifier(Class aClass, NSString *identifier);
+#define ComposeNotificationIdentifier(aClass,identifier) NotificationManagerComposeIdentifier(aClass.class, identifier)
 
 @protocol NotificationResponseHandler <NSObject>
 + (void)handleNotificationCenter:(UNUserNotificationCenter *)center response:(UNNotificationResponse *)response identifier:(NSString *)identifier completionHandler:(dispatch_block_t)completionHandler;

--- a/ownCloudAppFramework/Notifications/NotificationManager.m
+++ b/ownCloudAppFramework/Notifications/NotificationManager.m
@@ -135,3 +135,8 @@
 }
 
 @end
+
+NSString *NotificationManagerComposeIdentifier(Class aClass, NSString *identifier)
+{
+	return ([NSStringFromClass(aClass) stringByAppendingFormat:@":%@", identifier]);
+}


### PR DESCRIPTION
## Description
- adds support for MDM setting hierarchies with flat keys
- simplified relaunch when receiving MDM setting updates

## Example
```json
{
	"profiles$[0].index" 		 : 0,
	"profiles$[0].name"  		 : "hello",
	"profiles$[0].attributes.highlight"  : true,
	"profiles$[0].nicknames[0]" 	 : "hi",
	"profiles$[0].nicknames[2]" 	 : "howdy",
	"profiles$[0].nicknames[1]" 	 : "hey",

	"profiles$[1].index" 		 : 1,
	"profiles$[1].name"  		 : "maxwell",
	"profiles$[1].attributes.highlight"  : false,
	"profiles$[1].nicknames[0]" 	 : "max",
	"profiles$[1].nicknames[1]" 	 : "maxy",

	"unrelated.settings.with.dots"	 : "oc"
}
```

After (transparent) expansion, this equals:

```json
{
	"profiles" : [
		{
			"attributes" : {
				"highlight" : 1,
			},
			"index" : 0,
			"name" : "hello",
			"nicknames" : [
				"hi",
				"hey",
				"howdy"
			]
		},
		{
			"attributes" : {
				"highlight" : 0
			},
			"index" : 1,
			"name" : "maxwell",
			"nicknames" : [
				"max",
				"maxy"
			]
		}
	],

	"unrelated.settings.with.dots" : "oc"
}
```

## Screenshots
<img width="553" alt="Bildschirmfoto 2021-02-21 um 01 14 10" src="https://user-images.githubusercontent.com/639669/108611776-32fa4e00-73e2-11eb-8a60-3e72712d5403.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## QA

- [ ] (1) App closes suddenly when something is pushed https://github.com/owncloud/ios-app/pull/904#issuecomment-785037877