### PR TITLE
[fix/share-extension-passcode-lock-interval] Share Extension Passcode Lock Interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Summary
 -------
 
 * Bugfix - Enabling Markup Mode on iOS 16, Updating Theme: [#1141](https://github.com/owncloud/ios-app/issues/1141)
+* Bugfix - Share Extension Passcode Lock Interval: [#1156](https://github.com/owncloud/ios-app/issues/1156)
 * Bugfix - Video Metadata Image: [#5296](https://github.com/owncloud/enterprise/issues/5296)
 * Change - New Dark Mode Themes: [#1146](https://github.com/owncloud/ios-app/issues/1146)
 
@@ -22,6 +23,12 @@ Details
    does not updates colours.
 
    https://github.com/owncloud/ios-app/issues/1141
+
+* Bugfix - Share Extension Passcode Lock Interval: [#1156](https://github.com/owncloud/ios-app/issues/1156)
+
+   The passcode lock interval was not taken into use in the share extension.
+
+   https://github.com/owncloud/ios-app/issues/1156
 
 * Bugfix - Video Metadata Image: [#5296](https://github.com/owncloud/enterprise/issues/5296)
 

--- a/changelog/unreleased/1156
+++ b/changelog/unreleased/1156
@@ -1,0 +1,5 @@
+Bugfix: Share Extension Passcode Lock Interval
+
+The passcode lock interval was not taken into use in the share extension.
+
+https://github.com/owncloud/ios-app/issues/1156

--- a/ownCloud Share Extension/ShareViewController.swift
+++ b/ownCloud Share Extension/ShareViewController.swift
@@ -99,7 +99,7 @@ class ShareViewController: MoreStaticTableViewController {
 	}
     
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
         if didAppearInitial {
             AppLockManager.shared.appDidEnterBackground()
         }

--- a/ownCloud Share Extension/ShareViewController.swift
+++ b/ownCloud Share Extension/ShareViewController.swift
@@ -186,6 +186,7 @@ class ShareViewController: MoreStaticTableViewController {
 
 				for (bookmark) in bookmarks {
 					let row = StaticTableViewRow(buttonWithAction: { (_ row, _ sender) in
+                        self.didAppearInitial = false
 						self.openDirectoryPicker(for: bookmark, withBackButton: true)
 					}, title: bookmark.shortName, style: .plain, image: UIImage(named: "bookmark-icon")?.scaledImageFitting(in: CGSize(width: 25.0, height: 25.0)), imageWidth: 25, alignment: .left)
 					actionsRows.append(row)

--- a/ownCloud Share Extension/ShareViewController.swift
+++ b/ownCloud Share Extension/ShareViewController.swift
@@ -58,13 +58,14 @@ class ShareViewController: MoreStaticTableViewController {
 			// Share extension allowed
 			if !willAppearInitial {
 				willAppearInitial = true
-
-				if AppLockManager.supportedOnDevice {
-					AppLockManager.shared.showLockscreenIfNeeded()
-				}
+                
+                if AppLockManager.supportedOnDevice {
+                    AppLockManager.shared.showLockscreenIfNeeded()
+                }
 
 				if let appexNavigationController = self.navigationController as? AppExtensionNavigationController {
 					appexNavigationController.dismissalAction = { [weak self] (_) in
+                        AppLockManager.shared.appDidEnterBackground()
 						self?.returnCores(completion: {
 							Log.debug("Returned all cores (share sheet was closed / dismissed)")
 						})
@@ -96,6 +97,18 @@ class ShareViewController: MoreStaticTableViewController {
 			didAppearInitial = true
 		}
 	}
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if didAppearInitial {
+            AppLockManager.shared.appDidEnterBackground()
+        }
+    }
+    
+    @objc open override func dismissAnimated() {
+        AppLockManager.shared.appDidEnterBackground()
+        super.dismissAnimated()
+    }
 
 	private var requestedCoreBookmarks : [OCBookmark] = []
 
@@ -146,6 +159,7 @@ class ShareViewController: MoreStaticTableViewController {
 	}
 
 	@objc private func cancelAction () {
+        AppLockManager.shared.appDidEnterBackground()
 		self.returnCores(completion: {
 			let error = NSError(domain: NSErrorDomain.ShareViewErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Canceled by user"])
 			self.extensionContext?.cancelRequest(withError: error)

--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -173,12 +173,15 @@ public class AppLockManager: NSObject {
 			lockscreenOpenForced = forceShow
 			lockscreenOpen = true
 
-			// Show biometrical
-			if !forceShow, !self.shouldDisplayCountdown, self.biometricalAuthenticationSucceeded {
-				showBiometricalAuthenticationInterface(context: context)
-			} else if setupMode {
-				showBiometricalAuthenticationInterface(context: context)
-			}
+            // The following code needs to be executed after a short delay, because in the share sheet the biometrical unlock UI can block adding the PasscodeViewController UI
+            OnMainThread(after: 0.5) {
+                // Show biometrical
+                if !forceShow, !self.shouldDisplayCountdown, self.biometricalAuthenticationSucceeded {
+                    self.showBiometricalAuthenticationInterface(context: context)
+                } else if setupMode {
+                    self.showBiometricalAuthenticationInterface(context: context)
+                }
+            }
 		} else {
 			dismissLockscreen(animated: true)
 		}

--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -174,7 +174,11 @@ public class AppLockManager: NSObject {
 			lockscreenOpen = true
 
             // The following code needs to be executed after a short delay, because in the share sheet the biometrical unlock UI can block adding the PasscodeViewController UI
-            OnMainThread(after: 0.5) {
+            var delay = 0.0
+            if self.passwordViewHostViewController != nil {
+                delay = 0.5
+            }
+            OnMainThread(after: delay) {
                 // Show biometrical
                 if !forceShow, !self.shouldDisplayCountdown, self.biometricalAuthenticationSucceeded {
                     self.showBiometricalAuthenticationInterface(context: context)

--- a/ownCloudAppShared/AppLock/AppLockManager.swift
+++ b/ownCloudAppShared/AppLock/AppLockManager.swift
@@ -333,7 +333,7 @@ public class AppLockManager: NSObject {
 	}
 
 	// MARK: - App Events
-	@objc func appDidEnterBackground() {
+	@objc public func appDidEnterBackground() {
 		if unlocked {
 			lastApplicationBackgroundedDate = Date()
 		} else {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.
-->

## Description
The passcode lock interval was not taken into use in the share extension.

Background and foreground state is not possible in share extensions. Date will now be saved by triggering the mode manually.

## Related Issue
#1154

## Motivation and Context
Working passcode lock interval in share extension.

## How Has This Been Tested?
Have a look at the issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased
