### PR TITLE
[feature/drone-build-number] Use Drone Build Number as CFBundleVersion

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -390,7 +390,7 @@ end
   end
 
   lane :owncloud_ownbrander_build do
-    puts "ownBrander Build with Drone Build Number" + ENV["DRONE_BUILD_NUMBER"]
+    puts "ownBrander Build with Drone Build Number: " + ENV["DRONE_BUILD_NUMBER"]
     owncloud_branding_adhoc_build(
       BUILD_NUMBER: ENV["DRONE_BUILD_NUMBER"]
     )
@@ -674,7 +674,11 @@ end
       ipaName = values[:IPA_NAME]
     elsif
       time = Time.now
-      ipaName = appName + "-" + version + "-" + EXPORT_METHOD + "-" + time.strftime("%Y%m%d-%k%M") + ".ipa"
+      ipaSuffix = EXPORT_METHOD + "-" + time.strftime("%Y%m%d-%k%M")
+      if !values[:BUILD_NUMBER].nil?
+        ipaSuffix += "-" + BUILD_NUMBER
+      end
+      ipaName = appName + "-" + version + "-" + ipaSuffix + ".ipa"
     end
 
     generate_appicon()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -343,7 +343,7 @@ lane :owncloud_online_build do
   )
 end
 
-  lane :owncloud_branding_adhoc_build do
+  lane :owncloud_branding_adhoc_build do |values|
     build_ipa_in_house(
       ENTERPRISE_APP_ID: "com.owncloud.enterprise.ios-app",
       ENTERPRISE_APP_PROFILE: "Enterprise Distribution iOS Neo",
@@ -361,11 +361,12 @@ end
       APP_GROUP_IDENTIFIERS: "group.com.owncloud.enterprise.ios-app",
       EXPORT_METHOD: "enterprise",
       CONFIGURATION: "Release",
-      BETA_APP_ICON: false
+      BETA_APP_ICON: false,
+      BUILD_NUMBER: values[:BUILD_NUMBER]
     )
   end
 
-  lane :owncloud_branding_appstore_build do
+  lane :owncloud_branding_appstore_build do |values|
     build_ipa_in_house(
       ENTERPRISE_APP_ID: "com.owncloud.ios-app",
       ENTERPRISE_APP_PROFILE: "match AppStore com.owncloud.ios-app",
@@ -383,15 +384,19 @@ end
       APP_GROUP_IDENTIFIERS: "group.com.owncloud.ios-app",
       EXPORT_METHOD: "app-store",
       CONFIGURATION: "Release",
-      BETA_APP_ICON: false
+      BETA_APP_ICON: false,
+      BUILD_NUMBER: values[:BUILD_NUMBER]
     )
   end
 
   lane :owncloud_ownbrander_build do
-    puts "Drone Build Number"
-    puts ENV["DRONE_BUILD_NUMBER"]
-    owncloud_branding_adhoc_build()
-    owncloud_branding_appstore_build()
+    puts "ownBrander Build with Drone Build Number" + ENV["DRONE_BUILD_NUMBER"]
+    owncloud_branding_adhoc_build(
+      BUILD_NUMBER: ENV["DRONE_BUILD_NUMBER"]
+    )
+    owncloud_branding_appstore_build(
+      BUILD_NUMBER: ENV["DRONE_BUILD_NUMBER"]
+    )
   end
 
   lane :owncloud_enterprise_build do
@@ -450,6 +455,7 @@ end
     APP_GROUP_IDENTIFIERS = values[:APP_GROUP_IDENTIFIERS]
     EXPORT_METHOD = values[:EXPORT_METHOD]
     CONFIGURATION = values[:CONFIGURATION]
+    BUILD_NUMBER = values[:BUILD_NUMBER]
 
     appName = "ownCloud"
     themePath = "ownCloud/Resources/Theming/Branding.plist"
@@ -466,6 +472,15 @@ end
 
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleDisplayName", value: appName)
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleName", value: appName)
+
+    if !values[:BUILD_NUMBER].nil?
+      puts "Set Drone Build Number: " + BUILD_NUMBER
+      set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleVersion", value: BUILD_NUMBER)
+      set_info_plist_value(path: "ownCloud File Provider/Info.plist", key: "CFBundleVersion", value: BUILD_NUMBER)
+      set_info_plist_value(path: "ownCloud File Provider UI/Info.plist", key: "CFBundleVersion", value: BUILD_NUMBER)
+      set_info_plist_value(path: "ownCloud Share Extension/Info.plist", key: "CFBundleVersion", value: BUILD_NUMBER)
+      set_info_plist_value(path: "ownCloud Intents/Info.plist", key: "CFBundleVersion", value: BUILD_NUMBER)
+    end
 
     if !values[:URL_SCHEME].nil?
       update_url_schemes(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -388,6 +388,8 @@ end
   end
 
   lane :owncloud_ownbrander_build do
+    puts "Drone Build Number"
+    puts ENV["DRONE_BUILD_NUMBER"]
     owncloud_branding_adhoc_build()
     owncloud_branding_appstore_build()
   end
@@ -459,12 +461,12 @@ end
         appName = tmpAppName
       end
     end
-      
+
     puts "App Name: " + appName
 
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleDisplayName", value: appName)
     set_info_plist_value(path: "ownCloud/Resources/Info.plist", key: "CFBundleName", value: appName)
-    
+
     if !values[:URL_SCHEME].nil?
       update_url_schemes(
         path: "ownCloud/Resources/Info.plist",


### PR DESCRIPTION
## Description
This PR implements to set the Drone build number in fastlane (in ownBrander Builds) as `CFBundleVersion` for all app targets.
Furthermore the build number will be added to the output IPA filename.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
- every ownBrander build can be identified inside the app settings
- AppStore needs an unique build number for every new upload

## How Has This Been Tested?
- Trigger a new ownBrander build
- Install IPA
- check build number in app settings

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

