### PR TITLE
Added associated domains to resign script

### DIFF
--- a/enterprise/resign/README.md
+++ b/enterprise/resign/README.md
@@ -20,9 +20,9 @@ This script allows you to resign the ownCloud App IPA file with a different Appl
 
    - `group.com.yourcompany.ios-app`
 
-     
 
-     Please keep the prefix `group.` and append the bundle identifier of the app target. 
+
+     Please keep the prefix `group.` and append the bundle identifier of the app target.
 
 3. Edit the App IDs and assign the App Group created on step 2.
 
@@ -34,7 +34,7 @@ This script allows you to resign the ownCloud App IPA file with a different Appl
 
 ## Associated Domains
 
-Create a text file containing a list of line-break separated domain names (FQN) and name it `domains.txt`. This file is expected to be found in the same folder where provisioning profiles are stored. Currently only domains of type `applinks` are supported (others being `webcredentials` and `appclips`).
+Create a text file containing a list of line-break separated domain names (FQN) and name it `domains.txt`. This file is expected to be found in the same folder where this `README.md` file is stored. Currently only domains of type `applinks` are supported (others being `webcredentials` and `appclips`).
 
 ## Instructions
 
@@ -58,7 +58,7 @@ Create a text file containing a list of line-break separated domain names (FQN) 
 
    - `sh resignOwncloudApp "COMMON NAME DISTRIBUTION CERT"`
 
-     
+
 
      Replace `"COMMON NAME DISTRIBUTION CERT"` with the name of your certificate, e.g. `"iPhone Distribution: YOUR COMPANY"`.
 
@@ -66,9 +66,8 @@ Create a text file containing a list of line-break separated domain names (FQN) 
 
 ## IPA Resigned Entitlements Inspection
 
-To check the resigning entitlements of a signed IPA file, please use the script 
+To check the resigning entitlements of a signed IPA file, please use the script
 
-`./resignInspector.sh "Path to signed.ipa"` 
+`./resignInspector.sh "Path to signed.ipa"`
 
 to output the entitlements of the IPA file and all targets.
-

--- a/enterprise/resign/README.md
+++ b/enterprise/resign/README.md
@@ -32,6 +32,10 @@ This script allows you to resign the ownCloud App IPA file with a different Appl
 
 - Get the name of your signing certificate. In most cases this will be named `iPhone Distribution: YOUR COMPANY`.
 
+## Associated Domains
+
+Create a text file containing a list of line-break separated domain names (FQN) and name it `domains.txt`. This file is expected to be found in the same folder where provisioning profiles are stored. Currently only domains of type `applinks` are supported (others being `webcredentials` and `appclips`).
+
 ## Instructions
 
 1. Rename your `.ipa` file to `unsigned.ipa`

--- a/enterprise/resign/resignOwncloudApp
+++ b/enterprise/resign/resignOwncloudApp
@@ -7,7 +7,7 @@
  # For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
  # You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 
 #Define output formats
 BOLD="$(tput bold)"
@@ -58,12 +58,12 @@ APPPAYLOAD="$APPTEMP/Payload"
 APPDIR="$APPPAYLOAD/ownCloud.app"
 PROVISIONING_DIR="Provisioning Files"
 
