### PR TITLE
[fix/calens-git-references] Fix Calens Git references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog for ownCloud iOS Client [11.5.2] (2020-03-03)
 The following sections list the changes in ownCloud iOS Client 11.5.2 relevant to
 ownCloud admins and users.
 
-[11.5.2]: https://github.com/owncloud/client/compare/v11.5.1...v11.5.2
+[11.5.2]: https://github.com/owncloud/ios-app/compare/milestone/11.5.1...milestone/11.5.2
 
 Summary
 -------
@@ -40,7 +40,7 @@ Changelog for ownCloud iOS Client [11.5.1] (2020-02-17)
 The following sections list the changes in ownCloud iOS Client 11.5.1 relevant to
 ownCloud admins and users.
 
-[11.5.1]: https://github.com/owncloud/client/compare/v11.5.0...v11.5.1
+[11.5.1]: https://github.com/owncloud/ios-app/compare/milestone/11.5.0...milestone/11.5.1
 
 Summary
 -------
@@ -61,7 +61,7 @@ Changelog for ownCloud iOS Client [11.5.0] (2020-02-10)
 The following sections list the changes in ownCloud iOS Client 11.5.0 relevant to
 ownCloud admins and users.
 
-
+[11.5.0]: https://github.com/owncloud/ios-app/compare/milestone/11.5.0...milestone/11.5.0
 
 Summary
 -------

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -10,15 +10,15 @@ ownCloud admins and users.
 {{ if ne (len $allVersions) $next -}}
 {{ $previousVersion := (index $allVersions $next).Version -}}
 {{ if eq .Version "unreleased" -}}
-[{{ .Version }}]: https://github.com/owncloud/client/compare/v{{ $previousVersion }}...master
+[{{ .Version }}]: https://github.com/owncloud/ios-app/compare/milestone/{{ $previousVersion }}...master
 {{- else -}}
-[{{ .Version }}]: https://github.com/owncloud/client/compare/v{{ $previousVersion }}...v{{ .Version }}
+[{{ .Version }}]: https://github.com/owncloud/ios-app/compare/milestone/{{ $previousVersion }}...milestone/{{ .Version }}
 {{- end -}}
 {{ end -}}
 
 {{- /* last version managed by calens, end of the loop */ -}}
-{{ if eq .Version "2.6.2" -}}
-[{{ .Version }}]: https://github.com/owncloud/client/compare/v2.6.1...v{{ .Version }}
+{{ if eq .Version "11.5.0" -}}
+[{{ .Version }}]: https://github.com/owncloud/ios-app/compare/milestone/11.5.0...milestone/{{ .Version }}
 {{- end }}
 
 Summary


### PR DESCRIPTION
## Description
The Calens repo had some references inside the template, which pointed to the `client` repository. Furthermore the `milestone` branch pattern is used, instead of the `v` branch prefix.

- removed client repo with ios-app repo
- using milestone branch names, instead of v prefix

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

