### PR TITLE
[feature/connection-validator-2] Connection Validator that clears cookies on initial redirect

### DIFF
--- a/doc/CONFIGURATION.json
+++ b/doc/CONFIGURATION.json
@@ -1122,6 +1122,26 @@
   },
   {
     "autoExpansion" : "none",
+    "category" : "Connection",
+    "categoryTag" : "connection",
+    "classIdentifier" : "connection",
+    "className" : "OCConnection",
+    "description" : "Allows fine-tuning the behavior of the connection validator by enabling/disabling aspects of it.",
+    "flags" : 4,
+    "flatIdentifier" : "connection.validator-flags",
+    "key" : "validator-flags",
+    "label" : "connection.validator-flags",
+    "possibleValues" : [
+      {
+        "description" : "Clear all cookies for the connection when entering connection validation.",
+        "value" : "clear-cookies"
+      }
+    ],
+    "status" : "advanced",
+    "type" : "stringArray"
+  },
+  {
+    "autoExpansion" : "none",
     "category" : "Endpoints",
     "categoryTag" : "endpoints",
     "classIdentifier" : "connection",

--- a/docs/modules/ROOT/pages/ios_mdm_tables.adoc
+++ b/docs/modules/ROOT/pages/ios_mdm_tables.adoc
@@ -562,6 +562,21 @@ The following placeholders can be used to make it dynamic:
 |Policy regarding the use of plain (unencryped) HTTP URLs for creating bookmarks. A value of `warn` will create an issue (typically then presented to the user as a warning), but ultimately allow the creation of the bookmark. A value of `forbidden` will block the use of `http`-URLs for the creation of new bookmarks.
 |advanced `candidate`
 
+|connection.validator-flags
+|stringArray
+|
+|Allows fine-tuning the behavior of the connection validator by enabling/disabling aspects of it.
+[cols="1,2"]
+!===
+! Value
+! Description
+! `clear-cookies`
+! Clear all cookies for the connection when entering connection validation.
+
+!===
+
+|advanced `candidate`
+
 |core.action-concurrency-budgets
 |dictionary
 |`map[actions:10 all:0 download:3 download-wifi-and-cellular:3 download-wifi-only:2 transfer:6 upload:3 upload-cellular-and-wifi:3 upload-wifi-only:2]`

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -305,6 +305,11 @@
             value = "[openid-connect,oauth2]"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "oc:connection.validator-flags"
+            value = "[clear-cookies]"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption

--- a/ownCloud/Resources/Theming/Branding.plist
+++ b/ownCloud/Resources/Theming/Branding.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>connection.validator-flags</key>
+	<array>
+		<string>clear-cookies</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## Description
This PR points to a branch of the SDK with a connection validator that clears all cookies before starting the connection validator.

## Related Issue
https://github.com/owncloud/client/pull/8558

## How Has This Been Tested?
Using the `simple-apm` host simulator of the app.

## Diagram
Revision 3 of the Connection Validator is now implementing this:

![diagram](https://user-images.githubusercontent.com/639669/116810463-34fc2e00-ab44-11eb-8b0a-29bdf60ae999.png)

### Source
<details>
<summary>PlantUML source code</summary>

```
@startuml
start
if (status is 302?) then (yes)
  :put request back into the queue;
  -> enter connection validation;
  partition ConnectionValidator {
    :clear all cookies;
    repeat :start validation;
      if (validationRetryCount < 5) then (yes)
        #aaeeff:validationRetryCount ++;
        #aaeeff:Reset successCounter and failCounter;
        :<b>send request to status.php;
        :redirectionDepth = 0;
        while (status is 302 and redirectionDepth < 5) is (yes)
          :follow redirect;
          :redirectionDepth ++;
        endwhile (no)
        if (status is 200) then (yes)
          if (valid content) then (yes)
            #palegreen:successCounter ++;
          else (no)
            #pink:failCounter ++;
          endif
        else (no)
          #pink:failCounter ++;
        endif
        :<b>send authenticated request to WebDAV endpoint;
        if (status is 200) then (yes)
          if (valid content) then (yes)
            #palegreen:successCounter ++;
          else (no)
            #pink:failCounter ++;
          endif
        else (no)
          if (status is 401) then (yes)
            #aaeeff:trigger auth refresh;
          else (no)
          endif
          #pink:failCounter ++;
        endif
      else (no)
        :stop validation &\npause connection;
        :alert user;
        ->User presses Retry;
        :reset validationRetryCount;
        :re-start validation;
        end
      endif
    repeat while (successCounter >= failCounter) is (no);
    -> yes;
  }
  :resend queued request;
else (no)
endif
:handle response;
@enduml
```

</details>

[Editor](http://www.plantuml.com/plantuml/umla/tLH1Rjim4Bph5Gi4A184AToqlKY9co9vGO2cbrveQMGHOKYMksnW5FrxBSgmH3awz5gTQ7fcERDBpXsB2X9VJ94MXMxfVB-IoAIPFgwklroGTB1qlWDV54IbZq81FoDOQAFgPz9MN8-X_Lv4jSTShGbM4AXsrg8MxIpzKaOtgb_s2A-2wBH_VuGy3GWNwFSUGHJWeOJA92pdfw-NEku-GiBktaKhT4EVPwA7xqmfe6tBDqcNbzK9y14C8Ovr3UO4Go1b6sgLDeVV8wkysQmPjZbsHnmDhNplEp_11JGw39uVuAMZMrgDVxzssc0sX7Jed3Rur3npILIspXZtUYIasak7PyPXcyFnreqLypjnlLgTTZSVI3ztWPK57D6PLmRR0DWoxswcXWY6avOvMzldSZA3ESiskYsMQonNoFZpiQhOkn5TAq4svE_OF7nzwcdUQIlLVzoutD6drOSJfVCt945ljmYfUnJG1d2th3JNyU_ZEgrMiZW_IGzwzyDw5HcJSAf6j388Gf6d3_jg_OqHo0SmWoc5HlQS6K9lXKe6kfhdMEQWc7iPqk-O1lcmrxVJ2Ef389ckYa4kxS3z-azna6UR5CxZjQsAiLF3cMMdR6D00UoTPLJ57MmJNynV)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
