### PR TITLE
[feature/hide-background-location-settings] Do not show Background Location section by default

### DIFF
--- a/ownCloud/Settings/AutoUploadSettingsSection.swift
+++ b/ownCloud/Settings/AutoUploadSettingsSection.swift
@@ -210,6 +210,8 @@ class AutoUploadSettingsSection: SettingsSection {
 				updateDynamicUI()
 			}
 		}
+
+		NotificationCenter.default.post(name: .OCBookmarkManagerListChanged, object: nil)
 	}
 
 	private func setupVideoAutoUpload(enabled:Bool) {
@@ -226,6 +228,8 @@ class AutoUploadSettingsSection: SettingsSection {
 			   updateDynamicUI()
 		   }
 		}
+
+		NotificationCenter.default.post(name: .OCBookmarkManagerListChanged, object: nil)
 	}
 
 	private func getSelectedBookmark(for mediaType:MediaType) -> OCBookmark? {

--- a/ownCloud/Settings/MediaUploadSettingsViewController.swift
+++ b/ownCloud/Settings/MediaUploadSettingsViewController.swift
@@ -49,9 +49,9 @@ class MediaUploadSettingsViewController: StaticTableViewController {
 
 	@objc private func reconsiderSections() {
 		OnMainThread {
-			guard let proSettingsSection = self.proPhotoSettingsSection else { return }
+			guard let proSettingsSection = self.proPhotoSettingsSection, let userDefaults = OCAppIdentity.shared.userDefaults else { return }
 
-			if OCBookmarkManager.shared.bookmarks.count > 0, let userDefaults = OCAppIdentity.shared.userDefaults {
+			if OCBookmarkManager.shared.bookmarks.count > 0 {
 				if self.autoUploadSection == nil {
 					self.autoUploadSection = AutoUploadSettingsSection(userDefaults: userDefaults)
 
@@ -73,7 +73,7 @@ class MediaUploadSettingsViewController: StaticTableViewController {
 						} else {
 							self.addSection(backgroundUploadsSection)
 						}
-					} else {
+					} else if !userDefaults.instantUploadPhotos, !userDefaults.instantUploadVideos {
 						self.removeSection(backgroundUploadsSection, animated: true)
 					}
 				}
@@ -82,7 +82,7 @@ class MediaUploadSettingsViewController: StaticTableViewController {
 					self.removeSection(autoUploadSection)
 					self.autoUploadSection = nil
 				}
-				if let backgroundUploadsSection = self.backgroundUploadsSection, backgroundUploadsSection.attached {
+				if let backgroundUploadsSection = self.backgroundUploadsSection, backgroundUploadsSection.attached, !userDefaults.instantUploadPhotos, !userDefaults.instantUploadVideos {
 					self.removeSection(backgroundUploadsSection)
 					self.backgroundUploadsSection = nil
 				}

--- a/ownCloud/Settings/MediaUploadSettingsViewController.swift
+++ b/ownCloud/Settings/MediaUploadSettingsViewController.swift
@@ -66,8 +66,16 @@ class MediaUploadSettingsViewController: StaticTableViewController {
 				if let autoUploadSection = self.autoUploadSection, !autoUploadSection.attached {
 					self.addSection(autoUploadSection)
 				}
-				if let backgroundUploadsSection = self.backgroundUploadsSection, backgroundUploadsSection.rows.count > 0, !backgroundUploadsSection.attached {
-					self.addSection(backgroundUploadsSection)
+				if let backgroundUploadsSection = self.backgroundUploadsSection {
+					if !backgroundUploadsSection.attached, backgroundUploadsSection.rows.count > 0, (userDefaults.instantUploadPhotos || userDefaults.instantUploadVideos) {
+						if let autoUploadSection = self.autoUploadSection, let index = self.indexForSection(autoUploadSection) {
+							self.insertSection(backgroundUploadsSection, at: (index + 1), animated: true)
+						} else {
+							self.addSection(backgroundUploadsSection)
+						}
+					} else {
+						self.removeSection(backgroundUploadsSection, animated: true)
+					}
 				}
 			} else {
 				if let autoUploadSection = self.autoUploadSection, autoUploadSection.attached {

--- a/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewController.swift
+++ b/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewController.swift
@@ -153,6 +153,10 @@ open class StaticTableViewController: UITableViewController, Themeable {
 		return nil
 	}
 
+	open func indexForSection(_ inSection: StaticTableViewSection) -> Int? {
+		return sections.index(of: inSection)
+	}
+
 	// MARK: - View Controller
 	override open func viewDidLoad() {
 		super.viewDidLoad()


### PR DESCRIPTION
## Description
Do not show the `Background Location` settings section, if no upload path was chosen.

## Related Issue
#1050 

## Motivation and Context
[UX] Only show settings to the user, which can be enabled.

## How Has This Been Tested?
- open `Media Upload` settings
- `Background Location` settings section should only be visible, if a upload path was chosen 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

## QA

Reports:

- [x] (1) Browsing back, items are gone https://github.com/owncloud/ios-app/pull/1051#issuecomment-946416631 [FIXED]
- [x] (2) Upgrading with camera uploads enabled https://github.com/owncloud/ios-app/pull/1051#issuecomment-946420363 [FIXED]
- [x] (3) With both videos and photos enabled, background section is hidden https://github.com/owncloud/ios-app/pull/1051#issuecomment-946423937 [FIXED]