### PR TITLE
[feature/improved-acknowledgements] List/detail view of licenses

### DIFF
--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		DC3BE0DA2077BC6B002A0AC0 /* ownCloudSDK.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 239369782076110900BCE21A /* ownCloudSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DC3BE0DF2077CC14002A0AC0 /* ClientRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3BE0DD2077CC13002A0AC0 /* ClientRootViewController.swift */; };
 		DC3DEC7B22AFA1F000F3352D /* DownloadItemsHUDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3DEC7A22AFA1F000F3352D /* DownloadItemsHUDViewController.swift */; };
+		DC3F4522271A23A000ED2383 /* AcknowledgementsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3F4521271A23A000ED2383 /* AcknowledgementsTableViewController.swift */; };
 		DC4332002472E1B4002DC0E5 /* OCLicenseEMMProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = DC4331FE2472E1B4002DC0E5 /* OCLicenseEMMProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC4332012472E1B4002DC0E5 /* OCLicenseEMMProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = DC4331FF2472E1B4002DC0E5 /* OCLicenseEMMProvider.m */; };
 		DC44343E21ABFA5200376B16 /* StaticLoginProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC44343D21ABFA5200376B16 /* StaticLoginProfile.swift */; };
@@ -1265,6 +1266,7 @@
 		DC3DEC7A22AFA1F000F3352D /* DownloadItemsHUDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadItemsHUDViewController.swift; sourceTree = "<group>"; };
 		DC3DEC7C22AFFE8E00F3352D /* KVOWaiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KVOWaiter.swift; sourceTree = "<group>"; };
 		DC3DEC7F22B03AE700F3352D /* CardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewController.swift; sourceTree = "<group>"; };
+		DC3F4521271A23A000ED2383 /* AcknowledgementsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsTableViewController.swift; sourceTree = "<group>"; };
 		DC422449207CAFAA0006A2A6 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		DC42244B207CAFBB0006A2A6 /* ThemeCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCollection.swift; sourceTree = "<group>"; };
 		DC42244F207CB2500006A2A6 /* NSObject+ThemeApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+ThemeApplication.swift"; sourceTree = "<group>"; };
@@ -3043,6 +3045,7 @@
 				025FC72824781659009307A7 /* AutoUploadSettingsSection.swift */,
 				02DC7C8F24CB354800DCB2C6 /* ProPhotoUploadSettingsSection.swift */,
 				025FC744247EF0F1009307A7 /* BackgroundUploadsSettingsSection.swift */,
+				DC3F4521271A23A000ED2383 /* AcknowledgementsTableViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -4060,6 +4063,7 @@
 				397E276C23D05A5400117B07 /* ServerListToolCell.swift in Sources */,
 				DCC8535823CE1236007BA3EB /* LicenseInAppProductListViewController.swift in Sources */,
 				23EC775B2137F3DD0032D4E6 /* OCExtensionType+Extension.swift in Sources */,
+				DC3F4522271A23A000ED2383 /* AcknowledgementsTableViewController.swift in Sources */,
 				4C88041822E78D790016CBA9 /* MediaFilesSettings.swift in Sources */,
 				025FC7272478123E009307A7 /* MediaExportSettingsSection.swift in Sources */,
 				39B394492385334D00892E8D /* ThemeView.swift in Sources */,

--- a/ownCloud/Resources/en.lproj/Localizable.strings
+++ b/ownCloud/Resources/en.lproj/Localizable.strings
@@ -220,6 +220,7 @@
 "Privacy Policy" = "Privacy Policy";
 "Terms Of Use" = "Terms Of Use";
 "Acknowledgements" = "Acknowledgements";
+"license" = "license";
 "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged." = "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged.";
 "Video upload path" = "Video upload path";
 "Photo upload path" = "Photo upload path";

--- a/ownCloud/Settings/AcknowledgementsTableViewController.swift
+++ b/ownCloud/Settings/AcknowledgementsTableViewController.swift
@@ -1,0 +1,69 @@
+//
+//  AcknowledgementsTableViewController.swift
+//  ownCloud
+//
+//  Created by Felix Schwarz on 15.10.21.
+//  Copyright © 2021 ownCloud GmbH. All rights reserved.
+//
+
+import UIKit
+import ownCloudSDK
+import ownCloudAppShared
+
+class AcknowledgementsTableViewController: StaticTableViewController {
+
+	var licensesSection : StaticTableViewSection?
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		navigationItem.title = "Acknowledgements".localized
+
+		addSection(StaticTableViewSection(headerTitle: "", footerTitle: nil, identifier: nil, rows: [
+			StaticTableViewRow(message: "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged.".localized, style: .text)
+		]))
+
+		let context = OCExtensionContext(location: OCExtensionLocation(ofType: .license, identifier: nil), requirements: nil, preferences: nil)
+
+		OCExtensionManager.shared.provideExtensions(for: context, completionHandler: { (_, context, licenses) in
+			OnMainThread {
+				let licensesSection = StaticTableViewSection(headerTitle: "")
+
+				if let licenses = licenses {
+					for licenseExtensionMatch in licenses {
+						let extensionObject = licenseExtensionMatch.extension.provideObject(for: context)
+
+						if let licenseDict = extensionObject as? [String : Any],
+						   let licenseTitle = licenseDict["title"] as? String,
+						   let licenseURL = licenseDict["url"] as? URL {
+							licensesSection.insert(row: StaticTableViewRow(rowWithAction: { row, _ in
+								let textViewController = TextViewController()
+								let licenseText : NSMutableAttributedString = NSMutableAttributedString()
+								let textAttributes : [NSAttributedString.Key : Any] = [
+									.font : UIFont.systemFont(ofSize: UIFont.systemFontSize)
+								]
+
+								textViewController.title = "\(licenseTitle) \("license".localized)"
+								textViewController.navigationItem.largeTitleDisplayMode = .never
+
+								// License text
+								do {
+									var encoding : String.Encoding = .utf8
+									let licenseFileContents = try String(contentsOf: licenseURL, usedEncoding: &encoding)
+
+									licenseText.append(NSAttributedString(string: "\n" + licenseFileContents + "\n\n", attributes: textAttributes))
+								} catch {
+								}
+
+								textViewController.attributedText = licenseText
+
+								row.viewController?.navigationController?.pushViewController(textViewController, animated: true)
+							}, title: licenseTitle, accessoryType: .disclosureIndicator), at: 0)
+						}
+					}
+				}
+
+				self.addSection(licensesSection, animated: false)
+			}
+		})
+    }
+}

