### PR TITLE
[fix/biometrical-unlock-setup] Fix: Setup Passcode with Biometrical Unlock

### DIFF
--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -148,13 +148,15 @@ public class AppLockManager: NSObject {
 	}
 
 	// MARK: - Show / Dismiss Passcode View
-	public func showLockscreenIfNeeded(forceShow: Bool = false, context: LAContext = LAContext()) {
-		if self.shouldDisplayLockscreen || forceShow {
+	public func showLockscreenIfNeeded(forceShow: Bool = false, setupMode: Bool = false, context: LAContext = LAContext()) {
+		if self.shouldDisplayLockscreen || forceShow || setupMode {
 			lockscreenOpenForced = forceShow
 			lockscreenOpen = true
 
 			// Show biometrical
 			if !forceShow, !self.shouldDisplayCountdown, self.biometricalAuthenticationSucceeded {
+				showBiometricalAuthenticationInterface(context: context)
+			} else if setupMode {
 				showBiometricalAuthenticationInterface(context: context)
 			}
 		}

--- a/ownCloudAppShared/AppLock/PasscodeSetupCoordinator.swift
+++ b/ownCloudAppShared/AppLock/PasscodeSetupCoordinator.swift
@@ -127,6 +127,7 @@ public class PasscodeSetupCoordinator {
 					if self.passcodeFromFirstStep == passcode {
 						// Confirmed passcode matches the original ones -> save and lock the app
 						self.lock(with: passcode)
+						// foo
 						self.showSuggestBiometricalUnlockUI()
 					} else {
 						//Passcode is not the same
@@ -159,7 +160,7 @@ public class PasscodeSetupCoordinator {
 					self.completionHandler?(false)
 				})
 				if AppLockManager.supportedOnDevice {
-					AppLockManager.shared.showLockscreenIfNeeded()
+					AppLockManager.shared.showLockscreenIfNeeded(setupMode: true)
 				}
 			} else {
 				let alertController = UIAlertController(title: biometricalSecurityName, message: String(format:"Unlock using %@?".localized, biometricalSecurityName), preferredStyle: .alert)
@@ -170,7 +171,7 @@ public class PasscodeSetupCoordinator {
 						self.completionHandler?(false)
 					})
 					if AppLockManager.supportedOnDevice {
-						AppLockManager.shared.showLockscreenIfNeeded()
+						AppLockManager.shared.showLockscreenIfNeeded(setupMode: true)
 					}
 				}))
 

--- a/ownCloudAppShared/AppLock/PasscodeSetupCoordinator.swift
+++ b/ownCloudAppShared/AppLock/PasscodeSetupCoordinator.swift
@@ -127,7 +127,6 @@ public class PasscodeSetupCoordinator {
 					if self.passcodeFromFirstStep == passcode {
 						// Confirmed passcode matches the original ones -> save and lock the app
 						self.lock(with: passcode)
-						// foo
 						self.showSuggestBiometricalUnlockUI()
 					} else {
 						//Passcode is not the same

--- a/ownCloudAppShared/AppLock/PasscodeViewController.swift
+++ b/ownCloudAppShared/AppLock/PasscodeViewController.swift
@@ -173,7 +173,7 @@ public class PasscodeViewController: UIViewController, Themeable {
 		self.screenBlurringEnabled = { self.screenBlurringEnabled }()
 		self.errorMessageLabel?.minimumScaleFactor = 0.5
 		self.errorMessageLabel?.adjustsFontSizeToFitWidth = true
-		self.biometricalButtonHidden = !(!AppLockSettings.shared.biometricalSecurityEnabled || self.cancelButtonHidden)
+		self.biometricalButtonHidden = !((!AppLockSettings.shared.biometricalSecurityEnabled || !AppLockSettings.shared.lockEnabled) || self.cancelButtonHidden)
 		updateKeypadButtons()
         if let biometricalSecurityName = LAContext().supportedBiometricsAuthenticationName() {
             self.biometricalButton?.accessibilityLabel = biometricalSecurityName


### PR DESCRIPTION
## Description
Fix for passcode setup with biometrical unlock enabled:
- biometrical unlock button no longer appear in setup view
- after passcode was successfully setup, show biometrical unlock for permissions dialog

## Related Issue
https://github.com/owncloud/enterprise/issues/5086

## Motivation and Context
- do not show UI elements, which are not available in a context 
- show permission dialog in setup context

## How Has This Been Tested?
- Test setting up passcode with biometrical unlock in unbranded client
- Test in branded client (use the code below in `Branding.plist`)

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
<key>branding.organization-name</key>
<string>Demo</string>
<key>branding.profile-bookmark-name</key>
<string>Demo</string>
<key>branding.profile-url</key>
<string>https://demo.owncloud.com/</string>
<key>passcode.use-biometrical-unlock</key>
<true/>
<key>passcode.enforced</key>
<true/>
</dict>
</plist>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
