### PR TITLE
[feature/configurable-defaults] Allow configuration of default value for user defaults

### DIFF
--- a/ownCloudAppFramework/Branding/Branding.h
+++ b/ownCloudAppFramework/Branding/Branding.h
@@ -61,6 +61,8 @@ typedef NSString* BrandingImageName NS_TYPED_EXTENSIBLE_ENUM;
 - (nullable id)computedValueForClassSettingsKey:(OCClassSettingsKey)classSettingsKey;
 - (nullable NSURL *)urlForClassSettingsKey:(OCClassSettingsKey)settingsKey;
 
+- (void)registerUserDefaultsDefaults;
+
 @end
 
 extern OCClassSettingsIdentifier OCClassSettingsIdentifierBranding;
@@ -68,6 +70,7 @@ extern OCClassSettingsIdentifier OCClassSettingsIdentifierBranding;
 extern BrandingKey BrandingKeyAppName;
 extern BrandingKey BrandingKeyOrganizationName;
 extern BrandingKey BrandingKeyDisabledImportMethods;
+extern BrandingKey BrandingKeyUserDefaultsDefaultValues;
 
 extern BrandingFileImportMethod BrandingFileImportMethodOpenWith;
 extern BrandingFileImportMethod BrandingFileImportMethodShareExtension;

--- a/ownCloudAppFramework/Branding/Branding.m
+++ b/ownCloudAppFramework/Branding/Branding.m
@@ -207,6 +207,16 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 	return (self);
 }
 
+- (void)registerUserDefaultsDefaults
+{
+	// Register user defaults
+	NSDictionary *userDefaultsDefaults;
+	if ((userDefaultsDefaults = self.userDefaultsDefaultValues) != nil)
+	{
+		[OCAppIdentity.sharedAppIdentity.userDefaults registerDefaults:userDefaultsDefaults];
+	}
+}
+
 - (void)registerLegacyKeyPath:(BrandingLegacyKeyPath)keyPath forClassSettingsKey:(OCClassSettingsKey)classSettingsKey;
 {
 	NSMutableDictionary<OCClassSettingsKey, BrandingLegacyKeyPath> *mutableLegacyKeyPathsByClassSettingsKeys = nil;
@@ -229,6 +239,11 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 - (NSString *)organizationName
 {
 	return ([self computedValueForClassSettingsKey:BrandingKeyOrganizationName]);
+}
+
+- (NSDictionary *)userDefaultsDefaultValues
+{
+	return ([self computedValueForClassSettingsKey:BrandingKeyUserDefaultsDefaultValues]);
 }
 
 - (NSArray<BrandingFileImportMethod> *)disabledImportMethods
@@ -349,6 +364,14 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 				BrandingFileImportMethodShareExtension  : @"Disallow import through the Share Extension",
 				BrandingFileImportMethodFileProvider	: @"Disallow import through the File Provider (Files.app)"
 			}
+		},
+
+		// User Defaults
+		BrandingKeyUserDefaultsDefaultValues : @{
+			OCClassSettingsMetadataKeyType 		: OCClassSettingsMetadataTypeDictionary,
+			OCClassSettingsMetadataKeyDescription 	: @"Default values for user defaults. Allows overriding default settings.",
+			OCClassSettingsMetadataKeyStatus	: OCClassSettingsKeyStatusAdvanced,
+			OCClassSettingsMetadataKeyCategory	: @"Branding"
 		}
 	});
 }
@@ -357,9 +380,10 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(Branding)
 
 OCClassSettingsIdentifier OCClassSettingsIdentifierBranding = @"branding";
 
-OCClassSettingsKey BrandingKeyAppName = @"app-name";
-OCClassSettingsKey BrandingKeyOrganizationName = @"organization-name"; 	// Legacy Branding Key: organizationName
-OCClassSettingsKey BrandingKeyDisabledImportMethods = @"disabled-import-methods";
+BrandingKey BrandingKeyAppName = @"app-name";
+BrandingKey BrandingKeyOrganizationName = @"organization-name"; 	// Legacy Branding Key: organizationName
+BrandingKey BrandingKeyDisabledImportMethods = @"disabled-import-methods";
+BrandingKey BrandingKeyUserDefaultsDefaultValues = @"user-defaults-default-values";
 
 BrandingFileImportMethod BrandingFileImportMethodOpenWith = @"open-with";
 BrandingFileImportMethod BrandingFileImportMethodShareExtension = @"share-extension";

--- a/ownCloudAppFramework/Branding/BrandingClassSettingsSource.m
+++ b/ownCloudAppFramework/Branding/BrandingClassSettingsSource.m
@@ -24,6 +24,7 @@
 + (void)load
 {
 	[OCClassSettings.sharedSettings insertSource:[BrandingClassSettingsSource new] before:OCClassSettingsSourceIdentifierManaged after:nil];
+	[Branding.sharedBranding registerUserDefaultsDefaults];
 }
 
 - (OCClassSettingsSourceIdentifier)settingsSourceIdentifier


### PR DESCRIPTION
## Description
Adds a new `branding.user-defaults-default-values` class setting to allow registration of alternative defaults for user defaults.

To, f.ex. turn on conversion of HEIC to JPEG and of videos to MP4, one would use
```
<key>branding.user-defaults-default-values</key>
<dict>
	<key>convert-heic-to-jpeg</key>
	<true/>
	<key>convert-videos-to-mp4</key>
	<true/>
</dict>
```

## Related Issue
https://github.com/owncloud/enterprise/issues/4766

## How Has This Been Tested?
With a example `Branding.plist`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