--- a/ownCloud/Settings/MoreSettingsSection.swift
+++ b/ownCloud/Settings/MoreSettingsSection.swift
@@ -88,54 +88,7 @@ class MoreSettingsSection: SettingsSection {
 		}
 
 		acknowledgementsRow = StaticTableViewRow(rowWithAction: { (row, _) in
-			let context = OCExtensionContext(location: OCExtensionLocation(ofType: .license, identifier: nil), requirements: nil, preferences: nil)
-
-			OCExtensionManager.shared.provideExtensions(for: context, completionHandler: { (_, context, licenses) in
-				OnMainThread {
-					let textViewController = TextViewController()
-					let licenseText : NSMutableAttributedString = NSMutableAttributedString()
-
-					textViewController.title = "Acknowledgements".localized
-
-					if licenses != nil {
-						let titleAttributes : [NSAttributedString.Key : Any] = [
-							.font : UIFont.boldSystemFont(ofSize: UIFont.systemFontSize * 1.5)
-						]
-
-						let textAttributes : [NSAttributedString.Key : Any] = [
-							.font : UIFont.systemFont(ofSize: UIFont.systemFontSize)
-						]
-
-					   	// Preamble
-						licenseText.append(NSAttributedString(string: "Acknowledgements".localized + "\n", attributes: titleAttributes))
-						licenseText.append(NSAttributedString(string: "\n" + "Portions of this app may utilize the following copyrighted material, the use of which is hereby acknowledged.".localized + "\n\n", attributes: textAttributes))
-
-						for licenseExtensionMatch in licenses! {
-							let extensionObject = licenseExtensionMatch.extension.provideObject(for: context)
-
-							if let licenseDict = extensionObject as? [String : Any],
-							   let licenseTitle = licenseDict["title"] as? String,
-							   let licenseURL = licenseDict["url"] as? URL {
-							   	// Title
-								licenseText.append(NSAttributedString(string: licenseTitle + "\n", attributes: titleAttributes))
-
-								// License text
-								do {
-									var encoding : String.Encoding = .utf8
-									let licenseFileContents = try String(contentsOf: licenseURL, usedEncoding: &encoding)
-
-									licenseText.append(NSAttributedString(string: "\n" + licenseFileContents + "\n\n", attributes: textAttributes))
-								} catch {
-								}
-							}
-						}
-					}
-
-					textViewController.attributedText = licenseText
-
-					row.viewController?.navigationController?.pushViewController(textViewController, animated: true)
-				}
-			})
+			row.viewController?.navigationController?.pushViewController(AcknowledgementsTableViewController(style: .grouped), animated: true)
 		}, title: "Acknowledgements".localized, accessoryType: .disclosureIndicator, identifier: "acknowledgements")
 
 		var buildType = "release".localized

--- a/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
+++ b/ownCloudAppShared/User Interface/StaticTableView/StaticTableViewRow.swift
@@ -54,6 +54,7 @@ public enum StaticTableViewRowActionType {
 
 public enum StaticTableViewRowMessageStyle {
 	case plain
+	case text
 	case warning
 	case alert
 	case confirmation
@@ -604,6 +605,11 @@ open class StaticTableViewRow : NSObject, UITextFieldDelegate {
 				case .plain:
 					textColor = themeCollection.tintColor
 					tintColor = textColor
+					backgroundColor = themeCollection.tableRowColors.backgroundColor
+
+				case .text:
+					textColor = themeCollection.tableRowColors.labelColor
+					tintColor = themeCollection.tableRowColors.labelColor
 					backgroundColor = themeCollection.tableRowColors.backgroundColor
 
 				case .confirmation:

--- a/ownCloudAppShared/User Interface/Theme/UI/ThemeTableViewCell.swift
+++ b/ownCloudAppShared/User Interface/Theme/UI/ThemeTableViewCell.swift
@@ -141,6 +141,10 @@ open class ThemeTableViewCell: UITableViewCell, Themeable {
 						textColor = collection.tintColor
 						backgroundColor = collection.tableRowColors.backgroundColor
 
+					case .text:
+						textColor = collection.tableRowColors.labelColor
+						backgroundColor = collection.tableRowColors.backgroundColor
+
 					case .confirmation:
 						textColor = collection.approvalColors.normal.foreground
 						backgroundColor = collection.approvalColors.normal.background


### PR DESCRIPTION
## Description
Add new view controller to present license texts for each component individually.

## Related Issue
https://github.com/owncloud/enterprise/issues/4801

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 12 mini - 2021-10-15 at 23 51 30](https://user-images.githubusercontent.com/639669/137557420-a05d6158-2578-4d53-a864-e7a424591f71.png) | ![Simulator Screen Shot - iPhone 12 mini - 2021-10-15 at 23 51 47](https://user-images.githubusercontent.com/639669/137557434-02f93a61-c911-46b7-9a81-e152382bfff5.png)
--|--

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
