### PR TITLE
[fix/bright-branding-color] Branding: Color issues

### DIFF
--- a/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
+++ b/ownCloud/Static Login/Interface/StaticLoginSetupViewController.swift
@@ -118,7 +118,7 @@ class StaticLoginSetupViewController : StaticLoginStepViewController {
 
 		onboardingSection = StaticTableViewSection(headerTitle: nil, identifier: "onboardingSection")
 		if let message = profile.promptForHelpURL, let title = profile.helpURLButtonString {
-			let (proceedButton, _) = onboardingSection.addButtonFooter(message: message, messageItemStyle: .welcomeMessage, proceedLabel: title, proceedItemStyle: .informal, cancelLabel: nil)
+			let (proceedButton, _) = onboardingSection.addButtonFooter(message: message, messageItemStyle: .welcomeMessage, proceedLabel: title, proceedItemStyle: .welcomeInformal, cancelLabel: nil)
 				proceedButton?.addTarget(self, action: #selector(self.helpAction), for: .touchUpInside)
 		}
 

--- a/ownCloudAppShared/UIKit Extension/UIColor+Extension.swift
+++ b/ownCloudAppShared/UIKit Extension/UIColor+Extension.swift
@@ -100,4 +100,10 @@ extension UIColor {
 
 		return (String(format: "\(leadIn)%02x%02x%02x", Int(selfRed*255.0), Int(selfGreen*255.0), Int(selfBlue*255.0)))
 	}
+    
+    public func isLight() -> Bool {
+        guard let components = cgColor.components, components.count > 2 else {return false}
+        let brightness = ((components[0] * 299) + (components[1] * 587) + (components[2] * 114)) / 1000
+        return (brightness > 0.5)
+    }
 }

--- a/ownCloudAppShared/User Interface/Theme/NSObject+ThemeApplication.swift
+++ b/ownCloudAppShared/User Interface/Theme/NSObject+ThemeApplication.swift
@@ -43,6 +43,7 @@ public enum ThemeItemStyle {
 
 	case purchase
 	case welcome
+    case welcomeInformal
 }
 
 public enum ThemeItemState {
@@ -86,9 +87,14 @@ public extension NSObject {
 
 				case .purchase:
 					themeButton.themeColorCollection = collection.purchaseColors
-
-				case .welcome:
-					themeButton.themeColorCollection = collection.loginColors.filledColorPairCollection
+                
+                case .welcome:
+                    themeButton.themeColorCollection = collection.loginColors.filledColorPairCollection
+                
+                case .welcomeInformal:
+                    let fromPair = collection.loginColors.filledColorPairCollection
+                    let normal = ThemeColorPair(foreground: fromPair.normal.foreground.lighter(0.25), background: fromPair.normal.background.lighter(0.25))
+                    themeButton.themeColorCollection = ThemeColorPairCollection(fromPair: normal)
 
 				case .informal:
 					themeButton.themeColorCollection = collection.informalColors.filledColorPairCollection
@@ -210,6 +216,7 @@ public extension NSObject {
 
 				case .welcomeMessage:
 					normalColor = collection.loginColors.secondaryLabelColor
+                normalColor = collection.loginColors.secondaryLabelColor
 					highlightColor = collection.loginColors.secondaryLabelColor
 
 				case .message, .bigMessage:

--- a/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
+++ b/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
@@ -397,7 +397,16 @@ public class ThemeCollection : NSObject {
 				self.loginColors = colors.resolveThemeColorCollection("Login", self.darkBrandColors)
 
 				// Bar styles
-				self.statusBarStyle = styleResolver.resolveStatusBarStyle(for: "statusBarStyle", fallback: .lightContent)
+                var defaultStatusBarStyle : UIStatusBarStyle = .lightContent
+                if let backgroundColor = self.navigationBarColors.backgroundColor, backgroundColor.isLight() {
+                    if #available(iOSApplicationExtension 13.0, *) {
+                        defaultStatusBarStyle = .darkContent
+                    } else {
+                        defaultStatusBarStyle = .default
+                    }
+                }
+            
+                self.statusBarStyle = styleResolver.resolveStatusBarStyle(for: "statusBarStyle", fallback: defaultStatusBarStyle)
 				self.loginStatusBarStyle = styleResolver.resolveStatusBarStyle(for: "loginStatusBarStyle", fallback: self.statusBarStyle)
 				self.barStyle = styleResolver.resolveBarStyle(fallback: .black)
 
@@ -411,10 +420,10 @@ public class ThemeCollection : NSObject {
 				// Logo fill color
 				logoFillColor = UIColor.lightGray
 
-				if lightBrandColor.isEqual(UIColor(hex: 0xFFFFFF)) {
+				if lightBrandColor.isLight() {
 					self.neutralColors.normal.background = self.darkBrandColor
 					self.lightBrandColors.filledColorPairCollection.normal.background = self.darkBrandColor
-				}
+                }
 		}
 
 		self.informalColors = colors.resolveThemeColorCollection("Informal", self.lightBrandColors)


### PR DESCRIPTION
## Description
Fix some automatic color values, if the branding color is bright. Before we only had a look if the branding color is white, but this does not work. Introduced a new welcome style for informal button, because the general informal button color does not work for the login screen in all cases

## Related Issue
https://github.com/owncloud/enterprise/issues/5199

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
