### PR TITLE
[fix/oc-online-theme-colors] Updated ownCloud.online Toolbar /Tab Bar Color

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -248,11 +248,11 @@ platform :ios do
           prepare_metadata(
           	create_release_notes: options[:create_release_notes],
           	create_screenshots: options[:create_screenshots],
-          	app_name: "ownCloud.online",
+          	app_name: "ownCloud Online",
           	metadata_path: 'fastlane/metadata-owncloud-online/en-US/release_notes.txt'
           )
           
-        puts("Build ownCloud.online iOS App…")
+        puts("Build ownCloud Online iOS App…")
 
         # Moving the ownCloud.online Branding.plist to the correct place
         sh "mv ../ownCloud/Resources/Theming/Branding.plist ../ownCloud/Resources/Theming/Branding-regular.plist"
@@ -359,7 +359,7 @@ lane :owncloud_online_build do
     EXPORT_METHOD: "app-store",
     CONFIGURATION: "Debug",
     BETA_APP_ICON: false,
-    APP_NAME: "ownCloud.online"
+    APP_NAME: "ownCloud Online"
   )
 end
 

--- a/ownCloud/Resources/Theming/Branding-owncloud-online.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online.plist
@@ -145,7 +145,7 @@
 		<key>Tab</key>
 		<dict>
 			<key>Active</key>
-			<string>#000000</string>
+			<string>#00af90</string>
 			<key>Inactive</key>
 			<string>#777777</string>
 		</dict>
@@ -368,11 +368,11 @@
 				<key>Toolbar</key>
 				<dict>
 					<key>backgroundColor</key>
-					<string>Corporate.Color</string>
+					<string>Background.Standard</string>
 					<key>labelColor</key>
 					<string>Text.Inverse</string>
 					<key>secondaryLabelColor</key>
-					<string></string>
+					<string>Tab.Inactive</string>
 					<key>symbolColor</key>
 					<string></string>
 					<key>tintColor</key>

--- a/ownCloud/Resources/Theming/Branding-owncloud-online.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online.plist
@@ -7,7 +7,7 @@
 	<key>branding.can-edit-account</key>
 	<true/>
 	<key>branding.organization-name</key>
-	<string>ownCloud.online</string>
+	<string>ownCloud Online</string>
 	<key>branding.send-feedback-address</key>
 	<string></string>
 	<key>branding.profile-definitions</key>

--- a/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
+++ b/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
@@ -358,7 +358,6 @@ public class ThemeCollection : NSObject {
 				// Bars
 				self.navigationBarColors = colors.resolveThemeColorCollection("NavigationBar", self.darkBrandColors)
 				self.toolbarColors = colors.resolveThemeColorCollection("Toolbar", self.darkBrandColors)
-				self.toolbarColors.secondaryLabelColor = .lightGray
 				self.searchBarColors = colors.resolveThemeColorCollection("Searchbar", self.darkBrandColors)
 				self.loginColors = colors.resolveThemeColorCollection("Login", self.darkBrandColors)
 

--- a/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
+++ b/ownCloudScreenshotsTests/ownCloudScreenshotsTests.swift
@@ -61,7 +61,7 @@ class ScreenshotsTests: XCTestCase {
 				XCTFail("Error: File list not loaded")
 			}
 		} else {
-			accountName = "ownCloud.online"
+			accountName = "ownCloud Online"
 			brandedAppSetup(app: app)
 
 			let tablesQuery = app.tables


### PR DESCRIPTION
- updated toolbar / tab bar colors for ownCloud.online theme
- removed fixed secondary label color in light theme mode (which affects all branded themes)
- changed app name `ownCloud.online` to `ownCloud Online`

## Description
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/owncloud/enterprise/issues/4438

## Motivation and Context

## How Has This Been Tested?
- build branded app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

