### PR TITLE
[fix/markup-ios15 ] Enabling Markup Edit Mode on iOS 15

### DIFF
--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -128,6 +128,9 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 			if self.navigationItem.rightBarButtonItems?.count ?? 0 > 2 {
 				guard let markupButton = self.navigationItem.rightBarButtonItems?[1] else { return }
 				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			} else if UIDevice.current.isIpad, self.navigationItem.rightBarButtonItems?.count ?? 0 == 2 {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?[1] else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
 			} else {
 				guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
 				_ = markupButton.target?.perform(markupButton.action, with: markupButton)

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -124,14 +124,22 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 
 	@objc func enableEditingMode() {
 		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
-		if #available(iOS 14.0, *) {
-				if self.navigationItem.rightBarButtonItems?.count ?? 0 > 1 {
-					guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
-					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
-				} else {
-					guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
-					_ = markupButton.target?.perform(markupButton.action, with: markupButton)
-				}
+		if #available(iOS 15.0, *) {
+			if self.navigationItem.rightBarButtonItems?.count ?? 0 > 2 {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?[1] else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			} else {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			}
+		} else if #available(iOS 14.0, *) {
+			if self.navigationItem.rightBarButtonItems?.count ?? 0 > 1 {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.last else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			} else {
+				guard let markupButton = self.navigationItem.rightBarButtonItems?.first else { return }
+				_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+			}
 		} else { // action and target is nil on iOS 13
 			guard let markupButton = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton else { return }
 			markupButton.sendActions(for: .touchUpInside)


### PR DESCRIPTION
## Description
This is a fix for enabling the markup edit mode on iOS 15, which was broken there, because a new bar button is available there.

## Related Issue
#1012 

## Motivation and Context
Non working feature on iOS 15

## How Has This Been Tested?
- Select `Markup` action on a PDF or Image
- Markup feature should be enabled automatically
- Test on iOS 13, iOS 14 and iOS 15

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

