### PR TITLE
[feature/owncloud-online-screentshots] Create Screenshots for Branded Builds with Fastlane

### DIFF
--- a/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
+++ b/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
@@ -65,7 +65,7 @@ class ScreenshotsTests: XCTestCase {
 			brandedAppSetup(app: app)
 
 			let tablesQuery = app.tables
-			tablesQuery.staticTexts[accountName].firstMatch.tap()
+			app.navigationBars[accountName].buttons["Manage"].tap()
 
 			snapshot("11_ios_accounts_list_demo")
 

--- a/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
+++ b/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
@@ -23,10 +23,12 @@ import ownCloudSDK
 
 class ScreenshotsTests: XCTestCase {
 
-	let serverDescription = "ownCloud"
+	var accountName = "ownCloud"
+	let takeBrandedScreenshots = true
+
 	let url = "demo.owncloud.com"
- 	let user = "admin"
- 	let password = "admin"
+	let user = "admin"
+	let password = "admin"
 
 	override func setUp() {
 		super.setUp()
@@ -45,6 +47,43 @@ class ScreenshotsTests: XCTestCase {
 		setupSnapshot(app)
 		app.launch()
 
+		if !takeBrandedScreenshots {
+			regularAppSetup(app: app)
+
+			// Workaround: Open the File List to dismiss keyboard
+			prepareFileList(app: app)
+			app.navigationBars[accountName].buttons["Accounts"].tap()
+
+			snapshot("11_ios_accounts_list_demo")
+			prepareFileList(app: app)
+
+			if waitForDocumentsCell(app: app) != .completed {
+				XCTFail("Error: File list not loaded")
+			}
+		} else {
+			accountName = "ownCloud.online"
+			brandedAppSetup(app: app)
+
+			let tablesQuery = app.tables
+			tablesQuery.staticTexts[accountName].firstMatch.tap()
+
+			snapshot("11_ios_accounts_list_demo")
+
+			tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Access Files"]/*[[".cells.staticTexts[\"Access Files\"]",".staticTexts[\"Access Files\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+		}
+
+		preparePDFFile(app: app)
+		preparePhotos(app: app)
+		prepareQuickAccess(app: app)
+
+		if UIDevice.current.userInterfaceIdiom == .pad {
+			prepareMultipleWindows(app: app)
+		}
+
+		XCTAssert(true, "Screenshots taken")
+	}
+
+	func regularAppSetup(app: XCUIApplication) {
 		addUIInterruptionMonitor(withDescription: "System Dialog") {
 			(alert) -> Bool in
 			alert.buttons["Allow"].tap()
@@ -63,7 +102,7 @@ class ScreenshotsTests: XCTestCase {
 			XCTFail("Error: Account Button not available")
 		}
 		//Add account
-		let credentials : [String : String] = ["url" : url, "user" : user, "password" : password, "serverDescription" : serverDescription]
+		let credentials : [String : String] = ["url" : url, "user" : user, "password" : password, "serverDescription" : accountName]
 		addAccount(app: app, credentials: credentials)
 
 		if waitForAddAccountButton(app: app) != .completed {
@@ -81,25 +120,36 @@ class ScreenshotsTests: XCTestCase {
 		//Add account
 		let credentialsDemo2 : [String : String] = ["url" : url, "user" : user, "password" : password, "serverDescription" : "admin@demo.owncloud.com"]
 		addAccount(app: app, credentials: credentialsDemo2)
+	}
 
-		// Workaround: Open the File List to dismiss keyboard
-		prepareFileList(app: app)
-		app.navigationBars["ownCloud"].buttons["Accounts"].tap()
-		snapshot("11_ios_accounts_list_demo")
-		prepareFileList(app: app)
+	func brandedAppSetup(app: XCUIApplication) {
+		snapshot("10_ios_accounts_welcome_demo")
 
-		if waitForDocumentsCell(app: app) != .completed {
-			XCTFail("Error: File list not loaded")
+		//Settings
+		app.toolbars["Toolbar"].buttons["settingsBarButtonItem"].tap()
+		snapshot("60_ios_settings_demo")
+		app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+
+		let tablesQuery = app.tables
+		tablesQuery/*@START_MENU_TOKEN@*/.textFields["url"]/*[[".cells",".textFields[\"https:\/\/\"]",".textFields[\"url\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
+		tablesQuery/*@START_MENU_TOKEN@*/.textFields["url"]/*[[".cells",".textFields[\"https:\/\/\"]",".textFields[\"url\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.typeText(url)
+		tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Continue"]/*[[".buttons[\"Continue\"].staticTexts[\"Continue\"]",".staticTexts[\"Continue\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+		tablesQuery/*@START_MENU_TOKEN@*/.textFields["username"]/*[[".cells",".textFields[\"Username\"]",".textFields[\"username\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
+		tablesQuery/*@START_MENU_TOKEN@*/.textFields["username"]/*[[".cells",".textFields[\"Username\"]",".textFields[\"username\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.typeText(user)
+
+		let passwordSecureTextField = tablesQuery/*@START_MENU_TOKEN@*/.secureTextFields["password"]/*[[".cells",".secureTextFields[\"Password\"]",".secureTextFields[\"password\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/
+		passwordSecureTextField.tap()
+		passwordSecureTextField.typeText(password)
+		tablesQuery.buttons["Login"].tap()
+
+		addUIInterruptionMonitor(withDescription: "System Dialog") {
+			(alert) -> Bool in
+			alert.buttons["Allow"].tap()
+			return true
 		}
-		preparePDFFile(app: app)
-		preparePhotos(app: app)
-		prepareQuickAccess(app: app)
+		app.tap()
 
-		if UIDevice.current.userInterfaceIdiom == .pad {
-			prepareMultipleWindows(app: app)
-		}
-
-		XCTAssert(true, "Screenshots taken")
+		tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Access Files"]/*[[".cells.staticTexts[\"Access Files\"]",".staticTexts[\"Access Files\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
 	}
 
 	func addAccount(app: XCUIApplication, credentials: [String : String]) {
@@ -131,7 +181,7 @@ class ScreenshotsTests: XCTestCase {
 			XCTFail("Error: Account list not loaded")
 		}
 		let tablesQuery = app.tables
-		tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["ownCloud"]/*[[".cells[\"server-bookmark-cell\"].staticTexts[\"ownCloud\"]",".staticTexts[\"ownCloud\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.firstMatch.tap()
+		tablesQuery.staticTexts[accountName].firstMatch.tap()
 	}
 
 	func preparePDFFile(app: XCUIApplication) {
@@ -158,7 +208,7 @@ class ScreenshotsTests: XCTestCase {
 		scrollViewsQuery.children(matching: .other).element.children(matching: .other).element.swipeLeft()
 		scrollViewsQuery.children(matching: .other).element.children(matching: .other).element.swipeLeft()
 		snapshot("22_ios_files_preview_pdf_demo")
-		app.navigationBars["ownCloud Manual.pdf"].buttons["ownCloud"].tap()
+		app.navigationBars["ownCloud Manual.pdf"].buttons[accountName].tap()
 	}
 
 	func preparePhotos(app: XCUIApplication) {
@@ -176,7 +226,7 @@ class ScreenshotsTests: XCTestCase {
 		sleep(5)
 
 		snapshot("20_ios_files_list_demo")
-		app.navigationBars["Photos"].buttons["ownCloud"].tap()
+		app.navigationBars["Photos"].buttons[accountName].tap()
 	}
 
 	func prepareQuickAccess(app: XCUIApplication) {
@@ -216,7 +266,7 @@ class ScreenshotsTests: XCTestCase {
 
 	func waitForAccountList(app: XCUIApplication) -> XCTWaiter.Result {
 		let tablesQuery = app.tables
-		let tableCell = tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["ownCloud"]/*[[".cells[\"server-bookmark-cell\"].staticTexts[\"ownCloud\"]",".staticTexts[\"ownCloud\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.firstMatch
+		let tableCell = tablesQuery.staticTexts[accountName].firstMatch
 		let predicate = NSPredicate(format: "exists == 1")
 		let ocExpectation = expectation(for: predicate, evaluatedWith: tableCell, handler: nil)
 
@@ -243,7 +293,7 @@ class ScreenshotsTests: XCTestCase {
 	}
 
 	func waitForPDFViewer(app: XCUIApplication) -> XCTWaiter.Result {
-		let element = app.navigationBars["ownCloud Manual.pdf"].buttons["ownCloud"]
+		let element = app.navigationBars["ownCloud Manual.pdf"].buttons[accountName]
 		let predicate = NSPredicate(format: "exists == 1")
 		let ocExpectation = expectation(for: predicate, evaluatedWith: element, handler: nil)
 

--- a/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
+++ b/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
@@ -149,7 +149,8 @@ class ScreenshotsTests: XCTestCase {
 		}
 		app.tap()
 
-		tablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Access Files"]/*[[".cells.staticTexts[\"Access Files\"]",".staticTexts[\"Access Files\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+		let accountTablesQuery = app.tables
+		accountTablesQuery/*@START_MENU_TOKEN@*/.staticTexts["Access Files"]/*[[".cells.staticTexts[\"Access Files\"]",".staticTexts[\"Access Files\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
 	}
 
 	func addAccount(app: XCUIApplication, credentials: [String : String]) {
@@ -185,6 +186,9 @@ class ScreenshotsTests: XCTestCase {
 	}
 
 	func preparePDFFile(app: XCUIApplication) {
+		if waitForPDFCell(app: app) != .completed {
+			XCTFail("Error: Could not open PDF")
+		}
 		let tablesQuery = app.tables
 		tablesQuery.staticTexts["ownCloud Manual.pdf"].tap()
 
@@ -285,6 +289,15 @@ class ScreenshotsTests: XCTestCase {
 
 	func waitForDocumentsCell(app: XCUIApplication) -> XCTWaiter.Result {
 		let element = app.tables.cells.staticTexts["Documents"]
+		let predicate = NSPredicate(format: "exists == 1")
+		let ocExpectation = expectation(for: predicate, evaluatedWith: element, handler: nil)
+
+		let result = XCTWaiter().wait(for: [ocExpectation], timeout: 15)
+		return result
+	}
+
+	func waitForPDFCell(app: XCUIApplication) -> XCTWaiter.Result {
+		let element = app.tables.cells.staticTexts["ownCloud Manual.pdf"]
 		let predicate = NSPredicate(format: "exists == 1")
 		let ocExpectation = expectation(for: predicate, evaluatedWith: element, handler: nil)
 

--- a/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
+++ b/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
@@ -24,7 +24,7 @@ import ownCloudSDK
 class ScreenshotsTests: XCTestCase {
 
 	var accountName = "ownCloud"
-	let takeBrandedScreenshots = true
+	let takeBrandedScreenshots = false
 
 	let url = "demo.owncloud.com"
 	let user = "admin"


### PR DESCRIPTION
## Description
Changed the screenshot UI tests to support creating screenshots from branded builds like ownCloud.online.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Automatically generate UI screenshots from a branded build

## How Has This Been Tested?
- change variable `let takeBrandedScreenshots` to `true` in `ownCloudScreenshotsTests.swift`
- run fastlane with the following command: `fastlane release_on_appstore create_release_notes:false create_screenshots:true deliver:false build_regular_app:false build_emm_app:false build_owncloud_online_app:true`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

