### PR TITLE
fix: simplify Gemfile to allow GitHub dependabot to parse this file properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gem "fastlane"
 
-plugins_path = File.join(File.dirname(__FILE__), '.', 'fastlane/Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile("fastlane/Pluginfile")


### PR DESCRIPTION
## Description
GitHub dependabot cannot analyse the Gemfile due to error below

Error message:
```
Dependabot only supports uninterpolated string arguments to eval_gemfile. Got `plugins_path`
```


## Motivation and Context
Allow GitHub dependabot to manage dependencies

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [ ] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added changelog files for the fixed issues in folder changelog/unreleased
