### PR TITLE
[feature/security-first] Add capability control to allow password removal independent of password enforcement

### DIFF
--- a/ownCloudAppShared/Client/Sharing/ShareViewController.swift
+++ b/ownCloudAppShared/Client/Sharing/ShareViewController.swift
@@ -610,17 +610,33 @@ open class ShareViewController: CollectionViewController, SearchViewControllerDe
 			   permissions?.contains(.delete) == true && (
 				permissions?.contains(.create) == true ||
 				permissions?.contains(.update) == true) {
+				// Read/Write/Delete
+				if mode == .edit {
+					return capabilities.publicSharingPasswordBlockRemovalForReadWriteDelete == true
+				}
 				return capabilities.publicSharingPasswordEnforcedForReadWriteDelete == true
 			}
 			if permissions?.contains(.read) == true && (
 				permissions?.contains(.create) == true ||
 				permissions?.contains(.update) == true) {
+				// Read/Write
+				if mode == .edit {
+					return capabilities.publicSharingPasswordBlockRemovalForReadWrite == true
+				}
 				return capabilities.publicSharingPasswordEnforcedForReadWrite == true
 			}
 			if permissions?.contains(.create) == true {
+				// Upload only
+				if mode == .edit {
+					return capabilities.publicSharingPasswordBlockRemovalForUploadOnly == true
+				}
 				return capabilities.publicSharingPasswordEnforcedForUploadOnly == true
 			}
 			if permissions?.contains(.read) == true {
+				// Read only
+				if mode == .edit {
+					return capabilities.publicSharingPasswordBlockRemovalForReadOnly == true
+				}
 				return capabilities.publicSharingPasswordEnforcedForReadOnly == true
 			}
 		}


### PR DESCRIPTION
## Description
- ShareViewController: add support for new "block password removal" capabilities

## Related Issue
https://github.com/owncloud/ios-app/issues/1429

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
