### PR TITLE
[fix/ios12-branded-settings-crash] Fix iOS 12 crash when entering Settings on branded builds

### DIFF
--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -273,7 +273,14 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 	if ((urlString = [self computedValueForClassSettingsKey:settingsKey]) != nil)
 	{
-		if (urlString.length > 0)
+		NSURL *url = nil;
+
+		if ((url = OCTypedCast(urlString, NSURL)) != nil)
+		{
+			// urlString is already an NSURL - return it
+			return (url);
+		}
+		else if (urlString.length > 0)
 		{
 			return ([NSURL URLWithString:urlString]);
 		}

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -277,8 +277,11 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 		if ((url = OCTypedCast(urlString, NSURL)) != nil)
 		{
-			// urlString is already an NSURL - return it
-			return (url);
+			// urlString is already an NSURL - return it, unless it is empty
+			if (url.absoluteString.length > 0)
+			{
+				return (url);
+			}
 		}
 		else if (urlString.length > 0)
 		{


### PR DESCRIPTION
## Description
Addresses an issue where a branded build of the app crashes on iOS 12 upon entering Settings.

## Related Issue
https://github.com/owncloud/enterprise/issues/4701

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)