### PR TITLE
[docs-only] add toc to changelog

### DIFF
--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,7 +1,12 @@
+# Table of Contents
+
+{{ range . -}}
+  * [Changelog for {{ .Version }}](#changelog-for-owncloud-ios-client-{{ .Version | replace "." ""}}-{{ .Date | lower -}})
+{{ end -}}
+  * [Changelog for 11.4.5 versions and below](#changelog-for-1145-versions-and-below)
 {{ $allVersions := . }}
 {{- range $index, $changes := . }}{{ with $changes -}}
-Changelog for ownCloud iOS Client [{{ .Version }}] ({{ .Date }})
-=======================================
+# Changelog for ownCloud iOS Client [{{ .Version }}] ({{ .Date }})
 The following sections list the changes in ownCloud iOS Client {{ .Version }} relevant to
 ownCloud admins and users.
 
@@ -21,14 +26,12 @@ ownCloud admins and users.
 [{{ .Version }}]: https://github.com/owncloud/ios-app/compare/milestone/11.5.0...milestone/{{ .Version }}
 {{- end }}
 
-Summary
--------
+## Summary
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{- end }}{{ end }}
 
-Details
--------
+## Details
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{ range $par := .Paragraphs }}
@@ -47,7 +50,7 @@ Details
 {{ end }}{{ end -}}
 
 {{/* Start of old changelog */ -}}
-
+# Changelog for 11.4.5 versions and below
 ## Release version 11.4.5 (January 2021)
 
 - Fix: Crash in Detail View (#855)


### PR DESCRIPTION
## Description

Adds table of contents to the top of the CHANGELOG.md file.

### Anchor links in markdown are generated from the content of the header according to the following rules:

1. All text is converted to lowercase.
2. All non-word text (e.g., punctuation, HTML) is removed.
3. All spaces are converted to hyphens.
4. Two or more hyphens in a row are converted to one.
5. If a header with the same ID has already been generated, a unique incrementing number is appended, starting at 1.
6. All changelogs for 11.4.5 and below have a main entrance link

## Related Issue
- Relates to https://github.com/owncloud/docs/issues/4901
- Changes copied from: https://github.com/owncloud/ocis/pull/7691