-DISTRIBUTION_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/App.mobileprovision"
-FILEPROVIDER_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/FileProvider.mobileprovision"
-FILEPROVIDERUI_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/FileProviderUI.mobileprovision"
-INTENT_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/Intent.mobileprovision"
-SHAREEXTENSION_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/ShareExtension.mobileprovision"
-ASSOCIATED_DOMAINS=$(<$PROVISIONING_DIR/$METHOD/domains.txt)
+DISTRIBUTION_MOBILEPROVISION="$PROVISIONING_DIR/App.mobileprovision"
+FILEPROVIDER_MOBILEPROVISION="$PROVISIONING_DIR/FileProvider.mobileprovision"
+FILEPROVIDERUI_MOBILEPROVISION="$PROVISIONING_DIR/FileProviderUI.mobileprovision"
+INTENT_MOBILEPROVISION="$PROVISIONING_DIR/Intent.mobileprovision"
+SHAREEXTENSION_MOBILEPROVISION="$PROVISIONING_DIR/ShareExtension.mobileprovision"
+ASSOCIATED_DOMAINS="domains.txt"
 
 declare -a MOBILEPROVISIONS=(       "$DISTRIBUTION_MOBILEPROVISION"    "$FILEPROVIDER_MOBILEPROVISION"  "$FILEPROVIDERUI_MOBILEPROVISION"  "$INTENT_MOBILEPROVISION"  "$SHAREEXTENSION_MOBILEPROVISION"  );
 declare -a ENTITLEMENTS=(   "ownCloud.entitlements"  "ownCloud_File_Provider.entitlements" "ownCloud_File_Provider_UI.entitlements" "ownCloud_Intents.entitlements" "ownCloud_Share_Extension.entitlements" );
@@ -183,35 +183,33 @@ do
     PlistBuddy -c "Set com.apple.security.application-groups:0 ${APPGROUP}" "${ENTITLEMENTS[$i]}"
     PlistBuddy -c "Set OCAppIdentifierPrefix $APP_ID_PREFIX." "${LOCATIONS[$i]}/Info.plist"
     PlistBuddy -c "Set com.apple.developer.team-identifier ${TEAMID}" "${ENTITLEMENTS[$i]}"
-    
+
     if [[ "${ENTITLEMENTS[$i]}" =~ ^(ownCloud_File_Provider.entitlements)$ ]]; then
 	    PlistBuddy -c "Set NSExtension:NSExtensionFileProviderDocumentGroup $APPGROUP" "${LOCATIONS[$i]}/Info.plist"
-	  fi 
+	  fi
 
     if [[ "${ENTITLEMENTS[$i]}" =~ ^(ownCloud.entitlements)$ ]]; then
         ## Add associated domains
         if [ ! -z "$ASSOCIATED_DOMAINS" ]; then
-            PlistBuddy -c "Delete com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"  2>/dev/null
-            PlistBuddy -c "Add com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"  2>/dev/null
+            PlistBuddy -c "Delete com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"
+            PlistBuddy -c "Add com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"
             let COUNT=0;
-            IFS=',' read -ra strings <<< "$ASSOCIATED_DOMAINS";
-            for j in "${strings[@]}"
+            for DOMAIN in $(cat $ASSOCIATED_DOMAINS)
             do
-                    echo "Adding associated domain: $j into entitlement: ${ENTITLEMENTS[$i]}"
-                    PlistBuddy -c "Add com.apple.developer.associated-domains:$COUNT string applinks:$j" "${ENTITLEMENTS[$i]}" 2>/dev/null
-                    ((COUNT++))
-                    if [[ $COUNT -eq 20 ]]; then
-                        echo "Can not add more then 20 associated-domains as per apple guide lines";
-                        break;
-                    fi
+                echo "Adding associated domain: ${INFO}$DOMAIN${NC} into entitlement: ${INFO}${ENTITLEMENTS[$i]}${NC}"
+                PlistBuddy -c "Add com.apple.developer.associated-domains:$COUNT string applinks:$DOMAIN" "${ENTITLEMENTS[$i]}"
+                ((COUNT++))
+                if [[ $COUNT -eq 20 ]]; then
+                    echo "${WARN}Can not add more then 20 associated-domains as per apple guide lines${NC}";
+                    break;
+                fi
             done
         fi
     fi
 
     # Remove old Code Signatures
     rm -rf "${LOCATIONS[$i]}/_CodeSignature"
-
-    echo  ""$APPGROUP
+    echo ""
 done
 
 echo "${SUCCESS}Resign App, Extensions and Frameworks…${NC}"

--- a/enterprise/resign/resignOwncloudApp
+++ b/enterprise/resign/resignOwncloudApp
@@ -58,11 +58,12 @@ APPPAYLOAD="$APPTEMP/Payload"
 APPDIR="$APPPAYLOAD/ownCloud.app"
 PROVISIONING_DIR="Provisioning Files"
 
