### PR TITLE
[fix/continuous-audio-playback] Fix: Continuous Audio Playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/ios-app/compare/milestone/11.8.1...master
+
+Summary
+-------
+
+* Bugfix - Continuous Audio Playback: [#4924](https://github.com/owncloud/enterprise/issues/4924)
+
+Details
+-------
+
+* Bugfix - Continuous Audio Playback: [#4924](https://github.com/owncloud/enterprise/issues/4924)
+
+   Fixed continuous audio playback, which stopped, after two audio files.
+
+   https://github.com/owncloud/enterprise/issues/4924
+
 Changelog for ownCloud iOS Client [11.8.1] (2021-12-22)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.8.1 relevant to

--- a/changelog/unreleased/4924
+++ b/changelog/unreleased/4924
@@ -1,0 +1,5 @@
+Bugfix: Continuous Audio Playback
+
+Fixed continuous audio playback, which stopped, after two audio files.
+
+https://github.com/owncloud/enterprise/issues/4924

--- a/ownCloud/Client/Viewer/DisplayHostViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayHostViewController.swift
@@ -359,7 +359,8 @@ extension DisplayHostViewController {
 
 	@objc private func handleMediaPlaybackFinished(notification:Notification) {
 		if let mediaController = activeDisplayViewController as? MediaDisplayViewController {
-			if let displayViewController = adjacentViewController(relativeTo: mediaController, .after, includeOnlyMediaItems: true) {
+			if let displayViewController = adjacentViewController(relativeTo: mediaController, .after, includeOnlyMediaItems: true) as? MediaDisplayViewController {
+				activeDisplayViewController = displayViewController
 				self.setViewControllers([displayViewController], direction: .forward, animated: false, completion: nil)
 			}
 		}

--- a/ownCloud/Client/Viewer/DisplayHostViewController.swift
+++ b/ownCloud/Client/Viewer/DisplayHostViewController.swift
@@ -360,24 +360,26 @@ extension DisplayHostViewController {
 	@objc private func handleMediaPlaybackFinished(notification:Notification) {
 		if let mediaController = activeDisplayViewController as? MediaDisplayViewController {
 			if let displayViewController = adjacentViewController(relativeTo: mediaController, .after, includeOnlyMediaItems: true) as? MediaDisplayViewController {
-				activeDisplayViewController = displayViewController
 				self.setViewControllers([displayViewController], direction: .forward, animated: false, completion: nil)
+				activeDisplayViewController = displayViewController
 			}
 		}
 	}
 
 	@objc private func handlePlayNextMedia(notification:Notification) {
 		if let mediaController = activeDisplayViewController as? MediaDisplayViewController {
-			if let displayViewController = adjacentViewController(relativeTo: mediaController, .after, includeOnlyMediaItems: true) {
+			if let displayViewController = adjacentViewController(relativeTo: mediaController, .after, includeOnlyMediaItems: true) as? MediaDisplayViewController {
 				self.setViewControllers([displayViewController], direction: .forward, animated: false, completion: nil)
+				activeDisplayViewController = displayViewController
 			}
 		}
 	}
 
 	@objc private func handlePlayPreviousMedia(notification:Notification) {
 		if let mediaController = activeDisplayViewController as? MediaDisplayViewController {
-			if let displayViewController = adjacentViewController(relativeTo: mediaController, .before, includeOnlyMediaItems: true) {
+			if let displayViewController = adjacentViewController(relativeTo: mediaController, .before, includeOnlyMediaItems: true) as? MediaDisplayViewController {
 				self.setViewControllers([displayViewController], direction: .forward, animated: false, completion: nil)
+				activeDisplayViewController = displayViewController
 			}
 		}
 	}

--- a/ownCloud/Client/Viewer/Media/MediaDisplayViewController.swift
+++ b/ownCloud/Client/Viewer/Media/MediaDisplayViewController.swift
@@ -153,12 +153,14 @@ class MediaDisplayViewController : DisplayViewController {
 						// Construct image view overlay for AVPlayerViewController
 						let imageView = UIImageView(image: artworkImage)
 						imageView.translatesAutoresizingMaskIntoConstraints = false
-						imageView.contentMode = .center
+						imageView.contentMode = .scaleAspectFit
 						playerViewController?.contentOverlayView?.addSubview(imageView)
 
 						NSLayoutConstraint.activate([
-							imageView.centerYAnchor.constraint(equalTo: overlayView.centerYAnchor),
-							imageView.centerXAnchor.constraint(equalTo: overlayView.centerXAnchor)
+							imageView.leadingAnchor.constraint(equalTo: overlayView.leadingAnchor),
+							imageView.trailingAnchor.constraint(equalTo: overlayView.trailingAnchor),
+							imageView.topAnchor.constraint(equalTo: overlayView.topAnchor),
+							imageView.bottomAnchor.constraint(equalTo: overlayView.bottomAnchor)
 						])
 
 						// Create MPMediaItemArtwork to be shown in 'now playing' in the lock screen


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
Fixed continuous audio playback, which stopped, after two audio files, because of not setting the `activeDisplayViewController`, when starting a new audio file

## Related Issue
https://github.com/owncloud/enterprise/issues/4924

## Motivation and Context
Play continuous all audio files in a folder

## How Has This Been Tested?
- Put some audio files (at least 3 files) in a folder
- Select the first audio file
- The new audio file should start playing, when the current has finished

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased

## QA

- [X] (1) Title missing from 2nd file https://github.com/owncloud/ios-app/pull/1088#issuecomment-1011037914
- [x] (2) Wordart exceeds the screen width https://github.com/owncloud/ios-app/pull/1088#issuecomment-1011067496 [FIXED]
- [ ] (3) `Open in a new window` does not reproduce the mp3 file https://github.com/owncloud/ios-app/pull/1088#issuecomment-1011072901