### PR TITLE
[fix/branding-folder-color] Branding: Corporate Color as Folder Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ ownCloud admins and users.
 Summary
 -------
 
-* Change - (Branding) Corporate Color as Folder Color: [#1069](https://github.com/owncloud/ios-app/issues/1069)
 * Bugfix - PDF Editing: [#4934](https://github.com/owncloud/enterprise/issues/4934)
+* Change - (Branding) Corporate Color as Folder Color: [#1069](https://github.com/owncloud/ios-app/issues/1069)
 
 Details
 -------
+
+* Bugfix - PDF Editing: [#4934](https://github.com/owncloud/enterprise/issues/4934)
+
+   Fixed bug that prevents changes to PDFs being saved in place.
+
+   https://github.com/owncloud/enterprise/issues/4934
 
 * Change - (Branding) Corporate Color as Folder Color: [#1069](https://github.com/owncloud/ios-app/issues/1069)
 
@@ -20,12 +26,6 @@ Details
    key/value pair).
 
    https://github.com/owncloud/ios-app/issues/1069
-
-* Bugfix - PDF Editing: [#4934](https://github.com/owncloud/enterprise/issues/4934)
-
-   Fixed bug that prevents changes to PDFs being saved in place.
-
-   https://github.com/owncloud/enterprise/issues/4934
 
 Changelog for ownCloud iOS Client [11.8.1] (2021-12-22)
 =======================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/ios-app/compare/milestone/11.8.1...master
+
+Summary
+-------
+
+* Change - (Branding) Corporate Color as Folder Color: [#1069](https://github.com/owncloud/ios-app/issues/1069)
+
+Details
+-------
+
+* Change - (Branding) Corporate Color as Folder Color: [#1069](https://github.com/owncloud/ios-app/issues/1069)
+
+   Use the corporate color as folder color as default color (can be overridden by the specific
+   key/value pair).
+
+   https://github.com/owncloud/ios-app/issues/1069
+
 Changelog for ownCloud iOS Client [11.8.1] (2021-12-22)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.8.1 relevant to

--- a/changelog/unreleased/4857
+++ b/changelog/unreleased/4857
@@ -1,0 +1,5 @@
+Change: (Branding) Corporate Color as Folder Color
+
+Use the corporate color as folder color as default color (can be overridden by the specific key/value pair).
+
+https://github.com/owncloud/ios-app/issues/1069

--- a/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
+++ b/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
@@ -385,6 +385,8 @@ public class ThemeCollection : NSObject {
 					defaultSearchBarColor.labelColor = UIColor(hex: 0x000000)
 					defaultSearchBarColor.secondaryLabelColor = UIColor.gray
 					defaultSearchBarColor.backgroundColor = UIColor(hex: 0xF7F7F7)
+					self.tableRowColors.symbolColor = darkColor
+					self.tableRowHighlightColors.symbolColor = darkColor
 				}
 
 				self.searchBarColors = colors.resolveThemeColorCollection("Searchbar", defaultSearchBarColor)


### PR DESCRIPTION
## Description
Use the corporate color as folder color as default color (can be overridden by the specific key/value pair).

## Related Issue
[1069](https://github.com/owncloud/ios-app/issues/1069)

## Motivation and Context
Reduce default branding configuration by setting the corporate color by default.

## How Has This Been Tested?
Copy a `Branding.plist` only with the minimal color set into the project and build the app.
Check, if the folder was colored with the corporate color.

Set the corporate color:
```
<key>branding.theme-definitions$[0].darkBrandColor</key>
<string>#DD00DD</string>
```

Set the folder fill color:
```
<key>branding.theme-definitions$[0].Colors.Icon.folderFillColorr</key>
<string>#DD00DD</string>
```

Please check if everything is working fine, with the unbranded app (dark, light, contrast).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
