### PR TITLE
[fix/pdf-thumbnailview-position] PDF thumbnail view position on the iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/client/compare/v11.5.1...master
+
+Summary
+-------
+
+* Bugfix - PDF thumbnail view position on the iPad: [#905](https://github.com/owncloud/ios-app/pull/905)
+
+Details
+-------
+
+* Bugfix - PDF thumbnail view position on the iPad: [#905](https://github.com/owncloud/ios-app/pull/905)
+
+   Fixed the position of the PDF thumbnail view on the iPad from the bottom to the right position to
+   get more visible PDF content and to prevent enabling the iOS app switcher when scrolling throw
+   the thumbnail view.
+
+   https://github.com/owncloud/ios-app/pull/905
+
 Changelog for ownCloud iOS Client [11.5.1] (2020-02-17)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.5.1 relevant to

--- a/changelog/unreleased/905
+++ b/changelog/unreleased/905
@@ -1,0 +1,5 @@
+Bugfix: PDF thumbnail view position on the iPad
+
+Fixed the position of the PDF thumbnail view on the iPad from the bottom to the right position to get more visible PDF content and to prevent enabling the iOS app switcher when scrolling throw the thumbnail view.
+
+https://github.com/owncloud/ios-app/pull/905

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -330,7 +330,7 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 	// MARK: - Private helpers
 
 	private func setThumbnailPosition() {
-		if UIScreen.main.traitCollection.verticalSizeClass == .regular, UIDevice.current.orientation.isPortrait, !UIDevice.current.isIpad {
+		if !UIDevice.current.isIpad, UIDevice.current.orientation.isPortrait {
 			self.thumbnailViewPosition = .bottom
 		} else {
 			self.thumbnailViewPosition = .right

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -110,6 +110,8 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		if gotoPageNotificationObserver != nil {
 			NotificationCenter.default.removeObserver(gotoPageNotificationObserver!)
 		}
+		NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+
 	}
 
 	private var didSetupView : Bool = false
@@ -195,6 +197,7 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		super.viewDidLoad()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(handlePageChanged), name: .PDFViewPageChanged, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
 
 		gotoPageNotificationObserver = NotificationCenter.default.addObserver(forName: PDFViewerViewController.PDFGoToPageNotification.name, object: nil, queue: OperationQueue.main) { [weak self] (notification) in
 			if let page = notification.object as? PDFPage {
@@ -327,11 +330,16 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 	// MARK: - Private helpers
 
 	private func setThumbnailPosition() {
-		if UIScreen.main.traitCollection.verticalSizeClass == .regular {
+		if UIScreen.main.traitCollection.verticalSizeClass == .regular, UIDevice.current.orientation.isPortrait, !UIDevice.current.isIpad {
 			self.thumbnailViewPosition = .bottom
 		} else {
 			self.thumbnailViewPosition = .right
 		}
+	}
+
+	@objc func rotated() {
+		setThumbnailPosition()
+		setupConstraints()
 	}
 
 	private func calculateThumbnailSize() {

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -110,7 +110,6 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		if gotoPageNotificationObserver != nil {
 			NotificationCenter.default.removeObserver(gotoPageNotificationObserver!)
 		}
-		NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
 
 	}
 
@@ -197,7 +196,6 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		super.viewDidLoad()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(handlePageChanged), name: .PDFViewPageChanged, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
 
 		gotoPageNotificationObserver = NotificationCenter.default.addObserver(forName: PDFViewerViewController.PDFGoToPageNotification.name, object: nil, queue: OperationQueue.main) { [weak self] (notification) in
 			if let page = notification.object as? PDFPage {
@@ -330,16 +328,11 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 	// MARK: - Private helpers
 
 	private func setThumbnailPosition() {
-		if !UIDevice.current.isIpad, UIDevice.current.orientation.isPortrait {
+		if !UIDevice.current.isIpad, UIScreen.main.traitCollection.verticalSizeClass == .regular {
 			self.thumbnailViewPosition = .bottom
 		} else {
 			self.thumbnailViewPosition = .right
 		}
-	}
-
-	@objc func rotated() {
-		setThumbnailPosition()
-		setupConstraints()
 	}
 
 	private func calculateThumbnailSize() {


### PR DESCRIPTION
## Description
This PR changes the position of the PDF thumbnail view on the iPad from the bottom to the right position.

## Related Issue

## Motivation and Context
There are some reasons why the right position makes more sense:

- more visible (PDF) content, if the thumbnail view is on the right side
- if the thumbnail view is on the bottom, sometimes scrolling gesture activate the iOS app switcher

## How Has This Been Tested?
- open a PDF on the iPad
- thumbnail view should appear in landscape and portrait mode on the right side
- open a PDF on the iPhone
- thumbnail view should appear in landscape mode on the right, in portrait mode on the bottom

## Screenshots (if appropriate):
| Old version                                                                                                                                                                                  | Updated version                                                                                                                                                                              |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-02-22 at 11 04 11](https://user-images.githubusercontent.com/736109/108829138-17509c80-75c8-11eb-9fe3-0cbf2b93b628.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-02-22 at 11 08 23](https://user-images.githubusercontent.com/736109/108829143-191a6000-75c8-11eb-8607-188841cbbce7.png) |


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

## QA

- [ ] (1) Weird behaviour in iPhone portrait https://github.com/owncloud/ios-app/pull/905#issuecomment-787780425  