### PR TITLE
[feature/sort-order] Localized sort order

### DIFF
--- a/ownCloudAppShared/Client/User Interface/SortMethod.swift
+++ b/ownCloudAppShared/Client/User Interface/SortMethod.swift
@@ -77,16 +77,17 @@ public enum SortMethod: Int {
 	public func comparator(direction: SortDirection) -> OCSort {
 		var comparator: OCSort
 		var combinedComparator: OCSort?
+		let localizedSortComparator = OCSQLiteCollationLocalized.sortComparator!
 
 		let alphabeticComparator : OCSort = { (left, right) in
 			guard let leftName  = (left as? OCItem)?.name, let rightName = (right as? OCItem)?.name else {
 				return .orderedSame
 			}
 			if direction == .descendant {
-				return rightName.caseInsensitiveCompare(leftName)
+				return localizedSortComparator(rightName, leftName)
 			}
 
-			return leftName.caseInsensitiveCompare(rightName)
+			return localizedSortComparator(leftName, rightName)
 		}
 
 		let itemTypeComparator : OCSort = { (left, right) in


### PR DESCRIPTION
## Description
This PR changes sorting to use localized sorting across query results and database queries, via the SDK's new `OCLOCALIZED` collation and sort comparator.

What was previously 
`1`, `100`, `11`
now becomes 
`1`, `11`, `100`.

## Related Issue
#975 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
