### PR TITLE
[fix/auto-page-scrolling] Auto Enable Page Scrolling in Detail View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/client/compare/v11.5.2...master
+
+Summary
+-------
+
+* Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
+
+Details
+-------
+
+* Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
+
+   Prevent page container scrolling, when try to scroll inside the pdf thumbnail view on the
+   iPhone
+
+   https://github.com/owncloud/ios-app/issues/918
+
 Changelog for ownCloud iOS Client [11.5.2] (2020-03-03)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.5.2 relevant to

--- a/changelog/unreleased/918
+++ b/changelog/unreleased/918
@@ -1,0 +1,5 @@
+Bugfix: Swiping PDF thumbnail view on the iPhone
+
+Prevent page container scrolling, when try to scroll inside the pdf thumbnail view on the iPhone
+
+https://github.com/owncloud/ios-app/issues/918

--- a/ownCloud/Client/Viewer/DisplayHostViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayHostViewController.swift
@@ -38,6 +38,9 @@ class DisplayHostViewController: UIPageViewController {
 	public var items: [OCItem]? {
 		didSet {
 			playableItems = items?.filter({ $0.isPlayable })
+			OnMainThread {
+				self.autoEnablePageScrolling()
+			}
 		}
 	}
 
@@ -120,6 +123,12 @@ class DisplayHostViewController: UIPageViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlayNextMedia(notification:)), name: MediaDisplayViewController.MediaPlaybackNextTrackNotification, object: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlayPreviousMedia(notification:)), name: MediaDisplayViewController.MediaPlaybackPreviousTrackNotification, object: nil)
+	}
+
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+
+		self.autoEnablePageScrolling()
 	}
 
 	override var childForHomeIndicatorAutoHidden : UIViewController? {
@@ -360,4 +369,14 @@ extension DisplayHostViewController {
             }
         }
     }
+}
+
+extension DisplayHostViewController {
+	private var scrollView: UIScrollView? {
+		return view.subviews.compactMap { $0 as? UIScrollView }.first
+	}
+
+	private func autoEnablePageScrolling() {
+		self.scrollView?.isScrollEnabled = (self.items?.count ?? 0 < 2) ? false : true
+	}
 }


### PR DESCRIPTION
## Description
- disable page scrolling if less than two items inside the page view controller
- prevent page scrolling, when try to scroll inside the pdf thumbnail view on the iPhone

## Related Issue
#918 

## Motivation and Context
PDF Thumbnail View not working good 

## How Has This Been Tested?
- open PDF in detail view on and scroll inside the thumbnail view
- whole PDF view should not be scrollable
- open a folder with at least two images
- check if it is possible to scroll between images

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

