### PR TITLE
[fix/disable-gif-markup] Disable Markup Action for Mime-Type Gif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Summary
 * Bugfix - Swiping PDF thumbnail view on the iPhone: [#918](https://github.com/owncloud/ios-app/issues/918)
 * Bugfix - Added Dark Mode Support for QLPreviewController: [#919](https://github.com/owncloud/ios-app/issues/919)
 * Bugfix - Passcode Settings section not refreshed: [#923](https://github.com/owncloud/ios-app/issues/923)
+* Bugfix - Disable Markup Action for Mime-Type Gif: [#952](https://github.com/owncloud/ios-app/issues/952)
 * Change - "Go to Page" reallocated in PDF previews: [#4448](https://github.com/owncloud/enterprise/issues/4448)
 * Change - French Localization: [#4450](https://github.com/owncloud/enterprise/issues/4450)
 * Change - Presentation Mode: [#704](https://github.com/owncloud/ios-app/issues/704)
@@ -55,6 +56,12 @@ Details
    If a passcode was enabled or disabled in the settings, the UI section was not updated.
 
    https://github.com/owncloud/ios-app/issues/923
+
+* Bugfix - Disable Markup Action for Mime-Type Gif: [#952](https://github.com/owncloud/ios-app/issues/952)
+
+   Images with mime type image/gif can not edited with markup action and needs to be disabled.
+
+   https://github.com/owncloud/ios-app/issues/952
 
 * Change - "Go to Page" reallocated in PDF previews: [#4448](https://github.com/owncloud/enterprise/issues/4448)
 

--- a/changelog/unreleased/952
+++ b/changelog/unreleased/952
@@ -1,0 +1,5 @@
+Bugfix: Disable Markup Action for Mime-Type Gif
+
+Images with mime type image/gif can not edited with markup action and needs to be disabled.
+
+https://github.com/owncloud/ios-app/issues/952

--- a/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
@@ -29,7 +29,7 @@ class DocumentEditingAction : Action {
 	override class var keyModifierFlags: UIKeyModifierFlags? { return [.command] }
 	override class var locations : [OCExtensionLocationIdentifier]? { return [.moreItem, .moreDetailItem, .moreFolder, .keyboardShortcut, .contextMenuItem] }
 	class var supportedMimeTypes : [String] { return ["image", "pdf"] }
-	class var excludedMimeTypes : [String] { return ["image/x-dcraw", "image/heic"] }
+	class var excludedMimeTypes : [String] { return ["image/x-dcraw", "image/heic", "image/gif"] }
 	override class var licenseRequirements: LicenseRequirements? { return LicenseRequirements(feature: .documentMarkup) }
 
 	// MARK: - Extension matching


### PR DESCRIPTION
## Description
Images with mime type `image/gif` can not edited with markup action and needs to be disabled.

## Related Issue
#952

## Motivation and Context
Only show possible actions to the user

## How Has This Been Tested?
- add an image with mime type `image/gif` to the file list 
- check if action `Markup` is not available

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

