### PR TITLE
[feature/security-first-mdm] Add MDM/branding control over block_password_removal default value

### DIFF
--- a/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
+++ b/ownCloud.xcodeproj/xcshareddata/xcschemes/ownCloud.xcscheme
@@ -501,6 +501,11 @@
             value = "[user,login_hint]"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "oc:connection.block-password-removal-default"
+            value = "false"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption


### PR DESCRIPTION
## Description
Adds a MDM/branding control over block_password_removal default value and reverts the default to the previous behavior.

#### New option:
`connection.block-password-removal-default`
> If a server does not provide `block_password_removal` information as part of its capabilities, this option provides the fallback value controlling whether passwords can (value: false) or can not (value: true) be removed from an existing link even if capabilities otherwise indicate passwords need to be enforced for links.

#### Example configuration
To implement the behavior as requested in #1429, `connection.block-password-removal-default` needs to be set to `false` in the `Branding.plist`:

```xml
<key>connection.block-password-removal-default</key>
<false/>
```

## Related Issue
#1429 -- SDK portion: https://github.com/owncloud/ios-sdk/pull/139

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
