### PR TITLE
[feature/privacy-manifests] Add required privacy manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ ownCloud admins and users.
 ## Summary
 
 * Bugfix - Fix cleanup of Available Offline policies targeting unavailable spaces: [#1343](https://github.com/owncloud/ios-app/pull/1343)
+* Change - Add required privacy manifests: [#1348](https://github.com/owncloud/ios-app/pull/1348)
 * Enhancement - Improved sidebar with account-wide search: [#1320](https://github.com/owncloud/ios-app/pull/1320)
 * Enhancement - Password Policy support: [#1325](https://github.com/owncloud/ios-app/pull/1325)
 
@@ -44,6 +45,19 @@ ownCloud admins and users.
    retries for files from inaccessible or removed spaces.
 
    https://github.com/owncloud/ios-app/pull/1343
+
+* Change - Add required privacy manifests: [#1348](https://github.com/owncloud/ios-app/pull/1348)
+
+   Adds the [privacy
+   manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc)
+   [required by Apple starting May 1,
+   2024](https://developer.apple.com/news/?id=3d8a9yyh) to the app and upgrades
+   `krzyzanowskim/OpenSSL` to
+   [3.1.5001](https://github.com/krzyzanowskim/OpenSSL/releases/tag/3.1.5001) to
+   include a privacy manifest as [also required by
+   Apple](https://developer.apple.com/support/third-party-SDK-requirements/).
+
+   https://github.com/owncloud/ios-app/pull/1348
 
 * Enhancement - Improved sidebar with account-wide search: [#1320](https://github.com/owncloud/ios-app/pull/1320)
 

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+				<string>AC6B.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/changelog/12.2.0_2024-04-23/1348
+++ b/changelog/12.2.0_2024-04-23/1348
@@ -1,0 +1,5 @@
+Change: Add required privacy manifests
+
+Adds the [privacy manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc) [required by Apple starting May 1, 2024](https://developer.apple.com/news/?id=3d8a9yyh) to the app and upgrades `krzyzanowskim/OpenSSL` to [3.1.5001](https://github.com/krzyzanowskim/OpenSSL/releases/tag/3.1.5001) to include a privacy manifest as [also required by Apple](https://developer.apple.com/support/third-party-SDK-requirements/).
+
+https://github.com/owncloud/ios-app/pull/1348

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -474,6 +474,12 @@
 		DCB6B20C292E428000D27573 /* AccountController+ExtraItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB6B20B292E428000D27573 /* AccountController+ExtraItems.swift */; };
 		DCB6B20F292F843800D27573 /* CollectionViewAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB6B20E292F843800D27573 /* CollectionViewAction.swift */; };
 		DCB796582BC535AD00D6D759 /* RemoveFromSidebarAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB796572BC535AD00D6D759 /* RemoveFromSidebarAction.swift */; };
+		DCB86E8F2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
+		DCB86E902BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
+		DCB86E912BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
+		DCB86E922BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
+		DCB86E932BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
+		DCB86E942BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */; };
 		DCBAEADB29A3674700BFF393 /* OCItemPolicy+UniversalItemListCellContentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBAEAD429A361C100BFF393 /* OCItemPolicy+UniversalItemListCellContentProvider.swift */; };
 		DCBAEADE29A5536F00BFF393 /* CollectionViewSupplementaryCellProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBAEADD29A5536F00BFF393 /* CollectionViewSupplementaryCellProvider.swift */; };
 		DCBAEAE029A554CC00BFF393 /* CollectionViewSupplementaryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBAEADF29A554CC00BFF393 /* CollectionViewSupplementaryItem.swift */; };
@@ -1551,6 +1557,7 @@
 		DCB6B20E292F843800D27573 /* CollectionViewAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewAction.swift; sourceTree = "<group>"; };
 		DCB6C4DD24559B1600C1EAE1 /* AccountAuthenticationUpdaterPasswordPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAuthenticationUpdaterPasswordPromptViewController.swift; sourceTree = "<group>"; };
 		DCB796572BC535AD00D6D759 /* RemoveFromSidebarAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveFromSidebarAction.swift; sourceTree = "<group>"; };
+		DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		DCBAEAD429A361C100BFF393 /* OCItemPolicy+UniversalItemListCellContentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCItemPolicy+UniversalItemListCellContentProvider.swift"; sourceTree = "<group>"; };
 		DCBAEADD29A5536F00BFF393 /* CollectionViewSupplementaryCellProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewSupplementaryCellProvider.swift; sourceTree = "<group>"; };
 		DCBAEADF29A554CC00BFF393 /* CollectionViewSupplementaryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewSupplementaryItem.swift; sourceTree = "<group>"; };
@@ -1851,6 +1858,7 @@
 			children = (
 				DC3BAC63282472A80057FCD4 /* KNOWN_ISSUES.md */,
 				DC9BFBB220A19AF3007064B5 /* doc */,
+				DCB86E8E2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy */,
 				233BDEBF204FEFF300C06732 /* ownCloudSDK.xcodeproj */,
 				233BDE9E204FEFE500C06732 /* ownCloud */,
 				DC7DBA10207F59C500E7337D /* External */,
@@ -4305,6 +4313,7 @@
 				39DF77D524EA854C0066E8F0 /* LaunchScreen.storyboard in Resources */,
 				3968C883239C54AD00AC28AC /* ReleaseNotes.plist in Resources */,
 				59D4895220C83F2E00369C2E /* InfoPlist.strings in Resources */,
+				DCB86E8F2BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 				593A821120C7D4C5000E2A90 /* Localizable.strings in Resources */,
 				DCE684F6241BD4E800799C30 /* Branding.plist in Resources */,
 				DC9BFBB320A19AF4007064B5 /* doc in Resources */,
@@ -4325,6 +4334,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCB86E942BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 				391933DA2B0B9863007DF90B /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4373,6 +4383,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCB86E922BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4380,6 +4391,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCB86E912BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 				39DC7CD325C2E1570001E08C /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4397,6 +4409,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCB86E902BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 				DC576EC022647A070087316D /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4408,6 +4421,7 @@
 				392DDAE624C8923B009E5406 /* Assets.xcassets in Resources */,
 				39534BC724EA903200AD7907 /* InfoPlist.strings in Resources */,
 				3949F6A224E6781600EC99A3 /* Localizable.strings in Resources */,
+				DCB86E932BD7B9EE00492C09 /* PrivacyInfo.xcprivacy in Resources */,
 				39E104CA24C585C30085FDDD /* (null) in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6313,7 +6327,7 @@
 			repositoryURL = "https://github.com/krzyzanowskim/OpenSSL.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 3.1.5001;
 			};
 		};
 		DCEAF08B28084B3800980B6D /* XCRemoteSwiftPackageReference "Down" */ = {


### PR DESCRIPTION
## Description
Adds the [privacy manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc) [required by Apple starting May 1, 2024](https://developer.apple.com/news/?id=3d8a9yyh) to the app and upgrades `krzyzanowskim/OpenSSL` to [3.1.5001](https://github.com/krzyzanowskim/OpenSSL/releases/tag/3.1.5001) to include a privacy manifest as [also required by Apple](https://developer.apple.com/support/third-party-SDK-requirements/).

~Note: since changes to the `ios-sdk` are also needed, this PR is based on [feature/url-shortcuts](https://github.com/owncloud/ios-app/tree/feature/url-shortcuts) which adopts the latest `ios-sdk` API changes. It's target should be changed to `milestone/12.3` once `feature/url-shortcuts` has been merged there.~ Now targeting `milestone/12.2`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
