### PR TITLE
[fix/ios12-share-sheet] File Provider UI: Dismiss View on iOS 12

### DIFF
--- a/changelog/unreleased/986
+++ b/changelog/unreleased/986
@@ -1,0 +1,3 @@
+Bugfix: Views in File Provider UI (public links, share with user) could not be dismissed on iOS 12
+
+https://github.com/owncloud/ios-app/issues/986

--- a/ownCloud File Provider UI/DocumentActionViewController.swift
+++ b/ownCloud File Provider UI/DocumentActionViewController.swift
@@ -181,7 +181,11 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 	}
 
 	@objc func dismissView() {
-		self.dismiss(animated: true) {
+		if #available(iOS 13.0, *) {
+			self.dismiss(animated: true) {
+				self.complete()
+			}
+		} else {
 			self.complete()
 		}
 	}


### PR DESCRIPTION
## Description
Views in file provider UI (public links, share with user) could not be dismissed on iOS 12

## Related Issue
#986 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- follow instructions described in issue
- repeat the same on iOS 13, 14

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

