### PR TITLE
[fix/branded-state-restoration] Branded Login State Restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Summary
 * Bugfix - Passcode Settings Section: [#923](https://github.com/owncloud/ios-app/issues/923)
 * Bugfix - Disable Markup Action for Mime-Type Gif: [#952](https://github.com/owncloud/ios-app/issues/952)
 * Bugfix - UI refinements in action card: [#956](https://github.com/owncloud/ios-app/issues/956)
+* Bugfix - State Restoration for Branded Login: [#957](https://github.com/owncloud/ios-app/issues/957)
 * Change - "Go to Page" reallocated in PDF previews: [#4448](https://github.com/owncloud/enterprise/issues/4448)
 * Change - French Localization: [#4450](https://github.com/owncloud/enterprise/issues/4450)
 * Change - Local account-wide search using custom queries: [#53](https://github.com/owncloud/ios-app/issues/53)
@@ -73,6 +74,13 @@ Details
    view.
 
    https://github.com/owncloud/ios-app/issues/956
+
+* Bugfix - State Restoration for Branded Login: [#957](https://github.com/owncloud/ios-app/issues/957)
+
+   State restoration was not working for branded clients. This fix will restore the last shown
+   item after an app restart for branded clients.
+
+   https://github.com/owncloud/ios-app/issues/957
 
 * Change - "Go to Page" reallocated in PDF previews: [#4448](https://github.com/owncloud/enterprise/issues/4448)
 

--- a/changelog/unreleased/957
+++ b/changelog/unreleased/957
@@ -1,0 +1,6 @@
+Bugfix: State Restoration for Branded Login
+
+State restoration was not working for branded clients.
+This fix will restore the last shown item after an app restart for branded clients.
+
+https://github.com/owncloud/ios-app/issues/957

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -90,9 +90,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		   let bookmarkUUID = UUID(uuidString: bookmarkUUIDString),
 		   let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID),
 		   let navigationController = window?.rootViewController as? ThemeNavigationController,
-		   let serverListController = navigationController.topViewController as? ServerListTableViewController {
+		   let serverListController = navigationController.topViewController as? StateRestorationConnectProtocol {
 			if activity.title == OCBookmark.ownCloudOpenAccountPath {
-				serverListController.connect(to: bookmark, lastVisibleItemId: nil, animated: false)
+				serverListController.connect(to: bookmark, lastVisibleItemId: nil, animated: false, present: nil)
 				window?.windowScene?.userActivity = bookmark.openAccountUserActivity
 
 				return true
@@ -102,7 +102,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 				}
 
 				// At first connect to the bookmark for the item
-				serverListController.connect(to: bookmark, lastVisibleItemId: itemLocalID, animated: false)
+				serverListController.connect(to: bookmark, lastVisibleItemId: itemLocalID, animated: false, present: nil)
 				window?.windowScene?.userActivity = activity
 
 				return true

--- a/ownCloud/Server List/ServerListTableViewController.swift
+++ b/ownCloud/Server List/ServerListTableViewController.swift
@@ -22,7 +22,11 @@ import ownCloudApp
 import ownCloudAppShared
 import PocketSVG
 
-class ServerListTableViewController: UITableViewController, Themeable {
+public protocol StateRestorationConnectProtocol : class {
+	func connect(to bookmark: OCBookmark, lastVisibleItemId: String?, animated: Bool, present message: OCMessage?)
+}
+
+class ServerListTableViewController: UITableViewController, Themeable, StateRestorationConnectProtocol {
 	// MARK: - Views
 	@IBOutlet var welcomeOverlayView: UIView!
 	@IBOutlet var welcomeTitleLabel : UILabel!

--- a/ownCloud/Static Login/Interface/StaticLoginViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginViewController.swift
@@ -20,7 +20,10 @@ import UIKit
 import ownCloudSDK
 import ownCloudAppShared
 
-class StaticLoginViewController: UIViewController, Themeable {
+class StaticLoginViewController: UIViewController, Themeable, StateRestorationConnectProtocol {
+	private var bookmark: OCBookmark?
+	private var lastVisibleItemId: String?
+
 	private let maximumContentWidth : CGFloat = 400
 	let loginBundle : StaticLoginBundle
 
@@ -200,6 +203,11 @@ class StaticLoginViewController: UIViewController, Themeable {
 		self.toolbarShown = true
 	}
 
+	func connect(to bookmark: OCBookmark, lastVisibleItemId: String?, animated: Bool, present message: OCMessage? = nil) {
+		self.bookmark = bookmark
+		self.lastVisibleItemId = lastVisibleItemId
+	}
+
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
 
@@ -307,6 +315,10 @@ class StaticLoginViewController: UIViewController, Themeable {
 		// animated (otherwise just the list is moved *inside* this view controller, which is weird) and the
 		// PushTransition correctly restores the view
 		serverList?.pushFromViewController = self
+
+		if let bookmark = bookmark {
+			serverList?.connect(to: bookmark, lastVisibleItemId: lastVisibleItemId, animated: false)
+		}
 
 		return serverList!
 	}


### PR DESCRIPTION
## Description
State restoration was not working for branded clients.

## Related Issue
#957 

## Motivation and Context
Reopen last used items after an app restart.

## How Has This Been Tested?
- open an item 
- set app to background
- force quit app
- restart app
- as a result the last shown item should be reopened
- on the iPad: all windows should be reopened with the last items

Please test this steps in the regular unbranded app and for a branded client like ownCloud Online

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