-DISTRIBUTION_MOBILEPROVISION="$PROVISIONING_DIR/App.mobileprovision"
-FILEPROVIDER_MOBILEPROVISION="$PROVISIONING_DIR/FileProvider.mobileprovision"
-FILEPROVIDERUI_MOBILEPROVISION="$PROVISIONING_DIR/FileProviderUI.mobileprovision"
-INTENT_MOBILEPROVISION="$PROVISIONING_DIR/Intent.mobileprovision"
-SHAREEXTENSION_MOBILEPROVISION="$PROVISIONING_DIR/ShareExtension.mobileprovision"
+DISTRIBUTION_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/App.mobileprovision"
+FILEPROVIDER_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/FileProvider.mobileprovision"
+FILEPROVIDERUI_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/FileProviderUI.mobileprovision"
+INTENT_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/Intent.mobileprovision"
+SHAREEXTENSION_MOBILEPROVISION="$PROVISIONING_DIR/$METHOD/ShareExtension.mobileprovision"
+ASSOCIATED_DOMAINS=$(<$PROVISIONING_DIR/$METHOD/domains.txt)
 
 declare -a MOBILEPROVISIONS=(       "$DISTRIBUTION_MOBILEPROVISION"    "$FILEPROVIDER_MOBILEPROVISION"  "$FILEPROVIDERUI_MOBILEPROVISION"  "$INTENT_MOBILEPROVISION"  "$SHAREEXTENSION_MOBILEPROVISION"  );
 declare -a ENTITLEMENTS=(   "ownCloud.entitlements"  "ownCloud_File_Provider.entitlements" "ownCloud_File_Provider_UI.entitlements" "ownCloud_Intents.entitlements" "ownCloud_Share_Extension.entitlements" );
@@ -182,9 +183,30 @@ do
     PlistBuddy -c "Set com.apple.security.application-groups:0 ${APPGROUP}" "${ENTITLEMENTS[$i]}"
     PlistBuddy -c "Set OCAppIdentifierPrefix $APP_ID_PREFIX." "${LOCATIONS[$i]}/Info.plist"
     PlistBuddy -c "Set com.apple.developer.team-identifier ${TEAMID}" "${ENTITLEMENTS[$i]}"
+    
     if [[ "${ENTITLEMENTS[$i]}" =~ ^(ownCloud_File_Provider.entitlements)$ ]]; then
 	    PlistBuddy -c "Set NSExtension:NSExtensionFileProviderDocumentGroup $APPGROUP" "${LOCATIONS[$i]}/Info.plist"
-	fi
+	  fi 
+
+    if [[ "${ENTITLEMENTS[$i]}" =~ ^(ownCloud.entitlements)$ ]]; then
+        ## Add associated domains
+        if [ ! -z "$ASSOCIATED_DOMAINS" ]; then
+            PlistBuddy -c "Delete com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"  2>/dev/null
+            PlistBuddy -c "Add com.apple.developer.associated-domains array" "${ENTITLEMENTS[$i]}"  2>/dev/null
+            let COUNT=0;
+            IFS=',' read -ra strings <<< "$ASSOCIATED_DOMAINS";
+            for j in "${strings[@]}"
+            do
+                    echo "Adding associated domain: $j into entitlement: ${ENTITLEMENTS[$i]}"
+                    PlistBuddy -c "Add com.apple.developer.associated-domains:$COUNT string applinks:$j" "${ENTITLEMENTS[$i]}" 2>/dev/null
+                    ((COUNT++))
+                    if [[ $COUNT -eq 20 ]]; then
+                        echo "Can not add more then 20 associated-domains as per apple guide lines";
+                        break;
+                    fi
+            done
+        fi
+    fi
 
     # Remove old Code Signatures
     rm -rf "${LOCATIONS[$i]}/_CodeSignature"


### PR DESCRIPTION
## Description
Resign script can now inject associated domains into the resigned application's entitlements.

Store a text file `domains.txt` in the `/enterprise/resign` folder and run the resign script.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

