### PR TITLE
[fix/shortcut-emm-licensing] EMM Shortcuts Licensing

### DIFF
--- a/ownCloudAppFramework/Licensing/Providers/EMM/OCLicenseEMMProvider.m
+++ b/ownCloudAppFramework/Licensing/Providers/EMM/OCLicenseEMMProvider.m
@@ -32,12 +32,26 @@
 	return (self);
 }
 
+
 + (BOOL)isEMMVersion
 {
-	return (
-		[NSBundle.mainBundle.bundleIdentifier hasSuffix:@".emm"] || // BundleID of the main bundle ending in ".emm"
-		[NSBundle.mainBundle.bundleIdentifier hasSuffix:@"-emm"]    // BundleID of the main bundle ending in "-emm"
-	);
+    NSBundle *appBundle;
+
+    if ((appBundle = NSBundle.mainBundle) != nil)
+    {
+        if ([appBundle.bundleURL.pathExtension isEqual:@"appex"])
+        {
+            // Find container app bundle (ownCloud.app/PlugIns/Extension.appex)
+            appBundle = [NSBundle bundleWithURL:appBundle.bundleURL.URLByDeletingLastPathComponent.URLByDeletingLastPathComponent];
+        }
+        
+        return (
+            [appBundle.bundleIdentifier hasSuffix:@".emm"] || // BundleID of the main bundle ending in ".emm"
+            [appBundle.bundleIdentifier hasSuffix:@"-emm"]    // BundleID of the main bundle ending in "-emm"
+        );
+    }
+    
+    return NO;
 }
 
 - (void)startProvidingWithCompletionHandler:(OCLicenseProviderCompletionHandler)completionHandler


### PR DESCRIPTION
## Description
If app is build as EMM version, the app shows an licensing error, when running shortcut intents (could not read app bundle identifier in extension)

## Related Issue
#1114 

## Motivation and Context
EMM version should not show or restricted by licensing

## How Has This Been Tested?
- Build EMM version (use `fastlane owncloud_emm_build` for setting the app identifier)
- In `Shortcuts.app` create a new shortcut and add an ownCloud EMM action
- Running should not show an licensing error

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
