### PR TITLE
[feature/branded-login-localization] Localized Branded Login 

### DIFF
--- a/ownCloud/Resources/Theming/Branding-owncloud-online-legacy.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online-legacy.plist
@@ -21,12 +21,6 @@
 			<string>ownCloud Online</string>
 			<key>name</key>
 			<string>ownCloud Online</string>
-			<key>welcome</key>
-			<string>Welcome to ownCloud Online</string>
-			<key>promptForPasswordAuth</key>
-			<string>Enter your username and password</string>
-			<key>promptForTokenAuth</key>
-			<string>Please log in to authorize the app.</string>
 			<key>promptForURL</key>
 			<string>Please enter your ownCloud Online URL</string>
 			<key>promptForHelpURL</key>

--- a/ownCloud/Resources/Theming/Branding-owncloud-online.plist
+++ b/ownCloud/Resources/Theming/Branding-owncloud-online.plist
@@ -19,12 +19,6 @@
 			<string>ownCloud-online</string>
 			<key>name</key>
 			<string>ownCloud Online</string>
-			<key>welcome</key>
-			<string>Welcome to ownCloud Online</string>
-			<key>promptForPasswordAuth</key>
-			<string>Enter your username and password</string>
-			<key>promptForTokenAuth</key>
-			<string>Please log in to authorize the app.</string>
 			<key>promptForURL</key>
 			<string>Please enter your ownCloud Online URL</string>
 			<key>promptForHelpURL</key>

--- a/ownCloud/Resources/de.lproj/Localizable.strings
+++ b/ownCloud/Resources/de.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "Enter your username and password" = "Geben Sie Ihren Benutzernamen und Ihr Passwort ein";
 "Please log in to authorize the app." = "Bitte melden Sie sich an, um die App zu autorisieren.";
 "Welcome to %@" = "Willkommen bei %@";
+"Please enter a server URL" = "Bitte geben Sie eine Server-URL ein";
 
 /* Single Account */
 "You are connected as\n%@" = "Sie sind verbunden als\n%@";

--- a/ownCloud/Resources/de.lproj/Localizable.strings
+++ b/ownCloud/Resources/de.lproj/Localizable.strings
@@ -109,6 +109,9 @@
 "The server doesn't support any allowed authentication method." = "Der Server unterstützt keine erlaubte Authentifizierungsmethode.";
 "The server doesn't support any known and allowed authentication method found." = "Der Server unterstützt keine bekannte und erlaubte Authentifizierungsmethode, die gefunden wurde.";
 "Retry detection" = "Erkennung wiederholen";
+"Enter your username and password" = "Geben Sie Ihren Benutzernamen und Ihr Passwort ein";
+"Please log in to authorize the app." = "Bitte melden Sie sich an, um die App zu autorisieren.";
+"Welcome to %@" = "Willkommen bei %@";
 
 /* Single Account */
 "You are connected as\n%@" = "Sie sind verbunden als\n%@";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -109,6 +109,9 @@
 "The server doesn't support any allowed authentication method." = "The server doesn't support any allowed authentication method.";
 "The server doesn't support any known and allowed authentication method found." = "The server doesn't support any known and allowed authentication method found.";
 "Retry detection" = "Retry detection";
+"Enter your username and password" = "Enter your username and password";
+"Please log in to authorize the app." = "Please log in to authorize the app.";
+"Welcome to %@" = "Welcome to %@";
 
 /* Single Account */
 "You are connected as\n%@" = "You are connected as\n%@";

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "Enter your username and password" = "Enter your username and password";
 "Please log in to authorize the app." = "Please log in to authorize the app.";
 "Welcome to %@" = "Welcome to %@";
+"Please enter a server URL" = "Please enter a server URL";
 
 /* Single Account */
 "You are connected as\n%@" = "You are connected as\n%@";

--- a/ownCloud/Static Login/StaticLoginProfile.swift
+++ b/ownCloud/Static Login/StaticLoginProfile.swift
@@ -60,8 +60,10 @@ class StaticLoginProfile: NSObject {
 		} else {
 			self.promptForTokenAuth = "Please log in to authorize the app.".localized
 		}
-		if let promptForURL = profileDict["promptForURL"] as? String {
+		if let promptForURL = profileDict["promptForURL"] as? String, promptForURL.count > 0 {
 			self.promptForURL = promptForURL
+		} else {
+			self.promptForURL = "Please enter a server URL".localized
 		}
 		if let promptForHelpURL = profileDict["promptForHelpURL"] as? String {
 			self.promptForHelpURL = promptForHelpURL

--- a/ownCloud/Static Login/StaticLoginProfile.swift
+++ b/ownCloud/Static Login/StaticLoginProfile.swift
@@ -50,14 +50,15 @@ class StaticLoginProfile: NSObject {
 		if let name = profileDict["name"] as? String {
 			self.name = name
 		}
-		if let prompt = profileDict["promptForTokenAuth"] as? String {
-			self.promptForTokenAuth = prompt
-		}
-		if let promptForPasswordAuth = profileDict["promptForPasswordAuth"] as? String {
+		if let promptForPasswordAuth = profileDict["promptForPasswordAuth"] as? String, promptForPasswordAuth.count > 0 {
 			self.promptForPasswordAuth = promptForPasswordAuth
+		} else {
+			self.promptForPasswordAuth = "Enter your username and password".localized
 		}
-		if let promptForTokenAuth = profileDict["promptForTokenAuth"] as? String {
+		if let promptForTokenAuth = profileDict["promptForTokenAuth"] as? String, promptForTokenAuth.count > 0 {
 			self.promptForTokenAuth = promptForTokenAuth
+		} else {
+			self.promptForTokenAuth = "Please log in to authorize the app.".localized
 		}
 		if let promptForURL = profileDict["promptForURL"] as? String {
 			self.promptForURL = promptForURL
@@ -68,8 +69,12 @@ class StaticLoginProfile: NSObject {
 		if let helpURLButtonString = profileDict["helpURLButtonString"] as? String {
 			self.helpURLButtonString = helpURLButtonString
 		}
-		if let welcome = profileDict["welcome"] as? String {
+		if let welcome = profileDict["welcome"] as? String, welcome.count > 0 {
 			self.welcome = welcome
+		} else if let name = self.name {
+			self.welcome = String(format: "Welcome to %@".localized, name)
+		} else {
+			self.welcome = "Welcome".localized
 		}
 		if let bookmarkName = profileDict["bookmarkName"] as? String {
 			self.bookmarkName = bookmarkName


### PR DESCRIPTION
## Description
Made some branded profile configuration login parameter optional for localization.
If the keys does not exists, the default localization string will be used.

## Related Issue
https://github.com/owncloud/enterprise/issues/4501

## Motivation and Context
Provide localized branded login screen

## How Has This Been Tested?
- build a  branded app (ownCloud Online)
- check if localization change in login screen, if switching to other language (at the moment only German translation is available)
- add these keys to the `Branding.plist`: `welcome` `promptForPasswordAuth` `promptForTokenAuth` `promptForURL`
- Enter your own values for these keys
- Run app and check branded login screen, if strings will be used

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

## QA

Checks performed [here](https://github.com/owncloud/ios-app/pull/948#issuecomment-823156837)