### PR TITLE
[fix/disable-edit-mode-ios17] Disable Markup Edit Mode iOS 17

### DIFF
--- a/ownCloud/Client/Actions/EditDocumentViewController.swift
+++ b/ownCloud/Client/Actions/EditDocumentViewController.swift
@@ -154,10 +154,24 @@ class EditDocumentViewController: QLPreviewController, Themeable {
 			}
 		}
 	}
+	
+	func disableEditingMode() {
+		if #available(iOS 17.0, *) {
+			if let rightBarButtonItems = self.navigationItem.rightBarButtonItems, rightBarButtonItems.count > 0 {
+				for markupButton in rightBarButtonItems {
+					if (markupButton.debugDescription as NSString).contains("pencil.tip.crop.circle") {
+						_ = markupButton.target?.perform(markupButton.action, with: markupButton)
+					}
+				}
+			}
+		} else {
+			self.setEditing(false, animated: false)
+		}
+	}
 
 	@objc func dismissAnimated() {
-		self.setEditing(false, animated: false)
-
+		disableEditingMode()
+		
 		if savingMode == nil {
 			requestsavingMode { (savingMode) in
 				self.dismiss(animated: true) {


### PR DESCRIPTION
## Description
Fixed disabling edit mode in markup document view on iOS 17. The previous implementation is no longer working on iOS 17.
Problem was, that the edit mode was not disabled automatically. This prevents dismissing and saving the view.

## Related Issue
- https://github.com/owncloud/enterprise/issues/6253

## Motivation and Context
Save edited PDF file.

## How Has This Been Tested?
- Open iOS App 
- open a PDF File in Markup mode
- write or draw something
- click on "Done"
- choose "Overwrite original" or "Save as copy"
- view should be dismissed and changes saved

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
