### PR TITLE
[feature/mdm-auto-connect] Skip Account Screen via MDM

### DIFF
--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -60,7 +60,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			} else {
 				configure(window: window, with: userActivity)
 			}
-		} else if ServerListTableViewController.classSetting(forOCClassSettingsKey: .accountAutoConnect) as? Bool ?? false, let bookmark = OCBookmarkManager.shared.bookmark(at: 0) {
+		} else if ServerListTableViewController.classSetting(forOCClassSettingsKey: .accountAutoConnect) as? Bool ?? false, let bookmark = OCBookmarkManager.shared.bookmarks.first {
 			connect(to: bookmark)
 		}
 	}

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -60,6 +60,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			} else {
 				configure(window: window, with: userActivity)
 			}
+		} else if ServerListTableViewController.classSetting(forOCClassSettingsKey: .accountAutoConnect) as? Bool ?? false, let bookmark = OCBookmarkManager.shared.bookmark(at: 0) {
+			connect(to: bookmark)
 		}
 	}
 
@@ -88,12 +90,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	@discardableResult func configure(window: ThemeWindow?, with activity: NSUserActivity) -> Bool {
 		if let bookmarkUUIDString = activity.userInfo?[OCBookmark.ownCloudOpenAccountAccountUuidKey] as? String,
 		   let bookmarkUUID = UUID(uuidString: bookmarkUUIDString),
-		   let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID),
-		   let navigationController = window?.rootViewController as? ThemeNavigationController,
-		   let serverListController = navigationController.topViewController as? StateRestorationConnectProtocol {
+		   let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID) {
 			if activity.title == OCBookmark.ownCloudOpenAccountPath {
-				serverListController.connect(to: bookmark, lastVisibleItemId: nil, animated: false, present: nil)
-				window?.windowScene?.userActivity = bookmark.openAccountUserActivity
+				connect(to: bookmark)
 
 				return true
 			} else if activity.title == OpenItemUserActivity.ownCloudOpenItemPath {
@@ -102,8 +101,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 				}
 
 				// At first connect to the bookmark for the item
-				serverListController.connect(to: bookmark, lastVisibleItemId: itemLocalID, animated: false, present: nil)
-				window?.windowScene?.userActivity = activity
+				connect(to: bookmark, lastVisibleItemId: itemLocalID, activity: activity)
 
 				return true
 			}
@@ -115,6 +113,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		}
 
 		return false
+	}
+
+	func connect(to bookmark: OCBookmark, lastVisibleItemId: String? = nil, activity: NSUserActivity? = nil) {
+		if let navigationController = window?.rootViewController as? ThemeNavigationController,
+		   let serverListController = navigationController.topViewController as? StateRestorationConnectProtocol {
+			serverListController.connect(to: bookmark, lastVisibleItemId: lastVisibleItemId, animated: false, present: nil)
+			window?.windowScene?.userActivity = activity ?? bookmark.openAccountUserActivity
+		}
 	}
 
 	func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/ownCloud/Server List/ServerListTableViewController.swift
+++ b/ownCloud/Server List/ServerListTableViewController.swift
@@ -991,3 +991,37 @@ extension ServerListTableViewController: UITableViewDragDelegate {
 extension NSNotification.Name {
 	static let BookmarkMessageCountChanged = NSNotification.Name("boomark.message-count.changed")
 }
+
+// MARK: - OCClassSettings support
+extension OCClassSettingsIdentifier {
+	static let account = OCClassSettingsIdentifier("account")
+}
+
+extension OCClassSettingsKey {
+	static let accountAutoConnect = OCClassSettingsKey("auto-connect")
+}
+
+extension ServerListTableViewController : OCClassSettingsSupport {
+	static let classSettingsIdentifier : OCClassSettingsIdentifier = .account
+
+	static func defaultSettings(forIdentifier identifier: OCClassSettingsIdentifier) -> [OCClassSettingsKey : Any]? {
+		if identifier == .account {
+			return [
+				.accountAutoConnect : false
+			]
+		}
+
+		return nil
+	}
+
+	static func classSettingsMetadata() -> [OCClassSettingsKey : [OCClassSettingsMetadataKey : Any]]? {
+		return [
+			.accountAutoConnect : [
+				.type 		: OCClassSettingsMetadataType.boolean,
+				.description	: "Skip \"Account\" screen / automatically open \"Files\" screen after login",
+				.category	: "Account",
+				.status		: OCClassSettingsKeyStatus.supported
+			]
+		]
+	}
+}

--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -361,7 +361,9 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 							OCBookmarkManager.shared.addBookmark(bookmark)
 
 							self.loginViewController?.showFirstScreen()
-							//self.pushSuccessViewController()
+							if ServerListTableViewController.classSetting(forOCClassSettingsKey: .accountAutoConnect) as? Bool ?? false {
+								self.loginViewController?.openBookmark(bookmark)
+							}
 						} else {
 							var issue : OCIssue?
 							let nsError = error as NSError?

--- a/ownCloud/Static Login/Interface/StaticLoginViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginViewController.swift
@@ -332,10 +332,6 @@ class StaticLoginViewController: UIViewController, Themeable, StateRestorationCo
 		// PushTransition correctly restores the view
 		serverList?.pushFromViewController = self
 
-		if let bookmark = bookmark {
-			serverList?.connect(to: bookmark, lastVisibleItemId: lastVisibleItemId, animated: false)
-		}
-
 		return serverList!
 	}
 


### PR DESCRIPTION
## Description
Skip "Manage" screen / automatically open "Files" screen after login via MDM parameter

## Related Issue
https://github.com/owncloud/enterprise/issues/4801

## Motivation and Context
Skip the account screen automatically.

## How Has This Been Tested?
- configure branded app
- set parameter `account.auto-connect` with value `true` via MDM or `Branding.plist`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased

