### PR TITLE
[feature/reduce-mem-footprint] Reduce memory footprint

### DIFF
--- a/ownCloud File Provider/FileProviderContentEnumerator.m
+++ b/ownCloud File Provider/FileProviderContentEnumerator.m
@@ -16,7 +16,11 @@
  *
  */
 
-#import <ownCloudApp/ownCloudApp.h>
+#import <ownCloudSDK/ownCloudSDK.h>
+
+// BEGIN: Shared with ownCloudApp.framework
+#import "DisplaySettings.h"
+// END: shared with ownCloudApp.framework
 
 #import "FileProviderContentEnumerator.h"
 #import "FileProviderEnumeratorObserver.h"

--- a/ownCloud File Provider/FileProviderExtension.h
+++ b/ownCloud File Provider/FileProviderExtension.h
@@ -33,7 +33,6 @@
 
 extern OCClaimExplicitIdentifier OCClaimExplicitIdentifierFileProvider;
 
-extern OCClassSettingsIdentifier OCClassSettingsIdentifierFileProvider;
 extern OCClassSettingsKey OCClassSettingsKeyFileProviderSkipLocalErrorChecks;
 
 #define FPLogCmdBegin(command, format,...) \

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -376,6 +376,12 @@
 		 {
 			FPLogCmdBegin(@"StartProviding", @"Downloading %@", item);
 
+			if (((OCItem *)item).type == OCItemTypeCollection) {
+				// Can't download folders
+				completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{}]);
+				return;
+			}
+
 			[self.core downloadItem:(OCItem *)item options:@{
 
 				OCCoreOptionAddFileClaim : [OCClaim claimForLifetimeOfCore:core explicitIdentifier:OCClaimExplicitIdentifierFileProvider withLockType:OCClaimLockTypeRead]

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -17,7 +17,21 @@
  */
 
 #import <ownCloudSDK/ownCloudSDK.h>
-#import <ownCloudApp/ownCloudApp.h>
+
+// BEGIN: Shared with ownCloudApp.framework
+#import "Branding.h"
+#import "BrandingClassSettingsSource.h"
+#import "NotificationManager.h"
+#import "NotificationMessagePresenter.h"
+#import "NotificationAuthErrorForwarder.h"
+#import "OCBookmark+AppExtensions.h"
+#import "OCBookmark+FPServices.h"
+#import "OCCore+BundleImport.h"
+#import "OCFileProviderSettings.h"
+#import "VFSManager.h"
+#import "AppLockSettings.h"
+#import "ZIPArchive.h"
+// END: shared with ownCloudApp.framework
 
 #import "FileProviderExtension.h"
 #import "OCItem+FileProviderItem.h"
@@ -1382,7 +1396,6 @@
 @end
 
 OCClaimExplicitIdentifier OCClaimExplicitIdentifierFileProvider = @"fileProvider";
-OCClassSettingsIdentifier OCClassSettingsIdentifierFileProvider = @"file-provider";
 OCClassSettingsKey OCClassSettingsKeyFileProviderSkipLocalErrorChecks = @"skip-local-error-checks";
 
 /*

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -800,6 +800,7 @@
 				OCCoreOptionImportByCopying : @(importByCopying)
 			} placeholderCompletionHandler:^(NSError *error, OCItem *item) {
 				FPLogCmd(@"Completed with placeholderItem=%@, error=%@", item, error);
+				item.bookmarkUUID = self.core.bookmark.uuid.UUIDString; // ensure bookmarkUUID is present so that vfsItemID / itemIdentifier succeed
 				completionHandler(item, [error translatedError]);
 			} resultHandler:^(NSError *error, OCCore *core, OCItem *item, id parameter) {
 				if ([error.domain isEqual:OCHTTPStatusErrorDomain] && (error.code == OCHTTPStatusCodePRECONDITION_FAILED))

--- a/ownCloud File Provider/FileProviderExtension.m
+++ b/ownCloud File Provider/FileProviderExtension.m
@@ -487,7 +487,7 @@
 		 	// Cancel download if the item is currently downloading
 		 	if (item.isDownloading)
 		 	{
-		 		if ((downloadProgress = [self.core progressForItem:(OCItem *)item matchingEventType:OCEventTypeDownload]) != nil)
+		 		if ((downloadProgress = [self.core progressForItemWithLocalID:((OCItem *)item).localID matchingEventType:OCEventTypeDownload]) != nil)
 		 		{
 		 			[downloadProgress makeObjectsPerformSelector:@selector(cancel)];
 				}

--- a/ownCloud File Provider/FileProviderServiceSource.m
+++ b/ownCloud File Provider/FileProviderServiceSource.m
@@ -17,7 +17,12 @@
  */
 
 #import "FileProviderServiceSource.h"
-#import <ownCloudApp/ownCloudApp.h>
+
+// BEGIN: Shared with ownCloudApp.framework
+#import "OCFileProviderService.h"
+#import "OCCore+BundleImport.h"
+// END: Shared with ownCloudApp.framework
+
 #import <ownCloudSDK/ownCloudSDK.h>
 
 @interface OCCore (setNeedsToProcessSyncRecords)

--- a/ownCloud Intents/Base.lproj/Intents.intentdefinition
+++ b/ownCloud Intents/Base.lproj/Intents.intentdefinition
@@ -126,11 +126,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>K5U8aR</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>21E230</string>
+	<string>23G93</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>13E113</string>
+	<string>16A5230g</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>13.3</string>
+	<string>16.0</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -943,7 +943,7 @@
 			<integer>13</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>path,file,account,filename,fileextension,shouldOverwrite,waitForCompletion</key>
+				<key>path,file,account,filename,fileextension,shouldOverwrite</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -1216,54 +1216,6 @@
 					<true/>
 					<key>INIntentParameterTag</key>
 					<integer>11</integer>
-					<key>INIntentParameterType</key>
-					<string>Boolean</string>
-				</dict>
-				<dict>
-					<key>INIntentParameterConfigurable</key>
-					<true/>
-					<key>INIntentParameterDisplayName</key>
-					<string>Wait for upload to complete</string>
-					<key>INIntentParameterDisplayNameID</key>
-					<string>X18VvP</string>
-					<key>INIntentParameterDisplayPriority</key>
-					<integer>7</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataFalseDisplayName</key>
-						<string>false</string>
-						<key>INIntentParameterMetadataFalseDisplayNameID</key>
-						<string>7Zv2I0</string>
-						<key>INIntentParameterMetadataTrueDisplayName</key>
-						<string>true</string>
-						<key>INIntentParameterMetadataTrueDisplayNameID</key>
-						<string>w1TCyX</string>
-					</dict>
-					<key>INIntentParameterName</key>
-					<string>waitForCompletion</string>
-					<key>INIntentParameterPromptDialogs</key>
-					<array>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Configuration</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Wait for upload to complete before continuing</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>Wt9Wgt</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Primary</string>
-						</dict>
-					</array>
-					<key>INIntentParameterSupportsResolution</key>
-					<true/>
-					<key>INIntentParameterTag</key>
-					<integer>13</integer>
 					<key>INIntentParameterType</key>
 					<string>Boolean</string>
 				</dict>

--- a/ownCloud Share Extension/ShareExtensionViewController.swift
+++ b/ownCloud Share Extension/ShareExtensionViewController.swift
@@ -460,7 +460,7 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 	}
 }
 
