### PR TITLE
[fix/enable-markup-editing] Improved Enabling Markup Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ownCloud admins and users.
 Summary
 -------
 
+* Bugfix - Enabling Markup Mode: [#4468](https://github.com/owncloud/enterprise/issues/4468)
 * Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
 * Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
 * Bugfix - Added Dark Mode Support for QLPreviewController: [#919](https://github.com/owncloud/ios-app/issues/919)
@@ -19,6 +20,12 @@ Summary
 
 Details
 -------
+
+* Bugfix - Enabling Markup Mode: [#4468](https://github.com/owncloud/enterprise/issues/4468)
+
+   In some cases enabling markup mode failed.
+
+   https://github.com/owncloud/enterprise/issues/4468
 
 * Bugfix - Japanese Input Support: [#916](https://github.com/owncloud/ios-app/issues/916)
 

--- a/changelog/unreleased/4468
+++ b/changelog/unreleased/4468
@@ -1,0 +1,5 @@
+Bugfix: Enabling Markup Mode
+
+In some cases enabling markup mode failed.
+
+https://github.com/owncloud/enterprise/issues/4468

--- a/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
@@ -18,6 +18,7 @@
 
 import ownCloudSDK
 import ownCloudAppShared
+import QuickLook
 
 @available(iOS 13.0, *)
 class DocumentEditingAction : Action {
@@ -79,10 +80,18 @@ class DocumentEditingAction : Action {
 			} else {
 				guard let files = files, files.count > 0, let viewController = hostViewController else { return }
 				if let fileURL = files.first?.url, let item = self.context.items.first {
-					let editDocumentViewController = EditDocumentViewController(with: fileURL, item: item, core: self.core)
-					let navigationController = ThemeNavigationController(rootViewController: editDocumentViewController)
-					navigationController.modalPresentationStyle = .overFullScreen
-					viewController.present(navigationController, animated: true)
+
+					if QLPreviewController.canPreview(fileURL as QLPreviewItem) {
+
+						let editDocumentViewController = EditDocumentViewController(with: fileURL, item: item, core: self.core)
+						let navigationController = ThemeNavigationController(rootViewController: editDocumentViewController)
+						navigationController.modalPresentationStyle = .overFullScreen
+						viewController.present(navigationController, animated: true)
+					} else {
+						let alertController = ThemedAlertController(with: "Markup".localized, message: "File couldn't be opened".localized, okLabel: "OK".localized, action: nil)
+
+						hostViewController?.present(alertController, animated: true)
+					}
 				}
 			}
 		}

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -30,6 +30,7 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 	var itemTracker: OCCoreItemTracking?
 	var modifiedContentsURL: URL?
 	var dismissedViewWithoutSaving: Bool = false
+	var timer: DispatchSourceTimer?
 
 	var source: URL {
 		didSet {
@@ -95,26 +96,45 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		}
 	}
 
-	override func viewDidAppear(_ animated: Bool) {
-		super.viewDidAppear(animated)
-		enableEditingMode()
+	required init?(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	deinit {
+		Theme.shared.unregister(client: self)
+		timer = nil
+	}
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		let queue = DispatchQueue(label: "com.owncloud.edit-document-queue")
+		timer = DispatchSource.makeTimerSource(queue: queue)
+		timer!.schedule(deadline: .now(), repeating: .seconds(1))
+		timer!.setEventHandler { [weak self] in
+			OnMainThread {
+				if (UIDevice.current.isIpad && self?.navigationItem.rightBarButtonItems?.count ?? 0 > 1) || (!(self?.navigationController?.isToolbarHidden ?? false)) {
+					self?.timer = nil
+					self?.enableEditingMode()
+				}
+			}
+		}
+		timer!.resume()
 	}
 
 	@objc func enableEditingMode() {
 		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
-		OnMainThread(after:1.0) {
-			if #available(iOS 14.0, *) {
-				if UIDevice.current.isIpad {
-					guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
-				 _ = markupButton.target?.perform(markupButton.action, with: markupButton)
-				} else {
-					guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
-					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
-				}
-			} else { // action and target is nil on iOS 13
-				guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
-				markupButton.sendActions(for: .touchUpInside)
+		if #available(iOS 14.0, *) {
+			if UIDevice.current.isIpad {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			} else {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
 			}
+		} else { // action and target is nil on iOS 13
+			guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
+			markupButton.sendActions(for: .touchUpInside)
 		}
 	}
 
@@ -211,18 +231,6 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		alertController.addAction(UIAlertAction(title: "OK".localized, style: .cancel, handler: nil))
 
 		self.present(alertController, animated: true, completion: nil)
-	}
-
-	required init?(coder aDecoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
-
-	deinit {
-		Theme.shared.unregister(client: self)
-	}
-
-	override func viewDidLoad() {
-		super.viewDidLoad()
 	}
 
 	func applyThemeCollection(theme: Theme, collection: ThemeCollection, event: ThemeEvent) {

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -113,7 +113,7 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 		timer!.schedule(deadline: .now(), repeating: .seconds(1))
 		timer!.setEventHandler { [weak self] in
 			OnMainThread {
-				if (UIDevice.current.isIpad && self?.navigationItem.rightBarButtonItems?.count ?? 0 > 1) || (!(self?.navigationController?.isToolbarHidden ?? false)) {
+				if self?.navigationItem.rightBarButtonItems?.count ?? 0 > 1 || !(self?.navigationController?.isToolbarHidden ?? false) {
 					self?.timer = nil
 					self?.enableEditingMode()
 				}
@@ -125,13 +125,13 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 	@objc func enableEditingMode() {
 		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
 		if #available(iOS 14.0, *) {
-			if UIDevice.current.isIpad {
-				guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
-				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
-			} else {
-				guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
-				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
-			}
+				if self.navigationItem.rightBarButtonItems?.count ?? 0 > 1 {
+					guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
+					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+				} else {
+					guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
+					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+				}
 		} else { // action and target is nil on iOS 13
 			guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
 			markupButton.sendActions(for: .touchUpInside)


### PR DESCRIPTION
## Description
In some cases enabling markup mode failed. Now implemented a solution, which checks periodically, if the markup button is available, before enabling. Furthermore implemented a check, if item could be previewed in markup action and shows an error, if not possible.

## Related Issue
https://github.com/owncloud/enterprise/issues/4467
https://github.com/owncloud/enterprise/issues/4468

## Motivation and Context
Enable markup mode reliable

## How Has This Been Tested?
Open a PDF or image file in markup mode.

Please test on iPad and iPhone, iOS 14 and iOS 13

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

