### PR TITLE
[fix/a11y-1364-setupwizard] Fix Setup Wizard issue with largest Dynamic Type setting

### DIFF
--- a/ownCloud/Bookmarks/BookmarkViewController.swift
+++ b/ownCloud/Bookmarks/BookmarkViewController.swift
@@ -1154,6 +1154,7 @@ extension BookmarkViewController {
 			setupViewController.navigationItem.titleLabelText = OCLocalizedString("Add account", nil)
 
 			let navigationViewController = ThemeNavigationController(rootViewController: setupViewController)
+			setupViewController.view.translatesAutoresizingMaskIntoConstraints = true
 			navigationViewController.modalPresentationStyle = .fullScreen
 			hostViewController.present(navigationViewController, animated: true, completion: nil)
 		}

--- a/ownCloud/Bookmarks/Setup/BookmarkSetupStepViewController.swift
+++ b/ownCloud/Bookmarks/Setup/BookmarkSetupStepViewController.swift
@@ -112,6 +112,7 @@ class BookmarkSetupStepViewController: UIViewController, UITextFieldDelegate {
 		var views: [UIView] = topViews ?? []
 
 		let contentView = UIView()
+		contentView.translatesAutoresizingMaskIntoConstraints = false
 		contentView.cssSelectors = [.step, step.cssSelector]
 
 		// Title & message
@@ -181,8 +182,21 @@ class BookmarkSetupStepViewController: UIViewController, UITextFieldDelegate {
 		self.backgroundView.layer.masksToBounds = true
 		contentView.embed(toFillWith: backgroundView)
 
-		// Layout views vertically in background view
-		contentView.embedVertically(views: views, insets: NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20), spacingProvider: { leadingView, trailingView in
+		// Create scrollview
+		let scrollView = UIScrollView(frame: .zero)
+		scrollView.translatesAutoresizingMaskIntoConstraints = false
+		scrollView.setContentHuggingPriority(.required, for: .horizontal)
+		scrollView.setContentHuggingPriority(.required, for: .vertical)
+		contentView.embed(toFillWith: scrollView)
+
+		// Layout views vertically on top of background view
+		let scrollContainerView = UIView()
+		scrollContainerView.translatesAutoresizingMaskIntoConstraints = false
+		scrollContainerView.setContentCompressionResistancePriority(.required, for: .horizontal)
+		scrollContainerView.setContentCompressionResistancePriority(.required, for: .vertical)
+		scrollContainerView.setContentHuggingPriority(.required, for: .vertical)
+
+		scrollContainerView.embedVertically(views: views, insets: NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20), spacingProvider: { leadingView, trailingView in
 			if leadingView == self.topViews?.last {
 				return self.topViewsSpacing
 			}
@@ -197,6 +211,14 @@ class BookmarkSetupStepViewController: UIViewController, UITextFieldDelegate {
 			}
 			return 5
 		}, centered: false)
+
+		let guide = scrollView.contentLayoutGuide
+
+		scrollView.embed(toFillWith: scrollContainerView, enclosingAnchors: UIView.AnchorSet(leadingAnchor: contentView.leadingAnchor, trailingAnchor: contentView.trailingAnchor, topAnchor: guide.topAnchor, bottomAnchor: guide.bottomAnchor, centerXAnchor: contentView.centerXAnchor, centerYAnchor: guide.centerYAnchor))
+
+		NSLayoutConstraint.activate([
+			scrollView.heightAnchor.constraint(equalTo: scrollContainerView.heightAnchor).with(priority: UILayoutPriority(rawValue: 700))
+		])
 
 		// Set view controller's view
 		self.view = contentView

--- a/ownCloud/Bookmarks/Setup/BookmarkSetupViewController.swift
+++ b/ownCloud/Bookmarks/Setup/BookmarkSetupViewController.swift
@@ -51,6 +51,7 @@ class BookmarkSetupViewController: EmbeddingViewController, BookmarkComposerDele
 
 	override func loadView() {
 		let contentView = UIView()
+		contentView.translatesAutoresizingMaskIntoConstraints = false
 
 		visibleContentContainerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ownCloudAppShared/Client/Collection Views/Cells/AccountControllerCell.swift
+++ b/ownCloudAppShared/Client/Collection Views/Cells/AccountControllerCell.swift
@@ -85,6 +85,8 @@ class AccountControllerCell: ThemeableCollectionViewListCell {
 	}
 
 	func configureLayout() {
+		let dynamicHeight = UIFontMetrics.default.scaledValue(for: AccountControllerCell.avatarSideLength + 20)
+
 		NSLayoutConstraint.activate([
 			iconView.widthAnchor.constraint(equalToConstant: AccountControllerCell.avatarSideLength),
 			iconView.heightAnchor.constraint(equalToConstant: AccountControllerCell.avatarSideLength),
@@ -113,7 +115,7 @@ class AccountControllerCell: ThemeableCollectionViewListCell {
 			disconnectButton.trailingAnchor.constraint(lessThanOrEqualTo: infoView.trailingAnchor),
 			disconnectButton.centerYAnchor.constraint(equalTo: infoView.centerYAnchor),
 
-			contentView.heightAnchor.constraint(equalToConstant: AccountControllerCell.avatarSideLength + 20).with(priority: .defaultHigh)
+			contentView.heightAnchor.constraint(equalToConstant: dynamicHeight).with(priority: .defaultHigh)
 		])
 
 		infoView.setContentHuggingPriority(.required, for: .horizontal)

--- a/ownCloudAppShared/User Interface/SegmentView/UIView+EmbedAndLayout.swift
+++ b/ownCloudAppShared/User Interface/SegmentView/UIView+EmbedAndLayout.swift
@@ -36,6 +36,15 @@ public extension UIView {
 
 		public var centerXAnchor: NSLayoutXAxisAnchor
 		public var centerYAnchor: NSLayoutYAxisAnchor
+
+		public init(leadingAnchor: NSLayoutXAxisAnchor, trailingAnchor: NSLayoutXAxisAnchor, topAnchor: NSLayoutYAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor, centerXAnchor: NSLayoutXAxisAnchor, centerYAnchor: NSLayoutYAxisAnchor) {
+			self.leadingAnchor = leadingAnchor
+			self.trailingAnchor = trailingAnchor
+			self.topAnchor = topAnchor
+			self.bottomAnchor = bottomAnchor
+			self.centerXAnchor = centerXAnchor
+			self.centerYAnchor = centerYAnchor
+		}
 	}
 
 	var defaultAnchorSet : AnchorSet {


### PR DESCRIPTION
## Description
Make layout of setup wizard also usable when using the largest Dynamic Type text size by moving the content into a scrollview that comes into effect if the content of a step doesn't fit in the available vertical space.

## Related Issue
#1364

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)