### PR TITLE
Accessing hyper links in PDF view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ ownCloud admins and users.
 Summary
 -------
 
+* Bugfix - Accessing hyperlinks in PDF documents: [#4432](https://github.com/owncloud/enterprise/issues/4432)
 * Bugfix - PDF thumbnail view position on the iPad: [#905](https://github.com/owncloud/ios-app/pull/905)
 * Bugfix - Misplaced Collapsible Progress Bar in detail view: [#906](https://github.com/owncloud/ios-app/issues/906)
 
 Details
 -------
+
+* Bugfix - Accessing hyperlinks in PDF documents: [#4432](https://github.com/owncloud/enterprise/issues/4432)
+
+   Tap on hyperlinks in PDF documents opens the link.
+
+   https://github.com/owncloud/enterprise/issues/4432
 
 * Bugfix - PDF thumbnail view position on the iPad: [#905](https://github.com/owncloud/ios-app/pull/905)
 

--- a/changelog/unreleased/4432
+++ b/changelog/unreleased/4432
@@ -1,0 +1,4 @@
+Bugfix: Accessing hyperlinks in PDF documents
+Tap on hyperlinks in PDF documents opens the link.
+
+https://github.com/owncloud/enterprise/issues/4432

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -145,7 +145,7 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 				pdfView.displayDirection = .horizontal
 				pdfView.translatesAutoresizingMaskIntoConstraints = false
 				pdfView.usePageViewController(true, withViewOptions: nil)
-                pdfView.delegate = self
+				pdfView.delegate = self
 				containerView.addArrangedSubview(pdfView)
 
 				pageCountContainerView.translatesAutoresizingMaskIntoConstraints = false

--- a/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
+++ b/ownCloud/Client/Viewer/PDF/PDFViewerViewController.swift
@@ -20,6 +20,7 @@ import UIKit
 import ownCloudSDK
 import ownCloudAppShared
 import PDFKit
+import SafariServices
 
 extension UILabel {
 	func _setupPdfInfoLabel() {
@@ -144,6 +145,7 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 				pdfView.displayDirection = .horizontal
 				pdfView.translatesAutoresizingMaskIntoConstraints = false
 				pdfView.usePageViewController(true, withViewOptions: nil)
+                pdfView.delegate = self
 				containerView.addArrangedSubview(pdfView)
 
 				pageCountContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -205,7 +207,7 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 
 		if #available(iOS 13, *) {
 			let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.toggleFullscreen(_:)))
-			tapRecognizer.numberOfTapsRequired = 1
+			tapRecognizer.numberOfTapsRequired = 2
 			pdfView.addGestureRecognizer(tapRecognizer)
 		}
 		//pdfView.isUserInteractionEnabled = true
@@ -497,4 +499,11 @@ class PDFViewerViewController: DisplayViewController, DisplayExtension {
 		let maxPageCountText = "\(pdf.pageCount)"
 		pageCountLabel.text = NSString(format: "%@ of %@".localized as NSString, pageNrText, maxPageCountText) as String
 	}
+}
+
+extension PDFViewerViewController : PDFViewDelegate {
+    func pdfViewWillClick(onLink sender: PDFView, with url: URL) {
+        let vc = SFSafariViewController(url: url)
+        present(vc, animated: true)
+    }
 }


### PR DESCRIPTION
- Full screen mode in PDF view now requires to taps to hide bars

<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
- Tap on link opens it in SFSafariViewController which runs as separate process.
- Now full screen mode requires two taps instead of one since otherwise tapping links won't be possible due to collisions with UIGestureRecognizer instances used by PDFView internally.

## Related Issue
#4432

## Motivation and Context
Opening links in PDF was not possible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

