### PR TITLE
[fix/branding-login-onboarding-section] Branded Login: Onboarding Section

### DIFF
--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -50,7 +50,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 		if profile.canConfigureURL {
 			self.addSection(urlSection())
 			if OCBookmarkManager.shared.bookmarks.count == 0, profile.promptForHelpURL != nil, profile.helpURLButtonString != nil, profile.helpURL != nil {
-				self.addSection(urlHelpSection())
+				self.addSection(onboardingSection())
 			}
 		} else {
 			proceedWithLogin()
@@ -96,16 +96,16 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 		return urlSection
 	}
 
-	func urlHelpSection() -> StaticTableViewSection {
-		var urlHelpSection : StaticTableViewSection
+	func onboardingSection() -> StaticTableViewSection {
+		var onboardingSection : StaticTableViewSection
 
-		urlHelpSection = StaticTableViewSection(headerTitle: nil, identifier: "urlHelpSection")
+		onboardingSection = StaticTableViewSection(headerTitle: nil, identifier: "onboardingSection")
 		if let message = profile.promptForHelpURL, let title = profile.helpURLButtonString {
-			let (proceedButton, _) = urlHelpSection.addButtonFooter(message: message, messageItemStyle: .welcomeMessage, proceedLabel: title, proceedItemStyle: .informal, cancelLabel: nil)
+			let (proceedButton, _) = onboardingSection.addButtonFooter(message: message, messageItemStyle: .welcomeMessage, proceedLabel: title, proceedItemStyle: .informal, cancelLabel: nil)
 				proceedButton?.addTarget(self, action: #selector(self.helpAction), for: .touchUpInside)
 		}
 
-		return urlHelpSection
+		return onboardingSection
 	}
 
 	func loginMaskSection() -> StaticTableViewSection {
@@ -298,8 +298,8 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 		if let urlSection = self.sectionForIdentifier("urlSection") {
 			self.removeSection(urlSection)
 		}
-		if let urlHelpSection = self.sectionForIdentifier("urlHelpSection") {
-			self.removeSection(urlHelpSection)
+		if let onboardingSection = self.sectionForIdentifier("onboardingSection") {
+			self.removeSection(onboardingSection)
 		}
 
 		if busySection == nil {
@@ -454,8 +454,8 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 								self.removeSection(busySection)
 							}
 							self.addSection(self.urlSection())
-							if OCBookmarkManager.shared.bookmarks.count == 0, self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil {
-								self.addSection(self.urlHelpSection())
+							if OCBookmarkManager.shared.bookmarks.count == 0, self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil, self.sectionForIdentifier("onboardingSection") == nil {
+								self.addSection(self.onboardingSection())
 							}
 						} else {
 							self.cancel(nil)
@@ -505,8 +505,8 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 							}
 						}
 
-						if self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil {
-							self.addSection(self.urlHelpSection())
+						if self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil, self.sectionForIdentifier("onboardingSection") == nil {
+							self.addSection(self.onboardingSection())
 						}
 					}
 				}

--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -504,6 +504,10 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 								self.addSection(self.tokenMaskSection())
 							}
 						}
+
+						if self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil {
+							self.addSection(self.urlHelpSection())
+						}
 					}
 				}
 

--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -49,7 +49,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 
 		if profile.canConfigureURL {
 			self.addSection(urlSection())
-			if OCBookmarkManager.shared.bookmarks.count == 0, profile.promptForHelpURL != nil, profile.helpURLButtonString != nil, profile.helpURL != nil {
+			if OCBookmarkManager.shared.bookmarks.count == 0, profile.isOnboardingEnabled {
 				self.addSection(onboardingSection())
 			}
 		} else {
@@ -454,7 +454,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 								self.removeSection(busySection)
 							}
 							self.addSection(self.urlSection())
-							if OCBookmarkManager.shared.bookmarks.count == 0, self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil, self.sectionForIdentifier("onboardingSection") == nil {
+							if OCBookmarkManager.shared.bookmarks.count == 0, self.profile.isOnboardingEnabled, self.sectionForIdentifier("onboardingSection") == nil {
 								self.addSection(self.onboardingSection())
 							}
 						} else {
@@ -505,7 +505,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 							}
 						}
 
-						if self.profile.promptForHelpURL != nil, self.profile.helpURLButtonString != nil, self.profile.helpURL != nil, self.sectionForIdentifier("onboardingSection") == nil {
+						if self.profile.isOnboardingEnabled, self.sectionForIdentifier("onboardingSection") == nil {
 							self.addSection(self.onboardingSection())
 						}
 					}

--- a/ownCloud/Static Login/StaticLoginProfile.swift
+++ b/ownCloud/Static Login/StaticLoginProfile.swift
@@ -41,6 +41,12 @@ class StaticLoginProfile: NSObject {
 	var allowedHosts : [String]?
 	var allowedAuthenticationMethods : [OCAuthenticationMethodIdentifier]?
 	var themeStyleID : ThemeStyleIdentifier?
+	var isOnboardingEnabled : Bool {
+		if promptForHelpURL != nil, helpURLButtonString != nil, helpURL != nil {
+			return true
+		}
+		return false
+	}
 
 	enum Key : String, CaseIterable {
 		case identifier


### PR DESCRIPTION
## Description
Makes the onboarding section available for the branded login, if `can-add-account` it `true` or `false`.

## Related Issue
#1007 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

