### PR TITLE
[fix/pdf-editing] Fix PDF editing

### DIFF
--- a/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/DocumentEditingAction.swift
@@ -82,9 +82,10 @@ class DocumentEditingAction : Action {
 				if let fileURL = files.first?.url, let item = self.context.items.first {
 
 					if QLPreviewController.canPreview(fileURL as QLPreviewItem) {
-
 						let editDocumentViewController = EditDocumentViewController(with: fileURL, item: item, core: self.core)
 						let navigationController = ThemeNavigationController(rootViewController: editDocumentViewController)
+
+						editDocumentViewController.pdfViewController = hostViewController as? PDFViewerViewController
 						navigationController.modalPresentationStyle = .overFullScreen
 						viewController.present(navigationController, animated: true)
 					} else {

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -31,6 +31,7 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 	var modifiedContentsURL: URL?
 	var dismissedViewWithoutSaving: Bool = false
 	var timer: DispatchSourceTimer?
+	var pdfViewController : PDFViewerViewController?
 
 	var source: URL {
 		didSet {
@@ -218,6 +219,8 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 			}
 		case .updateContents:
 			if let core = core, let parentItem = item.parentItem(from: core) {
+				pdfViewController?.allowUpdatesUntilLocalModificationPersists = true
+
 				core.reportLocalModification(of: item, parentItem: parentItem, withContentsOfFileAt: url, isSecurityScoped: true, options: [OCCoreOption.importByCopying : true], placeholderCompletionHandler: { (error, _) in
 					if let error = error {
 						self.present(error: error, title: "Saving edited file failed".localized)


### PR DESCRIPTION
## Description
- fixes bug that prevents changes to PDFs being saved in place.
- after editing, the viewer no longer asks if the PDF file should be refreshed, but instead the viewer refreshes it automatically to reflect the changes.

## Related Issue
https://github.com/owncloud/enterprise/issues/4934

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
