### PR TITLE
[feature/branding-review-prompt] Enable App Store Review Prompt via Branding Parameter

### DIFF
--- a/ownCloud/Resources/Theming/Branding-owncloud-online-legacy.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online-legacy.plist
@@ -6,6 +6,8 @@
 	<false/>
 	<key>canEditAccount</key>
 	<true/>
+	<key>enableReviewPrompt</key>
+	<true/>
 	<key>organizationName</key>
 	<string>ownCloud.online</string>
 	<key>feedbackMail</key>

--- a/ownCloud/Resources/Theming/Branding-owncloud-online.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online.plist
@@ -6,6 +6,8 @@
 	<false/>
 	<key>branding.can-edit-account</key>
 	<true/>
+	<key>branding.enable-review-prompt</key>
+	<true/>
 	<key>branding.organization-name</key>
 	<string>ownCloud.online</string>
 	<key>branding.send-feedback-address</key>

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -48,7 +48,8 @@
 				@"send-feedback-address" : @"ios-app@owncloud.com",
 
 				@"can-add-account" : @(YES),
-				@"can-edit-account" : @(YES)
+				@"can-edit-account" : @(YES),
+				@"enable-review-prompt" : @(NO)
 			} metadata:@{
 				@"url-documentation" : @{
 					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeURLString,
@@ -95,6 +96,13 @@
 				@"can-edit-account" : @{
 					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeBoolean,
 					OCClassSettingsMetadataKeyDescription	: @"Controls whether the user can edit accounts.",
+					OCClassSettingsMetadataKeyCategory	: @"Branding",
+					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
+				},
+
+				@"enable-review-prompt" : @{
+					OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeBoolean,
+					OCClassSettingsMetadataKeyDescription	: @"Controls whether the app should prompt for an App Store review",
 					OCClassSettingsMetadataKeyCategory	: @"Branding",
 					OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced
 				},

--- a/ownCloudAppShared/Branding/Branding+App.swift
+++ b/ownCloudAppShared/Branding/Branding+App.swift
@@ -23,6 +23,7 @@ extension OCClassSettingsKey {
 	// Permissions
 	public static let canAddAccount : OCClassSettingsKey = OCClassSettingsKey("can-add-account")
 	public static let canEditAccount : OCClassSettingsKey = OCClassSettingsKey("can-edit-account")
+	public static let enableReviewPrompt : OCClassSettingsKey = OCClassSettingsKey("enable-review-prompt")
 
 	// Profiles
 	public static let profileDefinitions : OCClassSettingsKey = OCClassSettingsKey("profile-definitions")
@@ -134,6 +135,7 @@ extension Branding : BrandingInitialization {
 
 		registerLegacyKeyPath("canAddAccount",		forClassSettingsKey: .canAddAccount)
 		registerLegacyKeyPath("canEditAccount",		forClassSettingsKey: .canEditAccount)
+		registerLegacyKeyPath("enableReviewPrompt",		forClassSettingsKey: .enableReviewPrompt)
 
 		registerLegacyKeyPath("Profiles",		forClassSettingsKey: .profileDefinitions)
 
@@ -191,6 +193,10 @@ extension Branding {
 
 	public var canEditAccount : Bool {
 		return computedValue(forClassSettingsKey: .canEditAccount) as? Bool ?? true
+	}
+
+	public var enableReviewPrompt : Bool {
+		return computedValue(forClassSettingsKey: .enableReviewPrompt) as? Bool ?? false
 	}
 
 	public var profileDefinitions : [[String : Any]]? {

--- a/ownCloudAppShared/Tools/VendorServices.swift
+++ b/ownCloudAppShared/Tools/VendorServices.swift
@@ -104,6 +104,14 @@ public class VendorServices : NSObject {
 		return Branding.shared.canEditAccount
 	}
 
+	public var enableReviewPrompt: Bool {
+		if VendorServices.shared.isBranded {
+			return Branding.shared.enableReviewPrompt
+		}
+
+		return true
+	}
+
 	public var showBetaWarning: Bool {
 		if let showBetaWarning = self.classSetting(forOCClassSettingsKey: .showBetaWarning) as? Bool {
 			return showBetaWarning
@@ -223,7 +231,6 @@ public extension OCClassSettingsKey {
 	static let showBetaWarning = OCClassSettingsKey("show-beta-warning")
 	static let isBetaBuild = OCClassSettingsKey("is-beta-build")
 	static let enableUIAnimations = OCClassSettingsKey("enable-ui-animations")
-	static let enableReviewPrompt = OCClassSettingsKey("enable-review-prompt")
 
 	static let appStoreLink = OCClassSettingsKey("app-store-link")
 	static let recommendToFriendEnabled = OCClassSettingsKey("recommend-to-friend-enabled")
@@ -238,7 +245,7 @@ extension VendorServices : OCClassSettingsSupport {
 				.isBetaBuild : true,
 				.showBetaWarning : true,
 				.enableUIAnimations: true,
-				.enableReviewPrompt: !VendorServices.shared.isBranded,
+				.enableReviewPrompt: VendorServices.shared.enableReviewPrompt,
 
 				.appStoreLink : "https://itunes.apple.com/app/id1359583808?mt=8",
 				.recommendToFriendEnabled: !VendorServices.shared.isBranded


### PR DESCRIPTION
## Description
Added a new branding parameter to enable the app store review prompt. This setting is by default set to false, but if defined in Branding.plist or provided via MDM, the value can be overridden.

## Related Issue
#939 

## Motivation and Context
Needed for ownCloud online, but makes also sense to provide this parameter to other branded clients.

## How Has This Been Tested?
- build branded app for ownCloud online
- do the review time magic to test it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

