### PR TITLE
[fix/qlpreview-dark-mode] Dark Mode Support for QLPreviewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Details
    mode theme was not able set the dark mode style before.
 
    https://github.com/owncloud/ios-app/issues/919
-   
+
 * Bugfix - Passcode Settings section not refreshed: [#923](https://github.com/owncloud/ios-app/issues/923)
 
    If a passcode was enabled or disabled in the settings, the UI section was not updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
+* Bugfix - Added Dark Mode Support for QLPreviewController: [#919](https://github.com/owncloud/ios-app/issues/919)
 * Change - French Localization: [#4450](https://github.com/owncloud/enterprise/issues/4450)
 * Change - Presentation Mode: [#704](https://github.com/owncloud/ios-app/issues/704)
 
@@ -21,6 +22,13 @@ Details
    iPhone
 
    https://github.com/owncloud/ios-app/issues/918
+
+* Bugfix - Added Dark Mode Support for QLPreviewController: [#919](https://github.com/owncloud/ios-app/issues/919)
+
+   Dark mode for QLPreviewController only worked, when system dark mode was used. Custom dark
+   mode theme was not able set the dark mode style before.
+
+   https://github.com/owncloud/ios-app/issues/919
 
 * Change - French Localization: [#4450](https://github.com/owncloud/enterprise/issues/4450)
 

--- a/changelog/unreleased/919
+++ b/changelog/unreleased/919
@@ -1,0 +1,5 @@
+Bugfix: Added Dark Mode Support for QLPreviewController
+
+Dark mode for QLPreviewController only worked, when system dark mode was used. Custom dark mode theme was not able set the dark mode style before.
+
+https://github.com/owncloud/ios-app/issues/919

--- a/ownCloud/Client/Viewer/DisplayViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayViewController.swift
@@ -41,7 +41,7 @@ protocol DisplayViewEditingDelegate: class {
 	func save(item: OCItem, fileURL newVersion: URL)
 }
 
-class DisplayViewController: UIViewController {
+class DisplayViewController: UIViewController, Themeable {
 
 	var item: OCItem?
 	var itemIndex: Int?
@@ -565,6 +565,15 @@ class DisplayViewController: UIViewController {
 			}
 		}
 	}
+
+	// MARK: - Themeable implementation
+	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
+		progressView.applyThemeCollection(collection)
+		cancelButton.applyThemeCollection(collection)
+		metadataInfoLabel.applyThemeCollection(collection)
+		showPreviewButton.applyThemeCollection(collection)
+		infoLabel.applyThemeCollection(collection)
+	}
 }
 
 extension DisplayViewController : OCQueryDelegate {
@@ -640,17 +649,5 @@ extension DisplayViewController {
 	func configure(_ configuration: DisplayViewConfiguration) {
 		self.item = configuration.item
 		self.core = configuration.core
-	}
-}
-
-// MARK: - Themeable implementation
-
-extension DisplayViewController : Themeable {
-	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
-		progressView.applyThemeCollection(collection)
-		cancelButton.applyThemeCollection(collection)
-		metadataInfoLabel.applyThemeCollection(collection)
-		showPreviewButton.applyThemeCollection(collection)
-		infoLabel.applyThemeCollection(collection)
 	}
 }

--- a/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
+++ b/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
@@ -19,6 +19,7 @@
 import UIKit
 import ownCloudSDK
 import QuickLook
+import ownCloudAppShared
 
 class GestureView : UIView {
 
@@ -61,6 +62,9 @@ class PreviewViewController : DisplayViewController, QLPreviewControllerDataSour
 		qlPreviewController!.didMove(toParent: self)
 		qlPreviewController?.view.isHidden = true
 		qlPreviewController!.view.addSubview(overlayView)
+		if #available(iOS 13.0, *) {
+			qlPreviewController?.overrideUserInterfaceStyle = Theme.shared.activeCollection.interfaceStyle.userInterfaceStyle
+		}
 	}
 
 	override func viewDidAppear(_ animated: Bool) {
@@ -140,6 +144,15 @@ class PreviewViewController : DisplayViewController, QLPreviewControllerDataSour
 	override func canPreviewCurrentItem() -> Bool {
 		guard let url = self.source else { return false }
 		return QLPreviewController.canPreview(url as QLPreviewItem)
+	}
+	
+	// MARK: - Themeable implementation
+	override func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
+		super.applyThemeCollection(theme: theme, collection: collection, event: event)
+
+		if #available(iOS 13, *) {
+			qlPreviewController?.overrideUserInterfaceStyle = collection.interfaceStyle.userInterfaceStyle
+		}
 	}
 }
 

--- a/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
+++ b/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
@@ -67,32 +67,6 @@ class PreviewViewController : DisplayViewController, QLPreviewControllerDataSour
 		}
 	}
 
