### PR TITLE
[feature/ats-control] Add DISABLE_PLAIN_HTTP build flag

### DIFF
--- a/doc/BUILD_CUSTOMIZATION.md
+++ b/doc/BUILD_CUSTOMIZATION.md
@@ -1,0 +1,38 @@
+# Build Flags
+
+## Description
+
+Build Flags can be used to control the inclusion or exclusion of certain functionality or features at compile time.
+
+## Usage in Branding
+
+A **space-separated** list of flags can be specified in the `Branding.plist` with the key `build.flags`, f.ex.:
+
+```xml
+<key>build.flags</key>
+<string>DISABLE_BACKGROUND_LOCATION</string>
+```
+
+## Flags
+
+The following options can be used as `build.flags`:
+
+### `DISABLE_BACKGROUND_LOCATION`
+
+Removes the following from the app:
+- the option for location-triggered background uploads from Settings
+- the location description keys from the app's `Info.plist`
+
+Not used by default.
+
+### `DISABLE_APPSTORE_LICENSING`
+
+Removes the following from the app:
+- App Store integration for OCLicense
+- App Store related view controllers and settings section
+
+### `DISABLE_PLAIN_HTTP`
+
+Removes the following from the app:
+- the `NSAppTransportSecurity` dictionary from the app's `Info.plist`
+- including the `NSAllowsArbitraryLoads` key that's needed to allow plain/unsecured HTTP connections

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -547,6 +547,12 @@ end
         sh "mv ../ownCloud/Resources/Info.plist.mod ../ownCloud/Resources/Info.plist"
     end
 
+    # Special handling for app build flag DISABLE_PLAIN_HTTP (see above why this is needed)
+    if appBuildFlags.include? "DISABLE_PLAIN_HTTP"
+        sh "sed '/#ifndef DISABLE_PLAIN_HTTP/,/#endif/d' ../ownCloud/Resources/Info.plist >../ownCloud/Resources/Info.plist.mod"
+        sh "mv ../ownCloud/Resources/Info.plist.mod ../ownCloud/Resources/Info.plist"
+    end
+
 	# update_url_schemes can't seem to reach the second URL scheme ("oc") for authentication
 	# so using sed and a XML property instead
     if !appCustomAppScheme.empty?

--- a/ownCloud/Resources/Info.plist
+++ b/ownCloud/Resources/Info.plist
@@ -75,11 +75,13 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<false/>
+	#ifndef DISABLE_PLAIN_HTTP
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	#endif
 	<key>NSAppleMusicUsageDescription</key>
 	<string>This permission is needed for uploading media files to your server.</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
## Description
- add `DISABLE_PLAIN_HTTP` build flag
- re-add a reduced version of the `BUILD_CUSTOMIZATION.md` document to keep track of build flags and add documentation on `DISABLE_PLAIN_HTTP` to it

To use this flag, add the following to the Branding.plist before building with fastlane:

```xml
<key>build.flags</key>
<string>DISABLE_PLAIN_HTTP</string>
```

I also brought back part of `BUILD_CUSTOMIZATION.md` because:
- `build` configuration options are exported from the app, but not yet included in the iOS client docs yet (https://github.com/owncloud/docs-client-ios-app/issues/92)
- the auto-generated `build.flags` documentation references `BUILD_CUSTOMIZATION.md`

## Related Issue
https://github.com/owncloud/enterprise/issues/5290

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
