### PR TITLE
[fix/open-private-link-branding] Open Private Link in Branded Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/ios-app/compare/milestone/11.7.0...master
+
+Summary
+-------
+
+* Bugfix - Open Private Link in Branded App: [#1031](https://github.com/owncloud/ios-app/issues/1031)
+
+Details
+-------
+
+* Bugfix - Open Private Link in Branded App: [#1031](https://github.com/owncloud/ios-app/issues/1031)
+
+   Private links will now be opened in detail view, if the app client is branded.
+
+   https://github.com/owncloud/ios-app/issues/1031
+
 Changelog for ownCloud iOS Client [11.7.0] (2021-07-29)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.7.0 relevant to

--- a/changelog/unreleased/4558
+++ b/changelog/unreleased/4558
@@ -1,0 +1,5 @@
+Bugfix: Open Private Link in Branded App
+
+Private links will now be opened in detail view, if the app client is branded.
+
+https://github.com/owncloud/ios-app/issues/1031

--- a/ownCloud/Static Login/Interface/StaticLoginViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginViewController.swift
@@ -206,6 +206,7 @@ class StaticLoginViewController: UIViewController, Themeable, StateRestorationCo
 	func connect(to bookmark: OCBookmark, lastVisibleItemId: String?, animated: Bool, present message: OCMessage? = nil) {
 		self.bookmark = bookmark
 		self.lastVisibleItemId = lastVisibleItemId
+		self.openBookmark(bookmark)
 	}
 
 	override func viewWillAppear(_ animated: Bool) {
@@ -365,7 +366,7 @@ class StaticLoginViewController: UIViewController, Themeable, StateRestorationCo
 		let clientRootViewController = ClientRootViewController(bookmark: bookmark)
 		clientRootViewController.modalPresentationStyle = .overFullScreen
 
-		clientRootViewController.afterCoreStart(nil, completionHandler: { (error) in
+		clientRootViewController.afterCoreStart(self.lastVisibleItemId, completionHandler: { (error) in
 			// Set up custom push transition for presentation
 			if let navigationController = self.navigationController {
 				if let error = error {

--- a/ownCloud/Tools/URL+Extensions.swift
+++ b/ownCloud/Tools/URL+Extensions.swift
@@ -107,17 +107,19 @@ extension URL {
 					OCCoreManager.shared.requestCore(for: bookmark, setup: nil) { (core, error) in
 						if core != nil {
 							internetReachable = core!.connectionStatusSignals.contains(.reachable)
-							core?.retrieveItem(forPrivateLink: privateLinkURL, completionHandler: { (error, item) in
-								if foundItem == nil {
-									foundItem = item
-								}
-								if components?.host == bookmark.url?.host {
-									matchedBookmark = bookmark
-								}
-								lastError = error
-								OCCoreManager.shared.returnCore(for: bookmark, completionHandler: nil)
-								group.leave()
-							})
+							OnMainThread {
+								core?.retrieveItem(forPrivateLink: privateLinkURL, completionHandler: { (error, item) in
+									if foundItem == nil {
+										foundItem = item
+									}
+									if components?.host == bookmark.url?.host {
+										matchedBookmark = bookmark
+									}
+									lastError = error
+									OCCoreManager.shared.returnCore(for: bookmark, completionHandler: nil)
+									group.leave()
+								})
+							}
 						} else {
 							group.leave()
 						}

--- a/ownCloud/UIKit Extensions/UIWindow+Extension.swift
+++ b/ownCloud/UIKit Extensions/UIWindow+Extension.swift
@@ -24,13 +24,13 @@ extension UIWindow {
     func display(itemWithID Identifier:String, in bookmark:OCBookmark) {
         if let rootViewController = self.rootViewController as? ThemeNavigationController {
             rootViewController.popToRootViewController(animated: false)
-            if let serverListController = rootViewController.topViewController as? ServerListTableViewController {
-                if serverListController.presentedViewController != nil {
-                    serverListController.dismiss(animated: false, completion: {
-                        serverListController.connect(to: bookmark, lastVisibleItemId: Identifier, animated: false)
+            if let serverListController = rootViewController.topViewController as? StateRestorationConnectProtocol {
+				if let viewController = serverListController as? UIViewController, viewController.presentedViewController != nil {
+					viewController.dismiss(animated: false, completion: {
+                        serverListController.connect(to: bookmark, lastVisibleItemId: Identifier, animated: false, present: nil)
                     })
-                } else {
-                    serverListController.connect(to: bookmark, lastVisibleItemId: Identifier, animated: false)
+				} else {
+                    serverListController.connect(to: bookmark, lastVisibleItemId: Identifier, animated: false, present: nil)
                 }
             }
         }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
This PR fixes a bug, when trying to open a private link via the custom url scheme `owncloud://` or via associated domains `applinks:`.
Now after resolving the private link the file will be opened in detail view.

This PR also fixes a possible deadlock, when trying to retrieve an item for a link.

## Related Issue
#1031

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Check the issue for reproducing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

