### PR TITLE
[feature/disable-share-import] Branding option to disable file imports

### DIFF
--- a/doc/CONFIGURATION.json
+++ b/doc/CONFIGURATION.json
@@ -570,6 +570,33 @@
     "categoryTag" : "branding",
     "classIdentifier" : "branding",
     "className" : "Branding",
+    "description" : "List of disabled import methods that can't be used.",
+    "flatIdentifier" : "branding.disabled-import-methods",
+    "key" : "disabled-import-methods",
+    "label" : "branding.disabled-import-methods",
+    "possibleValues" : [
+      {
+        "description" : "Disallow import through the File Provider (Files.app)",
+        "value" : "file-provider"
+      },
+      {
+        "description" : "Disallow import through \"Open with\"",
+        "value" : "open-with"
+      },
+      {
+        "description" : "Disallow import through the Share Extension",
+        "value" : "share-extension"
+      }
+    ],
+    "status" : "supported",
+    "type" : "stringArray"
+  },
+  {
+    "autoExpansion" : "none",
+    "category" : "Branding",
+    "categoryTag" : "branding",
+    "classIdentifier" : "branding",
+    "className" : "Branding",
     "defaultValue" : false,
     "description" : "Controls whether the app should prompt for an App Store review. Only applies if the app is branded.",
     "flatIdentifier" : "branding.enable-review-prompt",

--- a/docs/modules/ROOT/pages/ios_mdm_tables.adoc
+++ b/docs/modules/ROOT/pages/ios_mdm_tables.adoc
@@ -317,6 +317,27 @@ tag::branding[]
 |App name to use throughout the app.
 |supported `candidate`
 
+|branding.disabled-import-methods
+|stringArray
+|
+|List of disabled import methods that can't be used.
+[cols="1,2"]
+!===
+! Value
+! Description
+! `file-provider`
+! Disallow import through the File Provider (Files.app)
+
+! `open-with`
+! Disallow import through "Open with"
+
+! `share-extension`
+! Disallow import through the Share Extension
+
+!===
+
+|supported `candidate`
+
 |branding.organization-name
 |string
 |

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -637,7 +637,7 @@
 	NSError *error = nil;
 	BOOL stopAccess = NO;
 
-	if ([Branding.sharedBranding.disabledImportMethods containsObject:BrandingFileImportMethodFileProvider])
+	if (![Branding.sharedBranding isImportMethodAllowed:BrandingFileImportMethodFileProvider])
 	{
 		completionHandler(nil, [OCErrorWithDescription(OCErrorInternal, OCLocalized(@"Importing files through the File Provider is not allowed on this device.")) translatedError]);
 

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -637,6 +637,13 @@
 	NSError *error = nil;
 	BOOL stopAccess = NO;
 
+	if ([Branding.sharedBranding.disabledImportMethods containsObject:BrandingFileImportMethodFileProvider])
+	{
+		completionHandler(nil, [OCErrorWithDescription(OCErrorInternal, OCLocalized(@"Importing files through the File Provider is not allowed on this device.")) translatedError]);
+
+		return;
+	}
+
 	if ([fileURL startAccessingSecurityScopedResource])
 	{
 		stopAccess = YES;

--- a/ownCloud Share Extension/ShareViewController.swift
+++ b/ownCloud Share Extension/ShareViewController.swift
@@ -54,7 +54,7 @@ class ShareViewController: MoreStaticTableViewController {
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
 
-		if Branding.shared.disabledImportMethods?.contains(.shareExtension) != true {
+		if Branding.shared.isImportMethodAllowed(.shareExtension) {
 			// Share extension allowed
 			if !willAppearInitial {
 				willAppearInitial = true
@@ -78,7 +78,7 @@ class ShareViewController: MoreStaticTableViewController {
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
 
-		if Branding.shared.disabledImportMethods?.contains(.shareExtension) == true {
+		if !Branding.shared.isImportMethodAllowed(.shareExtension) {
 			// Share extension disabled, alert user
 			let alertController = ThemedAlertController(title: "Share Extension disabled".localized, message: "Importing files through the Share Extension is not allowed on this device.".localized, preferredStyle: .alert)
 			alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: { [weak self] _ in

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File Provider.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File Provider.xcscheme
@@ -146,6 +146,11 @@
             value = "false"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "oc:branding.disabled-import-methods"
+            value = "[share-extension,open-with,file-provider]"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Share Extension.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Share Extension.xcscheme
@@ -58,9 +58,9 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
       <RemoteRunnable
-         runnableDebuggingMode = "0"
-         BundleIdentifier = "com.apple.DocumentsApp"
-         RemotePath = "/var/containers/Bundle/Application/992AF78C-7B9A-4EBF-AB5B-BA3202AD7B9D/Files.app">
+         runnableDebuggingMode = "1"
+         BundleIdentifier = "com.apple.mobileslideshow"
+         RemotePath = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications/MobileSlideShow.app">
       </RemoteRunnable>
       <MacroExpansion>
          <BuildableReference
@@ -91,6 +91,11 @@
             key = "oc:log.log-synchronous"
             value = "true"
             isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "oc:branding.disabled-import-methods"
+            value = "[share-extension]"
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -335,6 +335,11 @@
             value = "[com.owncloud.action.copy,com.owncloud.action.move]"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "oc:branding.disabled-import-methods"
+            value = "[share-extension,open-with,file-provider]"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption

--- a/ownCloud/AppDelegate.swift
+++ b/ownCloud/AppDelegate.swift
@@ -182,7 +182,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			guard let window = UserInterfaceContext.shared.currentWindow else { return false }
 
 			openPrivateLink(url: url, in: window)
-		} else {
+		} else if url.isFileURL {
 			var copyBeforeUsing = true
 			if let shouldOpenInPlace = options[UIApplication.OpenURLOptionsKey.openInPlace] as? Bool {
 				copyBeforeUsing = !shouldOpenInPlace

--- a/ownCloud/Import/ImportFilesController.swift
+++ b/ownCloud/Import/ImportFilesController.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import ownCloudSDK
+import ownCloudApp
 import ownCloudAppShared
 
 extension Array where Element: Equatable {
@@ -70,18 +71,37 @@ class ImportFilesController: NSObject {
 
 extension ImportFilesController {
 
-	public func importFile(_ importFile: ImportFile) {
-		importFiles.append(importFile)
+	public func importAllowed(alertUserOtherwise: Bool) -> Bool {
+		let importAllowed = Branding.shared.disabledImportMethods?.contains(.openWith) == false
 
-		prepareInputFileForImport(file: importFile, completion: { (error) in
-			guard error == nil else {
-				Log.error("Couldn't import file \(importFile.url.absoluteString) because of error: \(String(describing: error))")
+		if !importAllowed, alertUserOtherwise {
+			// Open with disabled, alert user
+			OnMainThread {
+				let alertController = ThemedAlertController(title: "Opening not allowed".localized, message: "Importing files through opening is not allowed on this device.".localized, preferredStyle: .alert)
+				alertController.addAction(UIAlertAction(title: "OK".localized, style: .default, handler: nil))
 
-				return
+				UserInterfaceContext.shared.currentViewControllerForPresenting?.present(alertController, animated: true, completion: nil)
 			}
+		}
 
-			self.showAccountUI()
-		})
+		return importAllowed
+	}
+
+	public func importFile(_ importFile: ImportFile) {
+		if self.importAllowed(alertUserOtherwise: true) {
+			// Import file
+			importFiles.append(importFile)
+
+			prepareInputFileForImport(file: importFile, completion: { (error) in
+				guard error == nil else {
+					Log.error("Couldn't import file \(importFile.url.absoluteString) because of error: \(String(describing: error))")
+
+					return
+				}
+
+				self.showAccountUI()
+			})
+		}
 	}
 
 	func makeLocalCopy(of itemURL: URL, completion: (_ error: Error?) -> Void) {

--- a/ownCloud/Import/ImportFilesController.swift
+++ b/ownCloud/Import/ImportFilesController.swift
@@ -72,7 +72,7 @@ class ImportFilesController: NSObject {
 extension ImportFilesController {
 
 	public func importAllowed(alertUserOtherwise: Bool) -> Bool {
-		let importAllowed = Branding.shared.disabledImportMethods?.contains(.openWith) == false
+		let importAllowed = Branding.shared.isImportMethodAllowed(.openWith)
 
 		if !importAllowed, alertUserOtherwise {
 			// Open with disabled, alert user

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -763,6 +763,19 @@
 "Preparing…" = "Preparing…";
 "Save here" = "Save here";
 
+/* Disallowed Import Methods */
+/* - Share Extension */
+"Share Extension disabled" = "Share Extension disabled";
+"Importing files through the Share Extension is not allowed on this device." = "Importing files through the Share Extension is not allowed on this device.";
+
+/* - Open with */
+"Opening not allowed" = "Opening not allowed";
+"Importing files through opening is not allowed on this device." = "Importing files through opening is not allowed on this device.";
+
+/* - Files.app */
+"Import not allowed" = "Import not allowed";
+"Importing files through the File Provider is not allowed on this device." = "Importing files through the File Provider is not allowed on this device.";
+
 /* Data migration from legacy app */
 "Account Migration" = "Account Migration";
 "App Passcode" = "App Passcode";

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -123,8 +123,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		   firstURL.matchesAppScheme {  // + URL matches app scheme
 			openPrivateLink(url: firstURL, in: scene)
 		} else {
-			URLContexts.forEach { (urlContext) in
-				ImportFilesController.shared.importFile(ImportFile(url: urlContext.url, fileIsLocalCopy: urlContext.options.openInPlace))
+			if ImportFilesController.shared.importAllowed(alertUserOtherwise: true) {
+				URLContexts.forEach { (urlContext) in
+					ImportFilesController.shared.importFile(ImportFile(url: urlContext.url, fileIsLocalCopy: urlContext.options.openInPlace))
+				}
 			}
 		}
 	}

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -118,14 +118,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-		if let firstURL = URLContexts.first?.url,
-		   !OCAuthenticationBrowserSessionCustomScheme.handleOpen(firstURL), // No custom scheme URL handling for this URL
-		   firstURL.matchesAppScheme {  // + URL matches app scheme
-			openPrivateLink(url: firstURL, in: scene)
-		} else {
-			if ImportFilesController.shared.importAllowed(alertUserOtherwise: true) {
-				URLContexts.forEach { (urlContext) in
-					ImportFilesController.shared.importFile(ImportFile(url: urlContext.url, fileIsLocalCopy: urlContext.options.openInPlace))
+		if let firstURL = URLContexts.first?.url { // Ensure the set isn't empty
+			if !OCAuthenticationBrowserSessionCustomScheme.handleOpen(firstURL), // No custom scheme URL handling for this URL
+			   firstURL.matchesAppScheme {  // + URL matches app scheme
+				openPrivateLink(url: firstURL, in: scene)
+			} else {
+				if ImportFilesController.shared.importAllowed(alertUserOtherwise: true) {
+					URLContexts.forEach { (urlContext) in
+						ImportFilesController.shared.importFile(ImportFile(url: urlContext.url, fileIsLocalCopy: urlContext.options.openInPlace))
+					}
 				}
 			}
 		}

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -123,7 +123,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			   firstURL.matchesAppScheme {  // + URL matches app scheme
 				openPrivateLink(url: firstURL, in: scene)
 			} else {
-				if ImportFilesController.shared.importAllowed(alertUserOtherwise: true) {
+				if firstURL.isFileURL, // Ensure the URL is a file URL
+				   ImportFilesController.shared.importAllowed(alertUserOtherwise: true) { // Ensure import is allowed
 					URLContexts.forEach { (urlContext) in
 						ImportFilesController.shared.importFile(ImportFile(url: urlContext.url, fileIsLocalCopy: urlContext.options.openInPlace))
 					}

--- a/ownCloudAppFramework/Branding/Branding.h
+++ b/ownCloudAppFramework/Branding/Branding.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString* BrandingLegacyKeyPath;
 typedef NSString* BrandingLegacyKey;
 typedef OCClassSettingsKey BrandingKey NS_TYPED_EXTENSIBLE_ENUM;
+typedef NSString* BrandingFileImportMethod NS_TYPED_EXTENSIBLE_ENUM;
 typedef NSString* BrandingImageName NS_TYPED_EXTENSIBLE_ENUM;
 
 @protocol BrandingInitialization <NSObject>
@@ -51,6 +52,7 @@ typedef NSString* BrandingImageName NS_TYPED_EXTENSIBLE_ENUM;
 
 @property(strong,nullable,nonatomic,readonly) NSString *appName; //!< Custom app name
 @property(strong,nullable,nonatomic,readonly) NSString *organizationName; //!< Custom organization name
+@property(strong,nullable,nonatomic,readonly) NSArray<BrandingFileImportMethod> *disabledImportMethods; //!< Disabled file import methods
 
 - (nullable UIImage *)brandedImageNamed:(BrandingImageName)imageName; //!< Returns the respective image from the appBundle
 
@@ -63,6 +65,11 @@ extern OCClassSettingsIdentifier OCClassSettingsIdentifierBranding;
 
 extern BrandingKey BrandingKeyAppName;
 extern BrandingKey BrandingKeyOrganizationName;
+extern BrandingKey BrandingKeyDisabledImportMethods;
+
+extern BrandingFileImportMethod BrandingFileImportMethodOpenWith;
+extern BrandingFileImportMethod BrandingFileImportMethodShareExtension;
+extern BrandingFileImportMethod BrandingFileImportMethodFileProvider;
 
 NS_ASSUME_NONNULL_END
 

--- a/ownCloudAppFramework/Branding/Branding.h
+++ b/ownCloudAppFramework/Branding/Branding.h
@@ -54,6 +54,8 @@ typedef NSString* BrandingImageName NS_TYPED_EXTENSIBLE_ENUM;
 @property(strong,nullable,nonatomic,readonly) NSString *organizationName; //!< Custom organization name
 @property(strong,nullable,nonatomic,readonly) NSArray<BrandingFileImportMethod> *disabledImportMethods; //!< Disabled file import methods
 
+- (BOOL)isImportMethodAllowed:(BrandingFileImportMethod)importMethod;
+
 - (nullable UIImage *)brandedImageNamed:(BrandingImageName)imageName; //!< Returns the respective image from the appBundle
 
 - (nullable id)computedValueForClassSettingsKey:(OCClassSettingsKey)classSettingsKey;

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -273,7 +273,14 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 	if ((urlString = [self computedValueForClassSettingsKey:settingsKey]) != nil)
 	{
-		if (urlString.length > 0)
+		NSURL *url = nil;
+
+		if ((url = OCTypedCast(urlString, NSURL)) != nil)
+		{
+			// urlString is already an NSURL - return it
+			return (url);
+		}
+		else if (urlString.length > 0)
 		{
 			return ([NSURL URLWithString:urlString]);
 		}

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -236,6 +236,16 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 	return ([self computedValueForClassSettingsKey:BrandingKeyDisabledImportMethods]);
 }
 
+- (BOOL)isImportMethodAllowed:(BrandingFileImportMethod)importMethod
+{
+	if ((importMethod != nil) && [self.disabledImportMethods containsObject:importMethod])
+	{
+		return (NO);
+	}
+
+	return (YES);
+}
+
 - (nullable UIImage *)brandedImageNamed:(BrandingImageName)imageName
 {
 	return ([UIImage imageNamed:imageName inBundle:self.appBundle compatibleWithTraitCollection:nil]);

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -231,6 +231,11 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 	return ([self computedValueForClassSettingsKey:BrandingKeyOrganizationName]);
 }
 
+- (NSArray<BrandingFileImportMethod> *)disabledImportMethods
+{
+	return ([self computedValueForClassSettingsKey:BrandingKeyDisabledImportMethods]);
+}
+
 - (nullable UIImage *)brandedImageNamed:(BrandingImageName)imageName
 {
 	return ([UIImage imageNamed:imageName inBundle:self.appBundle compatibleWithTraitCollection:nil]);
@@ -311,6 +316,19 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 			OCClassSettingsMetadataKeyDescription 	: @"Organization name to use throughout the app.",
 			OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusSupported,
 			OCClassSettingsMetadataKeyCategory	: @"Branding",
+		},
+
+		// Disabled import methods
+		BrandingKeyDisabledImportMethods : @{
+			OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeStringArray,
+			OCClassSettingsMetadataKeyDescription 	: @"List of disabled import methods that can't be used.",
+			OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusSupported,
+			OCClassSettingsMetadataKeyCategory	: @"Branding",
+			OCClassSettingsMetadataKeyPossibleValues : @{
+				BrandingFileImportMethodOpenWith	: @"Disallow import through \"Open with\"",
+				BrandingFileImportMethodShareExtension  : @"Disallow import through the Share Extension",
+				BrandingFileImportMethodFileProvider	: @"Disallow import through the File Provider (Files.app)"
+			}
 		}
 	});
 }
@@ -319,5 +337,10 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 OCClassSettingsIdentifier OCClassSettingsIdentifierBranding = @"branding";
 
-OCClassSettingsKey BrandingKeyAppName = @"app-name"; 			// Legacy Branding Key: organizationName
+OCClassSettingsKey BrandingKeyAppName = @"app-name";
 OCClassSettingsKey BrandingKeyOrganizationName = @"organization-name"; 	// Legacy Branding Key: organizationName
+OCClassSettingsKey BrandingKeyDisabledImportMethods = @"disabled-import-methods";
+
+BrandingFileImportMethod BrandingFileImportMethodOpenWith = @"open-with";
+BrandingFileImportMethod BrandingFileImportMethodShareExtension = @"share-extension";
+BrandingFileImportMethod BrandingFileImportMethodFileProvider = @"file-provider";

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -277,8 +277,11 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 		if ((url = OCTypedCast(urlString, NSURL)) != nil)
 		{
-			// urlString is already an NSURL - return it
-			return (url);
+			// urlString is already an NSURL - return it, unless it is empty
+			if (url.absoluteString.length > 0)
+			{
+				return (url);
+			}
 		}
 		else if (urlString.length > 0)
 		{

--- a/ownCloudAppShared/User Interface/UserInterfaceContext.swift
+++ b/ownCloudAppShared/User Interface/UserInterfaceContext.swift
@@ -44,4 +44,14 @@ open class UserInterfaceContext: NSObject {
 	public var currentWindow : UIWindow? {
 		return provider?.provideCurrentWindow()
 	}
+
+	public var currentViewControllerForPresenting : UIViewController? {
+		let viewController = currentWindow?.rootViewController
+
+		if let navigationController = viewController as? UINavigationController, let viewController = navigationController.visibleViewController {
+			return viewController
+		}
+
+		return viewController
+	}
 }

--- a/ownCloudScreenshotsTests/SnapshotHelper.swift
+++ b/ownCloudScreenshotsTests/SnapshotHelper.swift
@@ -180,11 +180,11 @@ open class Snapshot: NSObject {
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
-                #if swift(<5.0)
-                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
-                #else
+                // #if swift(<5.0)
+                //    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                // #else
                     try image.pngData()?.write(to: path, options: .atomic)
-                #endif
+                // #endif
             } catch let error {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)


### PR DESCRIPTION
## Description
Adds a new MDM option `branding.disabled-import-methods` to disable import methods:
- `open-with` disables "open with" calls in `SceneDelegate` and `AppDelegate`
- `share-extension` disables import through the Share Extension
- `file-provider` disables importing files through the File Provider Extension (**but still allows editing and folder creation**)

Example payload:
```xml
<key>branding.disabled-import-methods</key>
<array>
	<string>open-with</string>
	<string>share-extension</string>
</array>
```

## Related Issue
https://github.com/owncloud/enterprise/issues/4709

## Screenshots (if appropriate):
Share Sheet | Open with | File Provider
---|---|---
![Simulator Screen Shot - iPhone 12 Pro - 2021-08-11 at 20 37 33](https://user-images.githubusercontent.com/639669/129091414-398e163f-35a0-41e7-ae32-47e5c871777a.png) | ![IMG_4C78E386FF74-1](https://user-images.githubusercontent.com/639669/129091395-bcc97d9d-208a-4f1d-816e-e779b1719f4d.jpeg) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-08-11 at 21 21 42](https://user-images.githubusercontent.com/639669/129091406-70471457-32e5-44d2-aa16-b3ed08b1372d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
