### PR TITLE
[fix/fp-no-account] Show message in File Provider if no account has been set up

### DIFF
--- a/ownCloud File Provider UI/CancelLabelViewController.swift
+++ b/ownCloud File Provider UI/CancelLabelViewController.swift
@@ -26,9 +26,11 @@ class CancelLabelViewController: UIViewController {
 	@IBOutlet var label : UILabel!
 	@IBOutlet var button : ThemeButton!
 
-	var cancelAction: (() -> Void)?
+	typealias CancelAction = (() -> Void)
 
-	func updateCancelLabels(with message: String) {
+	var cancelAction: CancelAction?
+
+	func updateCancelLabels(with message: String, buttonLabel: String? = nil) {
 		let collection = Theme.shared.activeCollection
 
 		view.cssSelector = .toolbar
@@ -38,7 +40,7 @@ class CancelLabelViewController: UIViewController {
 		label.apply(css: collection.css, properties: [.stroke])
 
 		self.label.text = message
-		self.button.setTitle("Cancel".localized, for: .normal)
+		self.button.setTitle(buttonLabel ?? "Cancel".localized, for: .normal)
 	}
 
 	@IBAction func cancelScreen() {

--- a/ownCloud File Provider UI/DocumentActionViewController.swift
+++ b/ownCloud File Provider UI/DocumentActionViewController.swift
@@ -106,7 +106,7 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 
 		prepareNavigationController()
 
-		showCancelLabel(with: "Connecting…".localized)
+		showMessage(with: "Connecting…".localized)
 
 		var actionTypeLabel = ""
 		var actionExtensionType : ActionExtensionType = .undefined
@@ -139,7 +139,7 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 
 					OnMainThread {
 						if actionExtensionType == .sharing, core.connection.capabilities?.sharingAPIEnabled == false || item.isShareable == false {
-							self.showCancelLabel(with: String(format: "%@ is not available for this item.".localized, actionTypeLabel))
+							self.showMessage(with: String(format: "%@ is not available for this item.".localized, actionTypeLabel))
 						} else if core.connectionStatus == .online {
 							self.coreConnectionStatusObservation?.invalidate()
 							self.coreConnectionStatusObservation = nil
@@ -157,18 +157,18 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 							}
 						} else if core.connectionStatus == .connecting {
 							triedConnecting = true
-							self.showCancelLabel(with: "Connecting…".localized)
+							self.showMessage(with: "Connecting…".localized)
 						} else if core.connectionStatus == .offline || core.connectionStatus == .unavailable {
 							// Display error if `.connecting` isn't reached within 2 seconds
 							OnMainThread(after: 2) {
 								if !triedConnecting {
-									self.showCancelLabel(with: String(format: "%@ is not available, when this account is offline. Please open the app and log into your account before you can do this action.".localized, actionTypeLabel))
+									self.showMessage(with: String(format: "%@ is not available, when this account is offline. Please open the app and log into your account before you can do this action.".localized, actionTypeLabel))
 								}
 							}
 
 							// Display error if `.connecting` has already been reached
 							if triedConnecting {
-								self.showCancelLabel(with: String(format: "%@ is not available, when this account is offline. Please open the app and log into your account before you can do this action.".localized, actionTypeLabel))
+								self.showMessage(with: String(format: "%@ is not available, when this account is offline. Please open the app and log into your account before you can do this action.".localized, actionTypeLabel))
 							}
 						}
 					}
@@ -180,7 +180,18 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 	override func prepare(forError error: Error) {
 		if !OCFileProviderSettings.browseable {
 			prepareNavigationController()
-			showCancelLabel(with: "File Provider access has been disabled by the administrator.\n\nPlease use the app to access your files.".localized)
+			showMessage(with: "File Provider access has been disabled by the administrator.\n\nPlease use the app to access your files.".localized)
+			return
+		}
+
+		if OCBookmarkManager.shared.bookmarks.count == 0 {
+			prepareNavigationController()
+			showMessage(with: "No account has been set up in the {{app.name}} app yet.".localized, buttonLabel: "Open app".localized, action: { [weak self] in
+				if let appURLScheme = OCAppIdentity.shared.appURLSchemes?.first {
+					self?.extensionContext.open(URL(string: "\(appURLScheme)://fp-no-account")!)
+				}
+				self?.complete()
+			})
 			return
 		}
 
@@ -197,20 +208,29 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
 			AppLockManager.shared.showLockscreenIfNeeded()
 		} else {
 			prepareNavigationController()
-			showCancelLabel(with: "Passcode protection is not supported on this device.\nPlease disable passcode lock in the app settings.".localized)
+			showMessage(with: "Passcode protection is not supported on this device.\nPlease disable passcode lock in the app settings.".localized)
 		}
 	}
 
-	func showCancelLabel(with message: String) {
+	func showMessage(with message: String, buttonLabel: String? = nil, action: CancelLabelViewController.CancelAction? = nil) {
 		OnMainThread {
+			var messageController: CancelLabelViewController?
+
 			if let currentController = self.themeNavigationController?.viewControllers.first as? CancelLabelViewController {
-				currentController.updateCancelLabels(with: message)
+				messageController = currentController
 			} else if let cancelLabelViewController = UIStoryboard.init(name: "MainInterface", bundle: nil).instantiateViewController(withIdentifier: "CancelLabelViewController") as? CancelLabelViewController {
-				cancelLabelViewController.updateCancelLabels(with: message)
-				cancelLabelViewController.cancelAction = { [weak self] in
+				messageController = cancelLabelViewController
+			}
+
+			if let messageController {
+				messageController.updateCancelLabels(with: message, buttonLabel: buttonLabel)
+				messageController.cancelAction = action ?? { [weak self] in
 					self?.complete(cancelWith: NSError(domain: FPUIErrorDomain, code: Int(FPUIExtensionErrorCode.userCancelled.rawValue), userInfo: nil))
 				}
-				self.themeNavigationController?.viewControllers = [ cancelLabelViewController ]
+
+				if self.themeNavigationController?.viewControllers.first != messageController {
+					self.themeNavigationController?.viewControllers = [ messageController ]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
This PR makes the File Provider UI show a message if no account has been set up yet, offering to open the app. Previously, the FP UI was briefly shown and then dismissed.

## Related Issue

## Screenshots (if appropriate):
![Simulator Screenshot - iPhone 15 Plus - 2023-11-28 at 12 24 20](https://github.com/owncloud/ios-app/assets/639669/be1d661a-fc5a-43cd-8521-b77188016575)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)