### PR TITLE
[release/12.4.1] Release 12.4.1

### DIFF
--- a/changelog/1446/1448
+++ b/changelog/1446/1448
@@ -1,0 +1,5 @@
+Bugfix: Missing Framework
+
+There was an issue with PocketSVG 2.8.0 that causes all ownBrander builds / clean Xcode builds to fail due to a missing PocketSVG framework, resulting in a crash on startup.
+
+https://github.com/owncloud/ios-app/issues/1448

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -5273,8 +5273,8 @@
 				APP_BUILD_FLAGS = "$(inherited)";
 				APP_BUILD_FLAGS_SWIFT = "$(APP_BUILD_FLAGS)";
 				APP_PRODUCT_NAME = ownCloud;
-				APP_SHORT_VERSION = 12.4.0;
-				APP_VERSION = 296;
+				APP_SHORT_VERSION = 12.4.1;
+				APP_VERSION = 297;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -5344,8 +5344,8 @@
 				APP_BUILD_FLAGS = "$(inherited)";
 				APP_BUILD_FLAGS_SWIFT = "$(APP_BUILD_FLAGS)";
 				APP_PRODUCT_NAME = ownCloud;
-				APP_SHORT_VERSION = 12.4.0;
-				APP_VERSION = 296;
+				APP_SHORT_VERSION = 12.4.1;
+				APP_VERSION = 297;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -6253,32 +6253,32 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/plcrashreporter.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.10.1;
+				kind = exactVersion;
+				version = 1.12.0;
 			};
 		};
 		DC049197258CAF8200DEDC27 /* XCRemoteSwiftPackageReference "PocketSVG" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pocketsvg/PocketSVG.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.7.0;
+				kind = exactVersion;
+				version = 2.7.3;
 			};
 		};
 		DCEAF066280767BC00980B6D /* XCRemoteSwiftPackageReference "OpenSSL" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzyzanowskim/OpenSSL.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.5006;
+				kind = exactVersion;
+				version = 3.3.2000;
 			};
 		};
 		DCEAF08B28084B3800980B6D /* XCRemoteSwiftPackageReference "Down" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/johnxnguyen/Down";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = e754ab1c80920dd51a8e08290c912ac1c2ac8b58;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ownCloud/Release Notes/ReleaseNotes.plist
+++ b/ownCloud/Release Notes/ReleaseNotes.plist
@@ -2033,6 +2033,23 @@ Added an optional &quot;Wait for completion&quot; option to the &quot;Save File&
 				</dict>
 			</array>
 		</dict>
+		<dict>
+			<key>Version</key>
+			<string>12.4.1</string>
+			<key>ReleaseNotes</key>
+			<array>
+				<dict>
+					<key>Title</key>
+					<string>Startup Crash</string>
+					<key>Subtitle</key>
+					<string>Resolved a rare crash issue</string>
+					<key>Type</key>
+					<string>Fix</string>
+					<key>ImageName</key>
+					<string>ladybug</string>
+				</dict>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
There was an issue with PocketSVG 2.8.0 that causes all ownBrander builds / clean Xcode builds to fail due to a missing PocketSVG framework, resulting in a crash on startup.

## Related Issue
#1448 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**iOS documentation repository**](https://github.com/owncloud/docs-client-ios-app/issues).
- [x] I have read the [**CONTRIBUTING**](https://github.com/owncloud/ios-app/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added changelog files for the fixed issues in folder changelog/unreleased
