### PR TITLE
[fix/clear-lock] Clear lock when determining unlock expiry

### DIFF
--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -342,6 +342,11 @@ public class AppLockManager: NSObject {
 		if unlocked, !self.shouldDisplayCountdown {
 			if let date = self.lastApplicationBackgroundedDate {
 				if Int(-date.timeIntervalSinceNow) < AppLockSettings.shared.lockDelay {
+					// Clear unlocked state immediately if it has expired, so subsequently
+					// changing the device's clock time can't lead to an unlock
+					unlocked = false
+					lastApplicationBackgroundedDate = nil
+
 					return false
 				}
 			}

--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -340,8 +340,8 @@ public class AppLockManager: NSObject {
 		}
 
 		if unlocked, !self.shouldDisplayCountdown {
-			if let date = self.lastApplicationBackgroundedDate {
-				if date.timeIntervalSinceNow > 0 {
+			if let backgroundedDate = lastApplicationBackgroundedDate {
+				if backgroundedDate.timeIntervalSinceNow > 0 {
 					// Device time is earlier than lastApplicationBackgroundedDate,
 					// which should not be possible. Clear unlocked state immediately
 					// to protect against this or other attempts to gain access by
@@ -349,11 +349,12 @@ public class AppLockManager: NSObject {
 					unlocked = false
 					lastApplicationBackgroundedDate = nil
 
-					Log.error(tagged: ["Security"], "Current device time \(Date().description) preceeds last application backgrounded date \(lastApplicationBackgroundedDate?.description ?? "?"), possibly indicating device time manipulation. Unlock status cleared.")
+					Log.error(tagged: ["Security"], "Current device time \(Date().description) preceeds last application backgrounded date \(backgroundedDate.description), possibly indicating device time manipulation. Unlock status cleared.")
 
-					return false
+					return true
 				} else {
-					if Int(-date.timeIntervalSinceNow) < AppLockSettings.shared.lockDelay {
+					if Int(-backgroundedDate.timeIntervalSinceNow) < AppLockSettings.shared.lockDelay {
+						// Unlock still valid
 						return false
 					}
 				}

--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -352,19 +352,19 @@ public class AppLockManager: NSObject {
 					Log.error(tagged: ["Security"], "Current device time \(Date().description) preceeds last application backgrounded date \(lastApplicationBackgroundedDate?.description ?? "?"), possibly indicating device time manipulation. Unlock status cleared.")
 
 					return false
-				}
-
-				if Int(-date.timeIntervalSinceNow) < AppLockSettings.shared.lockDelay {
-					// Clear unlocked state immediately if it has expired, so subsequently
-					// changing the device's clock time can't lead to an unlock
-					unlocked = false
-					lastApplicationBackgroundedDate = nil
-
-					return false
+				} else {
+					if Int(-date.timeIntervalSinceNow) < AppLockSettings.shared.lockDelay {
+						return false
+					}
 				}
 			}
 		}
+
+		// Clear unlocked state immediately if it has expired, so subsequently
+		// changing the device's clock time can't lead to an unlock
 		unlocked = false
+		lastApplicationBackgroundedDate = nil
+
 		return true
 	}
 


### PR DESCRIPTION
## Description
Clear `unlock` and `lastApplicationBackgroundedDate` in `AppLockManager` in case an unlock has expired, to protect against subsequent attempts setting the device time to an earlier date.

Previously, only the `unlock` value was reset.

Also clears `unlock` and `lastApplicationBackgroundedDate` in `AppLockManager` and logs a security warning in case device time precedes `lastApplicationBackgroundedDate`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
