### PR TITLE
[feature/align-bookmark-names] Align bookmark names with Android and web

### DIFF
--- a/ownCloud/Bookmarks/BookmarkViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkViewController.swift
@@ -861,9 +861,10 @@ class BookmarkViewController: StaticTableViewController {
 
 		// URL
 		if urlRow != nil, fieldSelector(urlRow!) {
-			if bookmark.originURL != nil {
+			/* if bookmark.originURL != nil {
 				urlRow?.value = bookmark.originURL?.absoluteString
-			} else if bookmark.url != nil {
+			} else */
+			if bookmark.url != nil {
 				urlRow?.value = bookmark.url?.absoluteString
 			} else {
 				urlRow?.value = ""

--- a/ownCloud/Bookmarks/BookmarkViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkViewController.swift
@@ -861,9 +861,6 @@ class BookmarkViewController: StaticTableViewController {
 
 		// URL
 		if urlRow != nil, fieldSelector(urlRow!) {
-			/* if bookmark.originURL != nil {
-				urlRow?.value = bookmark.originURL?.absoluteString
-			} else */
 			if bookmark.url != nil {
 				urlRow?.value = bookmark.url?.absoluteString
 			} else {

--- a/ownCloud/Server List/ServerListBookmarkCell.swift
+++ b/ownCloud/Server List/ServerListBookmarkCell.swift
@@ -105,7 +105,7 @@ class ServerListBookmarkCell : ThemeTableViewCell {
 		didSet {
 			if let bookmark = bookmark {
 				titleLabel.text = bookmark.shortName
-				detailLabel.text = /* (bookmark.originURL != nil) ? bookmark.originURL!.absoluteString : */ bookmark.url?.absoluteString
+				detailLabel.text = bookmark.url?.absoluteString
 				accessibilityIdentifier = "server-bookmark-cell"
 
 				if directMessageCountTrackingEnabled {

--- a/ownCloud/Server List/ServerListBookmarkCell.swift
+++ b/ownCloud/Server List/ServerListBookmarkCell.swift
@@ -105,7 +105,7 @@ class ServerListBookmarkCell : ThemeTableViewCell {
 		didSet {
 			if let bookmark = bookmark {
 				titleLabel.text = bookmark.shortName
-				detailLabel.text = (bookmark.originURL != nil) ? bookmark.originURL!.absoluteString : bookmark.url?.absoluteString
+				detailLabel.text = /* (bookmark.originURL != nil) ? bookmark.originURL!.absoluteString : */ bookmark.url?.absoluteString
 				accessibilityIdentifier = "server-bookmark-cell"
 
 				if directMessageCountTrackingEnabled {

--- a/ownCloudAppFramework/SDK Extensions/OCBookmark+AppExtensions.m
+++ b/ownCloudAppFramework/SDK Extensions/OCBookmark+AppExtensions.m
@@ -51,11 +51,13 @@
 			userNamePrefix = [userName stringByAppendingString:@"@"];
 		}
 
-		if (self.originURL.host != nil)
+		/* if (self.originURL.host != nil)
 		{
 			return ([userNamePrefix stringByAppendingString:self.originURL.host]);
 		}
-		else if (self.url.host != nil)
+		else
+		*/
+		if (self.url.host != nil)
 		{
 			return ([userNamePrefix stringByAppendingString:self.url.host]);
 		}

--- a/ownCloudAppFramework/SDK Extensions/OCBookmark+AppExtensions.m
+++ b/ownCloudAppFramework/SDK Extensions/OCBookmark+AppExtensions.m
@@ -51,12 +51,6 @@
 			userNamePrefix = [userName stringByAppendingString:@"@"];
 		}
 
-		/* if (self.originURL.host != nil)
-		{
-			return ([userNamePrefix stringByAppendingString:self.originURL.host]);
-		}
-		else
-		*/
 		if (self.url.host != nil)
 		{
 			return ([userNamePrefix stringByAppendingString:self.url.host]);


### PR DESCRIPTION
## Description
Previously, the account list and auto-generated name used the redirect origin URL rather than the effective URL due to a [multi tenancy](https://github.com/owncloud/administration/tree/master/redirectServer) edge case. 

It now uses the effective URL:
- in the account list
- in the URL field of the edit bookmark view
- in the auto-generated `shortName` of the account

## Screenshots (if appropriate):

Client | Screenshot
------|------
Web | <img width="551" alt="O Connected to httpsocis ocis-traefik latest owncloud works as Albert Einstein" src="https://user-images.githubusercontent.com/639669/110548956-a665c480-8131-11eb-94e2-db006ad90fc6.png">
Android | ![Albert Einstein](https://user-images.githubusercontent.com/639669/110548926-9c43c600-8131-11eb-9790-01430f654a55.png)
iOS (before) | <img width="353" alt="Albert Einstein@ocis owncloud works" src="https://user-images.githubusercontent.com/639669/110549010-bc738500-8131-11eb-8eac-c94700720da8.png">
iOS (after) | <img width="356" alt="Bildschirmfoto 2021-03-09 um 23 39 26" src="https://user-images.githubusercontent.com/639669/110549040-cac1a100-8131-11eb-8a64-e865ac584230.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Alignment / New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