-	override func viewDidAppear(_ animated: Bool) {
-		super.viewDidAppear(animated)
-	}
-
-	override func viewSafeAreaInsetsDidChange() {
-		super.viewSafeAreaInsetsDidChange()
-
-		if let qlPreviewController = self.qlPreviewController {
-			qlPreviewController.view.translatesAutoresizingMaskIntoConstraints = false
-
-			NSLayoutConstraint.activate([
-				qlPreviewController.view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-				qlPreviewController.view.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
-				qlPreviewController.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-				qlPreviewController.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-
-				overlayView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-				overlayView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
-				overlayView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-				overlayView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
-				])
-		}
-
-		self.view.layoutIfNeeded()
-	}
-
 	override func renderSpecificView(completion: @escaping (Bool) -> Void) {
 		if source != nil {
 			if self.qlPreviewController?.dataSource === self {
@@ -100,6 +74,21 @@ class PreviewViewController : DisplayViewController, QLPreviewControllerDataSour
 				self.qlPreviewController?.reloadData()
 			} else {
 				// First display
+				if let qlPreviewController = self.qlPreviewController {
+					qlPreviewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+					NSLayoutConstraint.activate([
+						qlPreviewController.view.topAnchor.constraint(equalTo: self.view.topAnchor),
+						qlPreviewController.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+						qlPreviewController.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+						qlPreviewController.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+
+						overlayView.topAnchor.constraint(equalTo: self.view.topAnchor),
+						overlayView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+						overlayView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+						overlayView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+						])
+				}
 				self.showHideBarsTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.showHideBars))
 				self.showHideBarsTapGestureRecognizer.delegate = self
 				self.showHideBarsTapGestureRecognizer.numberOfTapsRequired = 1
@@ -145,7 +134,7 @@ class PreviewViewController : DisplayViewController, QLPreviewControllerDataSour
 		guard let url = self.source else { return false }
 		return QLPreviewController.canPreview(url as QLPreviewItem)
 	}
-	
+
 	// MARK: - Themeable implementation
 	override func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {
 		super.applyThemeCollection(theme: theme, collection: collection, event: event)


### PR DESCRIPTION
## Description

Added Dark Mode Support for QLPreviewController

- added themeable protocol
- setting style in protocol and after init view
- moved themeable protocol of superclass from extension in class to override it in subclass
- added changelog issue

## Related Issue
#919 

## Motivation and Context
Provide dark mode support for all UI elements

## How Has This Been Tested?
Best test scenario:
- open two app instances side-by-side on the iPad
- open a text file on the left side
- open the theme app settings on the right side
- change theme setting to `Dark` > text view background should be dark
- change theme setting to `Classic` > text view background should be white
- change theme setting to `Light` > text view background should be white
- change theme setting to `System Appearance` > iOS setting: Light > text view background should be dark
- change theme setting to `System Appearance` > iOS setting: Dark > text view background should be white

## Screenshots (if appropriate):

![Simulator Screen Shot - iPad Air (4th generation) - 2021-03-17 at 11 30 13](https://user-images.githubusercontent.com/736109/111453743-33051980-8714-11eb-86ed-fa9a47ce8d7c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

## QA

Findings

- [ ] (1) iPad landscape https://github.com/owncloud/ios-app/pull/932#issuecomment-810003557