### PR TITLE
[feature/additional-url-scheme] Added Additional URL Scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/ios-app/compare/milestone/11.6.0...master
+
+Summary
+-------
+
+* Change - Additional URL Scheme: [#979](https://github.com/owncloud/ios-app/issues/979)
+
+Details
+-------
+
+* Change - Additional URL Scheme: [#979](https://github.com/owncloud/ios-app/issues/979)
+
+   Added an app additional URL scheme to open a specific app, if more than one ownCloud apps are
+   installed with different bundle IDs.
+
+   https://github.com/owncloud/ios-app/issues/979
+
 Changelog for ownCloud iOS Client [11.6.0] (2021-05-12)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.6.0 relevant to

--- a/changelog/unreleased/979
+++ b/changelog/unreleased/979
@@ -1,0 +1,5 @@
+Change: Additional URL Scheme
+
+Added an app additional URL scheme to open a specific app, if more than one ownCloud apps are installed with different bundle IDs.
+
+https://github.com/owncloud/ios-app/issues/979

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -319,7 +319,8 @@ platform :ios do
       EXPORT_METHOD: "app-store",
       CONFIGURATION: "Release",
       BETA_APP_ICON: false,
-      APP_NAME: "ownCloud"
+      APP_NAME: "ownCloud",
+      URL_SCHEME: "owncloud-app"
     )
   end
 
@@ -342,7 +343,8 @@ platform :ios do
       EXPORT_METHOD: "app-store",
       CONFIGURATION: "Release",
       BETA_APP_ICON: false,
-      APP_NAME: "ownCloud"
+      APP_NAME: "ownCloud",
+      URL_SCHEME: "owncloud-emm"
     )
   end
 
@@ -365,7 +367,8 @@ lane :owncloud_online_build do
     EXPORT_METHOD: "app-store",
     CONFIGURATION: "Release",
     BETA_APP_ICON: false,
-    APP_NAME: "ownCloud Online"
+    APP_NAME: "ownCloud Online",
+    URL_SCHEME: "owncloud-online"
   )
 end
 
@@ -509,6 +512,15 @@ end
 
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleDisplayName", value: appName)
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleName", value: appName)
+    
+    if !values[:URL_SCHEME].nil?
+      update_url_schemes(
+        path: "ownCloud/Resources/Info.plist",
+        update_url_schemes: proc do |schemes|
+          schemes + [values[:URL_SCHEME]]
+        end
+      )
+    end
 
     set_info_plist_value(path: "ownCloud File Provider/Info.plist", key: "CFBundleDisplayName", value: appName)
     set_info_plist_value(path: "ownCloud File Provider/Info.plist", key: "CFBundleName", value: appName)


### PR DESCRIPTION
## Description
When building the apps (regular, EMM, oc.online) with fastlane, an additional app URL-Scheme will be added to the `Info.plist` file.
regular: `owncloud-app`
EMM: `owncloud-emm`
oc.online: `owncloud-online`

With this app specific URL scheme, the user can decide which app should be opened, if more than one of this apps is installed on the system.

## Related Issue
#979 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- open Safari
- run `bundle exec fastlane owncloud_emm_build`
- enter in URL bar: owncloud-emm://demo@owncloud.com/f/6
- ownCloud EMM app should be opened

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

