### PR TITLE
[fix/japanese-input-support] Japanese Input Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,19 @@ ownCloud admins and users.
 Summary
 -------
 
+* Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
 * Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
 
 Details
 -------
+
+* Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
+
+   Fixed a problem in scan view when renaming the file name and using a Japanese keyboard layout
+   (2-Byte character). After entering a character inside the file name the text cursor jumped to
+   the end.
+
+   https://github.com/owncloud/ios-app/issues/916
 
 * Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/client/compare/v11.5.2...master
+
+Summary
+-------
+
+* Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
+
+Details
+-------
+
+* Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
+
+   Fixed a problem in scan view when renaming the file name and using a Japanese keyboard layout
+   (2-Byte character). After entering a character inside the file name the text cursor jumped to
+   the end.
+
+   https://github.com/owncloud/ios-app/issues/916
+
 Changelog for ownCloud iOS Client [11.5.2] (2020-03-03)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.5.2 relevant to

--- a/changelog/unreleased/916
+++ b/changelog/unreleased/916
@@ -1,0 +1,6 @@
+Bugfix: Japanese Input Support 
+
+Fixed a problem in scan view when renaming the file name and using a Japanese keyboard layout (2-Byte character).
+After entering a character inside the file name the text cursor jumped to the end.
+
+https://github.com/owncloud/ios-app/issues/916

--- a/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
+++ b/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
@@ -444,10 +444,6 @@ open class StaticTableViewRow : NSObject, UITextFieldDelegate {
 			cellTextField.bottomAnchor.constraint(equalTo: (cell?.contentView.bottomAnchor)!, constant:-14).isActive = true
 		}
 
-		self.updateViewFromValue = { [weak cellTextField] (row) in
-			cellTextField?.text = row.value as? String
-		}
-
 		self.updateViewAppearance = { [weak cellTextField] (row) in
 			cellTextField?.isEnabled = row.enabled
 			cellTextField?.textColor = row.enabled ? Theme.shared.activeCollection.tableRowColors.labelColor : Theme.shared.activeCollection.tableRowColors.secondaryLabelColor

--- a/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
+++ b/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
@@ -67,10 +67,11 @@ open class StaticTableViewRow : NSObject, UITextFieldDelegate {
 	public var groupIdentifier : String?
 	public var type : StaticTableViewRowType
 
+	private var doUpdateViewFromValue : Bool = true
 	public var value : Any? {
 		didSet {
-			if updateViewFromValue != nil {
-				updateViewFromValue!(self)
+			if doUpdateViewFromValue {
+				updateViewFromValue?(self)
 			}
 		}
 	}
@@ -444,6 +445,10 @@ open class StaticTableViewRow : NSObject, UITextFieldDelegate {
 			cellTextField.bottomAnchor.constraint(equalTo: (cell?.contentView.bottomAnchor)!, constant:-14).isActive = true
 		}
 
+		self.updateViewFromValue = { [weak cellTextField] (row) in
+			cellTextField?.text = row.value as? String
+		}
+
 		self.updateViewAppearance = { [weak cellTextField] (row) in
 			cellTextField?.isEnabled = row.enabled
 			cellTextField?.textColor = row.enabled ? Theme.shared.activeCollection.tableRowColors.labelColor : Theme.shared.activeCollection.tableRowColors.secondaryLabelColor
@@ -476,7 +481,9 @@ open class StaticTableViewRow : NSObject, UITextFieldDelegate {
 	}
 
 	@objc func textFieldContentChanged(_ sender: UITextField) {
+		doUpdateViewFromValue = false
 		self.value = sender.text
+		doUpdateViewFromValue = true
 
 		self.textFieldAction?(self, sender, .changed)
 	}


### PR DESCRIPTION
## Description
Fixed a problem in scan view when renaming the file name and using a Japanese keyboard layout (2-Byte character).
After entering a character inside the file name the text cursor jumped to the end.

## Related Issue
#916 

## Motivation and Context
Japanese keyboard support for all text input

## How Has This Been Tested?
- only testable on a real device
- add Japanese keyboard layout to the iOS keyboards
- Scan a document 
- Rename the file name inside the scan view
- please check if the following text fields working as expected: Public Link > Edit Link Name, Bookmark > Edit Bookmark Name


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