-extension UserInterfaceContext : UserInterfaceContextProvider {
+extension UserInterfaceContext : ownCloudAppShared.UserInterfaceContextProvider {
 	public func provideRootView() -> UIView? {
 		return ShareExtensionViewController.shared?.view
 	}

--- a/ownCloud Share Extension/ShareExtensionViewController.swift
+++ b/ownCloud Share Extension/ShareExtensionViewController.swift
@@ -26,6 +26,9 @@ extension NSErrorDomain {
 	static let ShareErrorDomain = "ShareErrorDomain"
 }
 
+private let unitCountForImport: Int64 = 50
+private let unitCountForUpload: Int64 = 100
+
 @objc(ShareExtensionViewController)
 class ShareExtensionViewController: EmbeddingViewController, Themeable {
 	// MARK: - Initialization
@@ -93,62 +96,104 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 	var fpServiceSession : OCFileProviderServiceSession?
 	var asyncQueue : OCAsyncSequentialQueue = OCAsyncSequentialQueue()
 
+	var progressViewController: ProgressIndicatorViewController?
+	var uploadCoreProgress: Progress?
+
 	func importTo(selectedFolder: OCItem?, location: OCLocation?) {
-		if let targetFolder = selectedFolder, let bookmarkUUID = targetFolder.bookmarkUUID {
+		if let targetFolder = selectedFolder, let bookmarkUUID = targetFolder.bookmarkUUID ?? location?.bookmarkUUID?.uuidString {
 			if let bookmark = OCBookmarkManager.shared.bookmark(forUUIDString: bookmarkUUID) {
-				let vault = OCVault(bookmark: bookmark)
-				self.fpServiceSession = OCFileProviderServiceSession(vault: vault)
-
 				OnMainThread {
-					let progressViewController = ProgressIndicatorViewController(initialProgressLabel: "Preparing…".localized, progress: nil, cancelHandler: {})
+					self.progressViewController = ProgressIndicatorViewController(initialProgressLabel: "Preparing…".localized, progress: nil, cancelHandler: { [weak self] in
+						self?.uploadCoreProgress?.cancel() // Cancel transfers (!) via Progress instances provided by upload methods
+						self?.cancel()
+					})
+					self.contentViewController = self.progressViewController
 
-					self.contentViewController = progressViewController
+					let importCompletionHandler : ((_ error: Error?) -> Void) = { [weak self] (error) in
+						self?.finish(with: error)
+					}
 
-					AccountConnectionPool.shared.disconnectAll {
-						OnMainThread {
-							if let fpServiceSession = self.fpServiceSession {
-								self.importFiles(to: targetFolder, serviceSession: fpServiceSession, progressViewController: progressViewController, completion: { [weak self] (error) in
-									OnMainThread {
-										if let error = error {
-											self?.extensionContext?.cancelRequest(withError: error)
-										} else {
-											self?.extensionContext?.completeRequest(returningItems: [])
-										}
-									}
-								})
+					if let accountConnection = AccountConnectionPool.shared.connection(for: bookmark) {
+						// Account found - connect (just in case it's not)
+						accountConnection.connect { error in
+							if let error {
+								// Error connecting
+								Log.error("Share Extension could not connect: \(String(describing: error))")
+								self.finish(with: error)
+							} else if let core = accountConnection.core {
+								// Import files
+								OnMainThread {
+									self.importFiles(to: targetFolder, core: core, completion: importCompletionHandler)
+								}
+							} else {
+								// Error retrieving core for connection after connect (should never happen)
+								Log.error("Share Extension could not retrieve core for connection")
+								self.finish(with: NSError(ocError: .internal))
 							}
 						}
+					} else {
+						// Account not found - this should not be possible
+						self.finish(with: NSError(ocError: .internal))
 					}
 				}
 			}
 		}
 	}
 
-	func importFiles(to targetDirectory : OCItem, serviceSession: OCFileProviderServiceSession, progressViewController: ProgressIndicatorViewController?, completion: @escaping (_ error: Error?) -> Void) {
+	func importFiles(to targetDirectory : OCItem, core: OCCore, completion: @escaping (_ error: Error?) -> Void) {
 		if let inputItems : [NSExtensionItem] = self.extensionContext?.inputItems as? [NSExtensionItem] {
-			var totalItems : Int = 0
-			var importedItems : Int = 0
-			var importError : Error?
+			var totalItems : Int64 = 0
+			var importedItems : Int64 = 0
+			var uploadedItems : Int64 = 0
+			var importProgress: Progress
+			var uploadProgress: Progress
+			var totalProgress: Progress
+			var uploadError: Error?
+			let uploadWaitGroup: DispatchGroup = DispatchGroup()
 
 			for item : NSExtensionItem in inputItems {
 				if let attachments = item.attachments {
-					totalItems += attachments.count
+					totalItems += Int64(attachments.count)
 				}
 			}
 
-			let incrementImportedFile : () -> Void = { [weak progressViewController] in
+			importProgress = Progress(totalUnitCount: totalItems)
+			uploadProgress = Progress(totalUnitCount: totalItems)
+			totalProgress = Progress(totalUnitCount: (unitCountForImport + unitCountForUpload) * totalItems)
+			totalProgress.addChild(importProgress, withPendingUnitCount: unitCountForImport * totalItems)
+			totalProgress.addChild(uploadProgress, withPendingUnitCount: unitCountForUpload * totalItems)
+			self.progressViewController?.progress = totalProgress
+
+			uploadCoreProgress = Progress(totalUnitCount: totalItems)
+
+			let incrementImportCounter = {
+				// Increment progress
 				importedItems += 1
 
 				OnMainThread {
-					progressViewController?.update(progress: Float(importedItems)/Float(totalItems), text: NSString(format: "Importing item %ld of %ld".localized as NSString, importedItems, totalItems) as String)
+					importProgress.completedUnitCount = importedItems
+					totalProgress.localizedDescription = NSString(format: "Importing item %ld of %ld".localized as NSString, importedItems, totalItems) as String
+					// self.progressViewController?.update(text: NSString(format: "Importing item %ld of %ld".localized as NSString, importedItems, totalItems) as String)
 				}
 			}
 
-			// Keep session open
-			serviceSession.acquireFileProviderServicesHost(completionHandler: { (_, _, doneHandler) in
-				serviceSession.incrementSessionUsage()
-				doneHandler?()
-			}, errorHandler: { (_) in })
+			let updateUploadMessage = {
+				OnMainThread {
+					if importedItems == totalItems {
+						totalProgress.localizedDescription = "Uploading {{remainingFileCount}} files…".localized(["remainingFileCount" : "\(totalItems - uploadedItems)"])
+					}
+				}
+			}
+
+			let handleUploadResult: (_ error: Error?) -> Void = { (error) in
+				if let error {
+					uploadError = error
+				}
+				uploadProgress.completedUnitCount += 1
+				uploadedItems += 1
+				updateUploadMessage()
+				uploadWaitGroup.leave()
+			}
 
 			for item : NSExtensionItem in inputItems {
 				if let attachments = item.attachments {
@@ -160,14 +205,19 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 						if var type = attachment.registeredTypeIdentifiers.first, attachment.hasItemConformingToTypeIdentifier(UTType.item.identifier) {
 							if type == "public.plain-text" || type == "public.url" || attachment.registeredTypeIdentifiers.contains("public.file-url") {
 								asyncQueue.async({ (jobDone) in
-									if progressViewController?.cancelled == true {
+									if self.progressViewController?.cancelled == true {
 										jobDone()
 										return
 									}
+
+									incrementImportCounter()
+
 									// Workaround for saving attachements from Mail.app. Attachments from Mail.app contains two types e.g. "com.adobe.pdf" AND "public.file-url". For loading the file the type "public.file-url" is needed. Otherwise the resource could not be accessed (NSItemProviderSandboxedResource)
 									if attachment.registeredTypeIdentifiers.contains("public.file-url") {
 										type = "public.file-url"
 									}
+
+									let suggestedTextFileName = attachment.suggestedName ?? "Text".localized
 
 									attachment.loadItem(forTypeIdentifier: type, options: nil, completionHandler: { (item, error) -> Void in
 										if error == nil {
@@ -177,12 +227,12 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 
 											if let text = item as? String { // Save plain text content
 												let ext = UTType(type)?.preferredFilenameExtension
-												tempFilePath = NSTemporaryDirectory() + (attachment.suggestedName ?? "Text".localized) + "." + (ext ?? type)
+												tempFilePath = NSTemporaryDirectory() + suggestedTextFileName + "." + (ext ?? type)
 												data = Data(text.utf8)
 											} else if let url = item as? URL { // Download URL content
 												if url.isFileURL {
 													tempFileURL = URL(fileURLWithPath: NSTemporaryDirectory() + url.lastPathComponent)
-													if let tempFileURL = tempFileURL {
+													if let tempFileURL {
 														try? FileManager.default.copyItem(at: url, to: tempFileURL)
 													}
 												} else {
@@ -195,84 +245,58 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 												}
 											}
 
-											if tempFileURL == nil, let data = data, let tempFilePath = tempFilePath {
+											if tempFileURL == nil, let data = data, let tempFilePath {
 												FileManager.default.createFile(atPath: tempFilePath, contents:data, attributes:nil)
 												tempFileURL = URL(fileURLWithPath: tempFilePath)
 											}
 
-											if let tempFileURL = tempFileURL {
-												serviceSession.importThroughFileProvider(url: tempFileURL, to: targetDirectory, completion: { (error, _) in
-													try? FileManager.default.removeItem(at: tempFileURL)
+											if let tempFileURL {
+												uploadWaitGroup.enter()
 
-													if let error = error {
-														Log.error("Error importing item at \(tempFileURL) through file provider: \(String(describing: error))")
-
-														self.showAlert(title: NSString(format: "Error importing %@".localized as NSString, tempFileURL.lastPathComponent) as String, error: error, decisionHandler: { (doContinue) in
-															if !doContinue {
-																importError = error
-																progressViewController?.cancel()
-															}
-
-															jobDone()
-														})
-													} else {
-														incrementImportedFile()
-
-														jobDone()
-													}
-												})
+												if let coreProgress = self.uploadFile(from: tempFileURL, removeAfterImport: true, to: targetDirectory, via: core, schedulingDoneBlock: jobDone, completionHandler: handleUploadResult) {
+													self.uploadCoreProgress?.addChild(coreProgress, withPendingUnitCount: 1)
+												}
 											} else {
 												jobDone()
 											}
-										} else {
+										} else if let error {
 											Log.error("Error loading item: \(String(describing: error))")
 
-											self.showAlert(title: "Error loading item".localized, error: error, decisionHandler: { (doContinue) in
+											self.showAlert(title: "Error loading item".localized, error: error, decisionHandler: { [weak self] (doContinue) in
 												if !doContinue {
-													importError = error
-													progressViewController?.cancel()
+													self?.cancel()
 												}
 
 												jobDone()
 											})
+										} else {
+											jobDone()
 										}
 									})
 								})
 							} else {
 								// Handle local files
 								asyncQueue.async({ (jobDone) in
-									if progressViewController?.cancelled == true {
+									if self.progressViewController?.cancelled == true {
 										jobDone()
 										return
 									}
 
+									incrementImportCounter()
+
 									attachment.loadFileRepresentation(forTypeIdentifier: type) { (url, error) in
-										if error == nil, let url = url {
-											serviceSession.importThroughFileProvider(url: url, to: targetDirectory, completion: { (error, _) in
-												if let error = error {
-													Log.error("Error importing item at \(url.absoluteString) through file provider: \(String(describing: error))")
+										if error == nil, let url {
+											uploadWaitGroup.enter()
 
-													self.showAlert(title: NSString(format: "Error importing %@", url.lastPathComponent) as String, error: error, decisionHandler: { (doContinue) in
-														if !doContinue {
-															importError = error
-															progressViewController?.cancel()
-														}
-
-														jobDone()
-													})
-												} else {
-													incrementImportedFile()
-
-													jobDone()
-												}
-											})
-										} else if let error = error {
+											if let coreProgress = self.uploadFile(from: url, removeAfterImport: false, to: targetDirectory, via: core, schedulingDoneBlock: jobDone, completionHandler: handleUploadResult) {
+												self.uploadCoreProgress?.addChild(coreProgress, withPendingUnitCount: 1)
+											}
+										} else if let error {
 											Log.error("Error loading item: \(String(describing: error))")
 
-											self.showAlert(title: "Error loading item".localized, error: error, decisionHandler: { (doContinue) in
+											self.showAlert(title: "Error loading item".localized, error: error, decisionHandler: { [weak self] (doContinue) in
 												if !doContinue {
-													importError = error
-													progressViewController?.cancel()
+													self?.cancel()
 												}
 
 												jobDone()
@@ -289,15 +313,47 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 			}
 
 			asyncQueue.async({ (jobDone) in
-				// Balance previous retainSession() call and allow session to close
-				serviceSession.decrementSessionUsage()
-
 				OnMainThread {
-					completion(importError ?? ((progressViewController?.cancelled ?? false) ? NSError(ocError: .cancelled) : nil))
-					jobDone()
+					updateUploadMessage()
 				}
+
+				uploadWaitGroup.notify(queue: .main, execute: {
+ 					self.finish(with: ((self.progressViewController?.cancelled ?? false) ? NSError(ocError: .cancelled) : uploadError))
+ 					jobDone()
+				})
 			})
 		}
+	}
+
+	func uploadFile(from sourceURL: URL, removeAfterImport: Bool, to targetItem: OCItem, via core: OCCore, schedulingDoneBlock: @escaping os_block_t, completionHandler: @escaping (Error?) -> Void) -> Progress? {
+		let progress = core.importItemNamed(sourceURL.lastPathComponent, at: targetItem, from: sourceURL, isSecurityScoped: false, options: [
+			.importByCopying : true,
+			.automaticConflictResolutionNameStyle : OCCoreDuplicateNameStyle.bracketed.rawValue
+		], placeholderCompletionHandler: { [weak self] error, placeholderItem in
+			if removeAfterImport {
+				try? FileManager.default.removeItem(at: sourceURL)
+			}
+
+			if let error {
+				Log.error("Error importing item at \(sourceURL) through share extension: \(String(describing: error))")
+
+				self?.showAlert(title: NSString(format: "Error importing %@".localized as NSString, sourceURL.lastPathComponent) as String, error: error, decisionHandler: { [weak self] (doContinue) in
+					if !doContinue {
+						completionHandler(error)
+						self?.progressViewController?.cancel()
+					}
+
+					schedulingDoneBlock()
+				})
+			} else {
+				schedulingDoneBlock()
+			}
+		}, resultHandler: { error, core, item, parameter in
+			completionHandler(error)
+			schedulingDoneBlock()
+		})
+
+		return progress
 	}
 
 	// MARK: - Events
@@ -413,19 +469,35 @@ class ShareExtensionViewController: EmbeddingViewController, Themeable {
 	}
 
 	// MARK: - Actions
-	func completed() {
-		AppLockManager.shared.appDidEnterBackground()
-
-		AccountConnectionPool.shared.disconnectAll {
-			self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
-		}
+	func cancel() {
+		finish(with: NSError(domain: NSErrorDomain.ShareErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Canceled by user"]))
 	}
 
-	func cancel() {
-		AppLockManager.shared.appDidEnterBackground()
+	private var _isFinished: Bool = false
+	func finish(with error: Error?) {
+		var alreadyFinished: Bool = false
 
-		AccountConnectionPool.shared.disconnectAll {
-			self.extensionContext?.cancelRequest(withError: NSError(domain: NSErrorDomain.ShareErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Canceled by user"]))
+		OCSynchronized(self) {
+			alreadyFinished = _isFinished
+			_isFinished = true
+		}
+
+		if alreadyFinished {
+			// Already finished
+			Log.error("Share Extension already finished. Attempt to finish again with \(String(describing: error))")
+			return
+		}
+
+		OnMainThread {
+			AppLockManager.shared.appDidEnterBackground()
+
+			AccountConnectionPool.shared.disconnectAll { [weak self] in
+				if let error = error {
+					self?.extensionContext?.cancelRequest(withError: error)
+				} else {
+					self?.extensionContext?.completeRequest(returningItems: [])
+				}
+			}
 		}
 	}
 

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -6387,7 +6387,7 @@
 			repositoryURL = "https://github.com/krzyzanowskim/OpenSSL.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.5001;
+				minimumVersion = 3.1.5006;
 			};
 		};
 		DCEAF08B28084B3800980B6D /* XCRemoteSwiftPackageReference "Down" */ = {

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -217,6 +217,21 @@
 		DC0A35A124C1091400FB58FC /* UserInterfaceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0A35A024C1091400FB58FC /* UserInterfaceContext.swift */; };
 		DC0A5C432550C70800E6674B /* class-settings-sdk in Resources */ = {isa = PBXBuildFile; fileRef = DC0A5C422550C70800E6674B /* class-settings-sdk */; };
 		DC0CE19D28C89CD9009ABDFB /* CreateDocumentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0CE19C28C89CD9009ABDFB /* CreateDocumentAction.swift */; };
+		DC1251DF2C746F450040FBC6 /* DisplaySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0857D2293F2D7008CC05C /* DisplaySettings.m */; };
+		DC1251E02C746F8D0040FBC6 /* NotificationMessagePresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC832E7242CB18700153F8C /* NotificationMessagePresenter.m */; };
+		DC1251E12C746FA60040FBC6 /* NotificationAuthErrorForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = DCDBB60325252FDA00FAD707 /* NotificationAuthErrorForwarder.m */; };
+		DC1251E22C746FFF0040FBC6 /* VFSManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEA7F40282D3B110050A3C0 /* VFSManager.m */; };
+		DC1251E32C7470080040FBC6 /* OCVault+VFSManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DC49B55828365C5F00DAF13B /* OCVault+VFSManager.m */; };
+		DC1251E42C7470180040FBC6 /* OCFileProviderSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6179E628E0578400C7C4E0 /* OCFileProviderSettings.m */; };
+		DC1251E52C74703F0040FBC6 /* OCBookmark+FPServices.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF2DA8024C836240026D790 /* OCBookmark+FPServices.m */; };
+		DC1251E62C7470820040FBC6 /* Branding.m in Sources */ = {isa = PBXBuildFile; fileRef = DC24B27225B9DF31005783E2 /* Branding.m */; };
+		DC1251E72C74708B0040FBC6 /* BrandingClassSettingsSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DCB2C05E250C1F9E001083CA /* BrandingClassSettingsSource.m */; };
+		DC1251E82C7470C30040FBC6 /* OCBookmark+AppExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7C100F24B5F81E00227085 /* OCBookmark+AppExtensions.m */; };
+		DC1251E92C7470F80040FBC6 /* AppLockSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6A0E5326EA9E740076B533 /* AppLockSettings.m */; };
+		DC1251EA2C7471620040FBC6 /* OCCore+BundleImport.m in Sources */ = {isa = PBXBuildFile; fileRef = DC774E6222F44E6D000B11A1 /* OCCore+BundleImport.m */; };
+		DC1251EB2C74716A0040FBC6 /* ZIPArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = DC774E5D22F44E4A000B11A1 /* ZIPArchive.m */; };
+		DC1251EC2C74718B0040FBC6 /* libzip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCE93FF321FCA434000E14F2 /* libzip.framework */; };
+		DC1251F42C7474910040FBC6 /* NotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC832EA242CB4D600153F8C /* NotificationManager.m */; };
 		DC1621352B8FE26200EB17F8 /* OCVault+SidebarItems.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1621332B8FE26200EB17F8 /* OCVault+SidebarItems.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC1621362B8FE26200EB17F8 /* OCVault+SidebarItems.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1621342B8FE26200EB17F8 /* OCVault+SidebarItems.m */; };
 		DC1621382B8FE9BF00EB17F8 /* AddToSidebarAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1621372B8FE9BF00EB17F8 /* AddToSidebarAction.swift */; };
@@ -505,7 +520,6 @@
 		DCC0857B2293F29F008CC05C /* ownCloudSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 239369782076110900BCE21A /* ownCloudSDK.framework */; };
 		DCC0857F2293F48D008CC05C /* DisplaySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0857D2293F2D7008CC05C /* DisplaySettings.m */; };
 		DCC085802293F490008CC05C /* DisplaySettings.h in Headers */ = {isa = PBXBuildFile; fileRef = DCC0857C2293F2D7008CC05C /* DisplaySettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCC085812293F66D008CC05C /* ownCloudApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC0855C2293F1FD008CC05C /* ownCloudApp.framework */; };
 		DCC3700724D466D2008B0DEB /* DiagnosticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC3700624D466D2008B0DEB /* DiagnosticManager.swift */; };
 		DCC3701624D4D365008B0DEB /* OCScanJobActivity+DiagnosticGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC3701524D4D365008B0DEB /* OCScanJobActivity+DiagnosticGenerator.swift */; };
 		DCC5E4472326564F002E5B84 /* NSObject+AnnotatedProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = DCC5E444232654DE002E5B84 /* NSObject+AnnotatedProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -900,13 +914,6 @@
 			remoteGlobalIDString = DCC8F9AA202852A200EB6701;
 			remoteInfo = ownCloudSDK;
 		};
-		DCC085822293F671008CC05C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 233BDE94204FEFE500C06732 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DCC0855B2293F1FD008CC05C;
-			remoteInfo = ownCloudApp;
-		};
 		DCC6566320C9B7E400110A97 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 233BDE94204FEFE500C06732 /* Project object */;
@@ -1283,6 +1290,9 @@
 		DC0B37962051681600189B9A /* ThemeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeButton.swift; sourceTree = "<group>"; };
 		DC0CE19128C7DBE3009ABDFB /* OpenInWebAppAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInWebAppAction.swift; sourceTree = "<group>"; };
 		DC0CE19C28C89CD9009ABDFB /* CreateDocumentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDocumentAction.swift; sourceTree = "<group>"; };
+		DC1251ED2C7474100040FBC6 /* FileProvider.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FileProvider.framework; path = System/Library/Frameworks/FileProvider.framework; sourceTree = SDKROOT; };
+		DC1251F02C74743E0040FBC6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		DC1251F22C7474500040FBC6 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		DC136581208223F000FC0F60 /* OCBookmark+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCBookmark+Extension.swift"; sourceTree = "<group>"; };
 		DC1621332B8FE26200EB17F8 /* OCVault+SidebarItems.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCVault+SidebarItems.h"; sourceTree = "<group>"; };
 		DC1621342B8FE26200EB17F8 /* OCVault+SidebarItems.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OCVault+SidebarItems.m"; sourceTree = "<group>"; };
@@ -1840,11 +1850,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCC085812293F66D008CC05C /* ownCloudApp.framework in Frameworks */,
+				DC27A18F20CAA0BA008ACB6C /* ownCloudSDK.framework in Frameworks */,
+				DC1251EC2C74718B0040FBC6 /* libzip.framework in Frameworks */,
 				02AE32E424D2FA8B00A19476 /* CrashReporter in Frameworks */,
 				DC2565EE225F5A1900828AA5 /* UserNotifications.framework in Frameworks */,
 				DC973BBE24A28ED0001DEEC4 /* CoreServices.framework in Frameworks */,
-				DC27A18F20CAA0BA008ACB6C /* ownCloudSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2908,6 +2918,9 @@
 		DC85573220513CC700189B9A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DC1251F22C7474500040FBC6 /* LocalAuthentication.framework */,
+				DC1251F02C74743E0040FBC6 /* UIKit.framework */,
+				DC1251ED2C7474100040FBC6 /* FileProvider.framework */,
 				DCEC3DE3242F665D0076B43C /* CoreServices.framework */,
 				DC080CF0238C8D850044C5D2 /* StoreKit.framework */,
 				DC2565E8225F5A1900828AA5 /* UserNotifications.framework */,
@@ -4134,7 +4147,6 @@
 			);
 			dependencies = (
 				DC27A19320CAA0C6008ACB6C /* PBXTargetDependency */,
-				DCC085832293F671008CC05C /* PBXTargetDependency */,
 			);
 			name = "ownCloud File Provider";
 			packageProductDependencies = (
@@ -5123,17 +5135,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC1251E22C746FFF0040FBC6 /* VFSManager.m in Sources */,
+				DC1251E42C7470180040FBC6 /* OCFileProviderSettings.m in Sources */,
+				DC1251E12C746FA60040FBC6 /* NotificationAuthErrorForwarder.m in Sources */,
+				DC1251E32C7470080040FBC6 /* OCVault+VFSManager.m in Sources */,
+				DC1251F42C7474910040FBC6 /* NotificationManager.m in Sources */,
+				DC1251EB2C74716A0040FBC6 /* ZIPArchive.m in Sources */,
 				DC2218C62822C5B900808BCE /* OCVFSNode+FileProviderItem.m in Sources */,
+				DC1251E72C74708B0040FBC6 /* BrandingClassSettingsSource.m in Sources */,
 				DC98BBD420FF824600F4ED3E /* FileProviderEnumeratorObserver.m in Sources */,
+				DC1251E62C7470820040FBC6 /* Branding.m in Sources */,
 				DC2218CC2823329100808BCE /* FileProviderContentEnumerator.m in Sources */,
 				DC27A1E920CC56B0008ACB6C /* FileProviderExtensionThumbnailRequest.m in Sources */,
 				DCF2DA7A24C82E480026D790 /* FileProviderServiceSource.m in Sources */,
 				DC625141225C904700736874 /* NSError+MessageResolution.m in Sources */,
 				DC27A1A820CC095C008ACB6C /* OCCore+FileProviderTools.m in Sources */,
+				DC1251E82C7470C30040FBC6 /* OCBookmark+AppExtensions.m in Sources */,
+				DC1251E52C74703F0040FBC6 /* OCBookmark+FPServices.m in Sources */,
+				DC1251E92C7470F80040FBC6 /* AppLockSettings.m in Sources */,
+				DC1251DF2C746F450040FBC6 /* DisplaySettings.m in Sources */,
 				DCC6564A20C9B7E400110A97 /* FileProviderExtension.m in Sources */,
 				DC27A1A520CBEF85008ACB6C /* OCBookmark+FileProvider.m in Sources */,
 				DC27A18E20CA9F66008ACB6C /* OCItem+FileProviderItem.m in Sources */,
+				DC1251EA2C7471620040FBC6 /* OCCore+BundleImport.m in Sources */,
 				DC98BBCB20FF815C00F4ED3E /* NSNumber+OCSyncAnchorData.m in Sources */,
+				DC1251E02C746F8D0040FBC6 /* NotificationMessagePresenter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5313,11 +5339,6 @@
 			isa = PBXTargetDependency;
 			name = ownCloudSDK;
 			targetProxy = DCC085792293F296008CC05C /* PBXContainerItemProxy */;
-		};
-		DCC085832293F671008CC05C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DCC0855B2293F1FD008CC05C /* ownCloudApp */;
-			targetProxy = DCC085822293F671008CC05C /* PBXContainerItemProxy */;
 		};
 		DCC6566420C9B7E400110A97 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5793,9 +5814,10 @@
 				CODE_SIGN_ENTITLEMENTS = "ownCloud Action Extension/ownCloud Action Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(APP_VERSION)";
-				DEVELOPMENT_TEAM = 4AP2STM4H5;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 4AP2STM4H5;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -5813,6 +5835,8 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.owncloud.ios-app.ownCloud-Action-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.owncloud.ios-app.ownCloud-Action-Extension";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -4171,7 +4171,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = "ownCloud GmbH";
 				TargetAttributes = {
 					233BDE9B204FEFE500C06732 = {

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/MakeTVG.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/MakeTVG.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File Provider.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File Provider.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File ProviderUI.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud File ProviderUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Intents.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Intents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Share Extension.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud Share Extension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudApp.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudScreenshotsTests.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudScreenshotsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudTests.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloudTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ownCloud/App Controllers/AccountController+ExtraItems.swift
+++ b/ownCloud/App Controllers/AccountController+ExtraItems.swift
@@ -20,7 +20,7 @@ import UIKit
 import ownCloudSDK
 import ownCloudAppShared
 
-extension AccountController: AccountControllerExtraItems {
+extension AccountController: ownCloudAppShared.AccountControllerExtraItems {
 	var activitySideBarItem: CollectionSidebarAction? {
 		var sideBarItem: CollectionSidebarAction? = specialItems[.activity] as? CollectionSidebarAction
 

--- a/ownCloud/App Controllers/AccountController+ItemActions.swift
+++ b/ownCloud/App Controllers/AccountController+ItemActions.swift
@@ -59,7 +59,7 @@ extension AccountController {
 	}
 }
 
-extension AccountController: DataItemSwipeInteraction {
+extension AccountController: ownCloudAppShared.DataItemSwipeInteraction {
 	public func provideTrailingSwipeActions(with context: ClientContext?) -> UISwipeActionsConfiguration? {
 		if let hostViewController = context?.originatingViewController ?? context?.rootViewController {
 			let deleteRowAction = UIContextualAction(style: .destructive, title: localizedDeleteTitle, handler: { [weak self, weak hostViewController] (_, _, completionHandler) in
@@ -96,7 +96,7 @@ extension AccountController {
 	}
 }
 
-extension AccountController: DataItemContextMenuInteraction {
+extension AccountController: ownCloudAppShared.DataItemContextMenuInteraction {
 	public func composeContextMenuItems(in viewController: UIViewController?, location: OCExtensionLocationIdentifier, with context: ClientContext?) -> [UIMenuElement]? {
 		if let hostViewController = context?.originatingViewController ?? context?.rootViewController {
 			var menuItems: [UIMenuElement] = []
@@ -166,7 +166,7 @@ extension AccountController: DataItemContextMenuInteraction {
 	}
 }
 
-extension AccountController: DataItemDragInteraction {
+extension AccountController: ownCloudAppShared.DataItemDragInteraction {
 	public func provideDragItems(with context: ClientContext?) -> [UIDragItem]? {
 		if let bookmark, let userActivity = openInNewWindowUserActivity(with: clientContext) {
 			let itemProvider = NSItemProvider(item: bookmark, typeIdentifier: "com.owncloud.ios-app.ocbookmark")
@@ -182,7 +182,7 @@ extension AccountController: DataItemDragInteraction {
 	}
 }
 
-extension AccountController: DataItemDropInteraction {
+extension AccountController: ownCloudAppShared.DataItemDropInteraction {
 	public func allowDropOperation(for session: UIDropSession, with context: ClientContext?) -> UICollectionViewDropProposal? {
 		if session.localDragSession == nil {
 			return nil

--- a/ownCloud/AppDelegate.swift
+++ b/ownCloud/AppDelegate.swift
@@ -308,7 +308,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	}
 }
 
-extension UserInterfaceContext : UserInterfaceContextProvider {
+extension UserInterfaceContext : ownCloudAppShared.UserInterfaceContextProvider {
 	public func provideRootView() -> UIView? {
 		return provideCurrentWindow()
 	}

--- a/ownCloud/Client/Actions/Actions+Extensions/AvailableOfflineAction.swift
+++ b/ownCloud/Client/Actions/Actions+Extensions/AvailableOfflineAction.swift
@@ -38,7 +38,7 @@ class AvailableOfflineAction: Action {
 			if let itemLocation = item.location, let policies = core.retrieveAvailableOfflinePoliciesCovering(item, completionHandler: nil) {
 				for policy in policies {
 					// Only show if item is not already available offline via parent item
-					if let policyLocation = policy.location, itemLocation.isLocated(in: policyLocation) && itemLocation != policyLocation {
+					if let policyLocation = policy.location, itemLocation.isLocated(in: policyLocation) && !itemLocation.isEqual(policyLocation) {
 						return .none
 					}
 				}

--- a/ownCloud/Media Uploads/MediaUploadOperation.swift
+++ b/ownCloud/Media Uploads/MediaUploadOperation.swift
@@ -37,9 +37,11 @@ class MediaUploadOperation : Operation {
 		self.core = core
 		self.mediaUploadJob = mediaUploadJob
 		self.assetId = assetId
-		if let vault = self.core?.vault {
-			self.fpSession = OCFileProviderServiceSession(vault: vault)
-		}
+
+		// Disable FileProvider usage due to XPC / stability issues
+		// if let vault = self.core?.vault {
+		// 	self.fpSession = OCFileProviderServiceSession(vault: vault)
+		// }
 	}
 
 	override func main() {

--- a/ownCloud/SceneDelegate.swift
+++ b/ownCloud/SceneDelegate.swift
@@ -51,9 +51,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			window = ThemeWindow(windowScene: windowScene)
 
 			window?.rootViewController = appRootViewController
-			if #available(iOS 16, *) {
+			if #unavailable(iOS 16) {
+				// Only needed prior to iOS 16
 				// From the console: "Manually adding the rootViewController's view to the view hierarchy is no longer supported. Please allow UIWindow to add the rootViewController's view to the view hierarchy itself."
-			} else {
 				window?.addSubview(appRootViewController.view)
 			}
 			window?.makeKeyAndVisible()
@@ -167,7 +167,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 }
 
-extension ClientContext: ClientContextProvider {
+extension ClientContext: ownCloudAppShared.ClientContextProvider {
 	public func provideClientContext(for bookmarkUUID: UUID, completion: (Error?, ownCloudAppShared.ClientContext?) -> Void) {
 		if let sceneDelegate = scene?.delegate as? SceneDelegate,
 		   let sections = sceneDelegate.appRootViewController.sidebarViewController?.allSections {

--- a/ownCloud/Tools/VendorServices+App.swift
+++ b/ownCloud/Tools/VendorServices+App.swift
@@ -112,7 +112,7 @@ extension VendorServices {
 	}
 }
 
-extension VendorServices: MFMailComposeViewControllerDelegate {
+extension VendorServices: MessageUI.MFMailComposeViewControllerDelegate {
 	public func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
 		controller.dismiss(animated: true)
 	}

--- a/ownCloudAppShared/Branding/Branding+App.swift
+++ b/ownCloudAppShared/Branding/Branding+App.swift
@@ -65,7 +65,7 @@ enum BrandingColorAlias: String, CaseIterable {
 	case fileIconColor = "file-icon-color"
 }
 
-extension Branding : BrandingInitialization {
+extension Branding : ownCloudApp.BrandingInitialization {
 	public static func initializeBranding() {
 		self.registerOCClassSettingsDefaults([
 			.documentationURL : "https://doc.owncloud.com/ios-app/latest/",

--- a/ownCloudAppShared/Client/Account/Connection/AccountConnection.swift
+++ b/ownCloudAppShared/Client/Account/Connection/AccountConnection.swift
@@ -295,10 +295,12 @@ open class AccountConnection: NSObject {
 			connection.fpServiceStandby?.stop()
 
 			// Return core
-			OCCoreManager.shared.returnCore(for: self.bookmark, completionHandler: {
+			OCCoreManager.shared.returnCore(for: self.bookmark, completionHandler: { [weak self] in
 				connection.richStatus = nil
 				connection.core = nil
 				connection.status = .noCore
+
+				self?.progressSummarizer.resetPrioritySummaries()
 
 				OnMainThread {
 					completion?(nil)

--- a/ownCloudAppShared/Client/Collection Views/Cells/UniversalItemListCell Content Providers/OCItem+UniversalItemListCellContentProvider.swift
+++ b/ownCloudAppShared/Client/Collection Views/Cells/UniversalItemListCell Content Providers/OCItem+UniversalItemListCellContentProvider.swift
@@ -238,7 +238,7 @@ extension OCItem: UniversalItemListCellContentProvider {
 		var progress : Progress?
 
 		if syncActivity.rawValue & (OCItemSyncActivity.downloading.rawValue | OCItemSyncActivity.uploading.rawValue) != 0, !hasMessageForItem {
-			progress = context?.core?.progress(for: self, matching: .none)?.first
+			progress = context?.core?.progressForItem(withLocalID: self.localID, matching: .none)?.first
 
 			if progress == nil {
 				progress = Progress.indeterminate()

--- a/ownCloudAppShared/Intent/OCLicenseManager+Setup.swift
+++ b/ownCloudAppShared/Intent/OCLicenseManager+Setup.swift
@@ -107,7 +107,7 @@ public extension OCClassSettingsKey {
 	static var disableEnterpriseLicensing : OCClassSettingsKey { return OCClassSettingsKey(rawValue: "disable-enterprise-licensing") }
 }
 
-extension OCLicenseManager : OCClassSettingsSupport {
+extension OCLicenseManager : ownCloudSDK.OCClassSettingsSupport {
 	public static var classSettingsIdentifier: OCClassSettingsIdentifier {
 		return .licensing
 	}

--- a/ownCloudAppShared/Tools/Log.swift
+++ b/ownCloudAppShared/Tools/Log.swift
@@ -99,7 +99,7 @@ public class Log {
 	}
 }
 
-extension OCLogger : OCLogIntroFormat {
+extension OCLogger : ownCloudSDK.OCLogIntroFormat {
 	public func logIntroFormat() -> String {
 		return "{{stdIntro}}; Log options: \(Log.logOptionStatus)"
 	}

--- a/ownCloudAppShared/UIKit Extension/UIView+OCDataItem.swift
+++ b/ownCloudAppShared/UIKit Extension/UIView+OCDataItem.swift
@@ -19,7 +19,7 @@
 import UIKit
 import ownCloudSDK
 
-extension UIView : OCDataItem, OCDataItemVersioning {
+extension UIView : ownCloudSDK.OCDataItem, ownCloudSDK.OCDataItemVersioning {
 	private static let associatedKeyViewUUID = malloc(1)!
 
 	public var dataItemType: OCDataItemType {

--- a/ownCloudAppShared/User Interface/Progress/ProgressIndicatorViewController.swift
+++ b/ownCloudAppShared/User Interface/Progress/ProgressIndicatorViewController.swift
@@ -57,6 +57,8 @@ open class ProgressIndicatorViewController: UIViewController, Themeable {
 							self?.activityIndicator.stopAnimating()
 							self?.activityIndicator.isHidden = true
 							self?.progressView.isHidden = false
+
+							self?.progressView.progress = Float(progress.fractionCompleted)
 						}
 					}
 				})
@@ -78,6 +80,7 @@ open class ProgressIndicatorViewController: UIViewController, Themeable {
 		super.init(nibName: nil, bundle: nil)
 
 		self.progress = progress
+		self.cssSelectors = [ .modal ]
 
 		if let initialTitleLabel = initialTitleLabel {
 			titleLabel = UILabel()

--- a/ownCloudAppShared/User Interface/Progress/ProgressSummarizer.swift
+++ b/ownCloudAppShared/User Interface/Progress/ProgressSummarizer.swift
@@ -330,6 +330,15 @@ public class ProgressSummarizer: NSObject {
 		}
 	}
 
+	public func resetPrioritySummaries() {
+		OCSynchronized(self) {
+			Log.debug("Reset priority summaries")
+
+			prioritySummaries.removeAll()
+			self.prioritySummary = nil
+		}
+	}
+
 	// MARK: - Change notifications
 	private var observers : [ProgressSummaryNotificationObserver] = []
 	public func addObserver(_ observer: AnyObject, notificationBlock: @escaping ProgressSummarizerNotificationBlock) {

--- a/ownCloudAppShared/User Interface/Progress/ProgressView.swift
+++ b/ownCloudAppShared/User Interface/Progress/ProgressView.swift
@@ -25,7 +25,8 @@ public class ProgressView: UIView, Themeable, CAAnimationDelegate, ThemeCSSAutoS
 	var foregroundCircleLayer : CAShapeLayer = CAShapeLayer()
 	var stopButtonLayer : CAShapeLayer = CAShapeLayer()
 
-	private let dimensions : CGSize = CGSize(width: 30, height: 30)
+	private let dimensions = CGSize(width: 30, height: 30)
+	private let minimumViewSize = CGSize(width: 50, height: 50)
 	private let circleLineWidth : CGFloat = 3
 
 	private var _observerRegistered : Bool = false
@@ -132,6 +133,16 @@ public class ProgressView: UIView, Themeable, CAAnimationDelegate, ThemeCSSAutoS
 		Theme.shared.register(client: self, applyImmediately: true)
 
 		self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.cancel)))
+
+		self.addConstraints([
+			// Enforce minimum size of .dimensions
+			widthAnchor.constraint(greaterThanOrEqualToConstant: dimensions.width),
+			heightAnchor.constraint(greaterThanOrEqualToConstant: dimensions.height),
+
+			// Nudge Auto Layout towards using .minimumViewSize (.dimensions + extra space to make a better touch target) while allowing individual "overrides"
+			widthAnchor.constraint(equalToConstant: minimumViewSize.width).with(priority: .defaultHigh),
+			heightAnchor.constraint(equalToConstant: minimumViewSize.height).with(priority: .defaultHigh)
+		])
 
 		NotificationCenter.default.addObserver(self, selector: #selector(self.appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
 	}

--- a/ownCloudAppShared/User Interface/View Providers/OCResourceText+ViewProvider.swift
+++ b/ownCloudAppShared/User Interface/View Providers/OCResourceText+ViewProvider.swift
@@ -45,7 +45,7 @@ class ThemeableTextView : UITextView, Themeable {
 	}
 }
 
-extension OCResourceText : OCViewProvider {
+extension OCResourceText : ownCloudSDK.OCViewProvider {
 	public func provideView(for size: CGSize, in context: OCViewProviderContext?, completion completionHandler: @escaping (UIView?) -> Void) {
 		var attributedText : NSAttributedString?
 


### PR DESCRIPTION
## Description
In this PR:
- reduced memory consumption of the File Provider by removing dependency on `ownCloudApp` and its dependencies (like `OpenSSL.framework`). This increases the amount of memory available to the File Provider after loading, thereby also improving stability.
- avoid use of FileProvider via XPC due to stability issues
   - [x] by Media Import
   - [x] by Share Extension (refactored/rewritten to upload directly from the extension)
   - [x] by `SaveFileIntent` (Apple Shortcuts integration)
- add code handling iOS/iPadOS 18 requests to the File Provider to download folder items
- fix spurious "invalid parameter" error on import in File Provider
- properly clean up status of `ProgressSummarizer` after disconnect

Paired with https://github.com/owncloud/ios-sdk/pull/110.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
