### PR TITLE
[fix/private-links-capability] Respect privateLinks capability

### DIFF
--- a/ownCloudAppShared/Client/Sharing/PublicLinkTableViewController.swift
+++ b/ownCloudAppShared/Client/Sharing/PublicLinkTableViewController.swift
@@ -28,6 +28,11 @@ open class PublicLinkTableViewController: SharingTableViewController {
 		return false
 	}
 
+	var privateLinkSharingEnabled : Bool {
+		if let core = core, core.connectionStatus == .online, core.connection.capabilities?.sharingAPIEnabled == true, core.connection.capabilities?.supportsPrivateLinks == true, item.isShareable { return true }
+		return false
+	}
+
 	open override func viewDidLoad() {
 		super.viewDidLoad()
 
@@ -40,7 +45,9 @@ open class PublicLinkTableViewController: SharingTableViewController {
 		}
 
 		addHeaderView()
-		addPrivateLinkSection()
+		if privateLinkSharingEnabled {
+			addPrivateLinkSection()
+		}
 
 		if publicLinkSharingEnabled {
 			self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addPublicLink))


### PR DESCRIPTION
## Description
Respect `files.privateLinks` capability and do not offer to create private links when privateLinks are not supported.

## Related Issue
https://github.com/owncloud/ios-app/issues/1138

## Screenshots (if appropriate):
Before | After
-------|--------
![Bildschirmfoto 2022-08-22 um 11 23 02](https://user-images.githubusercontent.com/639669/185889538-18467bd7-632c-49c9-866e-9a3ee7344006.png) | ![Bildschirmfoto 2022-08-22 um 11 22 26](https://user-images.githubusercontent.com/639669/185889572-eade9016-af32-4269-b3c4-23f4cf741575.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
