### PR TITLE
[fix/enable-markup-iOS16] Enabling Markup Mode on iOS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,18 @@ ownCloud admins and users.
 Summary
 -------
 
-* Bugfix - Enabling Markup Mode on iOS 16: [#1141](https://github.com/owncloud/ios-app/issues/1141)
-* Bugfix - Updating Theme: [#1141](https://github.com/owncloud/ios-app/issues/1141)
+* Bugfix - Enabling Markup Mode on iOS 16, Updating Theme: [#1141](https://github.com/owncloud/ios-app/issues/1141)
 * Bugfix - Video Metadata Image: [#5296](https://github.com/owncloud/enterprise/issues/5296)
 * Change - New Dark Mode Themes: [#1146](https://github.com/owncloud/ios-app/issues/1146)
 
 Details
 -------
 
-* Bugfix - Enabling Markup Mode on iOS 16: [#1141](https://github.com/owncloud/ios-app/issues/1141)
+* Bugfix - Enabling Markup Mode on iOS 16, Updating Theme: [#1141](https://github.com/owncloud/ios-app/issues/1141)
 
    Enabling markup mode was broken on iOS 16 because of rearranged navigation bar and toolbar
-   items.
-
-   https://github.com/owncloud/ios-app/issues/1141
-
-* Bugfix - Updating Theme: [#1141](https://github.com/owncloud/ios-app/issues/1141)
-
-   Fixes a bug when a new theme was activated, this causes that the UITabBar and UIToolbar does not
-   updates colours.
+   items. Furthermore when a new theme was choosen, this causes that the UITabBar and UIToolbar
+   does not updates colours.
 
    https://github.com/owncloud/ios-app/issues/1141
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+Changelog for ownCloud iOS Client [unreleased] (UNRELEASED)
+=======================================
+The following sections list the changes in ownCloud iOS Client unreleased relevant to
+ownCloud admins and users.
+
+[unreleased]: https://github.com/owncloud/ios-app/compare/milestone/11.10.1...master
+
+Summary
+-------
+
+* Bugfix - Enabling Markup Mode on iOS 16: [#1141](https://github.com/owncloud/ios-app/issues/1141)
+
+Details
+-------
+
+* Bugfix - Enabling Markup Mode on iOS 16: [#1141](https://github.com/owncloud/ios-app/issues/1141)
+
+   Enabling markup mode was broken on iOS 16 because of rearranged navigation bar and toolbar
+   items.
+
+   https://github.com/owncloud/ios-app/issues/1141
+
 Changelog for ownCloud iOS Client [11.10.1] (2022-08-02)
 =======================================
 The following sections list the changes in ownCloud iOS Client 11.10.1 relevant to

--- a/changelog/unreleased/1141
+++ b/changelog/unreleased/1141
@@ -1,0 +1,5 @@
+Bugfix: Enabling Markup Mode on iOS 16
+
+Enabling markup mode was broken on iOS 16 because of rearranged navigation bar and toolbar items.
+
+https://github.com/owncloud/ios-app/issues/1141

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -125,7 +125,15 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 
 	@objc func enableEditingMode() {
 		// Activate editing mode by performing the action on pencil icon. Unfortunately that's the only way to do it apparently
-		if #available(iOS 15.0, *) {
+        if #available(iOS 16.0, *) {
+            if self.navigationItem.rightBarButtonItems?.count ?? 0 > 3 {
+                guard let markupButton = self.navigationItem.rightBarButtonItems?[0] else { return }
+                _ = markupButton.target?.perform(markupButton.action, with: markupButton)
+            } else if self.toolbarItems?.count ?? 0 > 4 {
+                guard let markupButton = self.toolbarItems?[4] else { return }
+                _ = markupButton.target?.perform(markupButton.action, with: markupButton)
+            }
+        } else if #available(iOS 15.0, *) {
 			if self.navigationItem.rightBarButtonItems?.count ?? 0 > 2 {
 				guard let markupButton = self.navigationItem.rightBarButtonItems?[1] else { return }
 				_ = markupButton.target?.perform(markupButton.action, with: markupButton)

--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -132,6 +132,9 @@ class EditDocumentViewController: QLPreviewController, Themeable {
             } else if self.toolbarItems?.count ?? 0 > 4 {
                 guard let markupButton = self.toolbarItems?[4] else { return }
                 _ = markupButton.target?.perform(markupButton.action, with: markupButton)
+            } else if self.toolbarItems?.count ?? 0 < 4 {
+                guard let markupButton = self.toolbarItems?[2] else { return }
+                _ = markupButton.target?.perform(markupButton.action, with: markupButton)
             }
         } else if #available(iOS 15.0, *) {
 			if self.navigationItem.rightBarButtonItems?.count ?? 0 > 2 {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
Enabling markup mode was broken on iOS 16 because of rearranged navigation bar and toolbar items.

## Related Issue
#1141 

## Motivation and Context
Enable markup mode automatically after selecting the action.

## How Has This Been Tested?

### on a iOS 16 device
- Select action `Markup` on a PDF or Image file
- Markup UI should be visible

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased
