### PR TITLE
[fix/mac-drop-crash] Fix file drop crash on macOS

### DIFF
--- a/ownCloudAppFramework/Foundation Extensions/NSURL+OCVaultTools.m
+++ b/ownCloudAppFramework/Foundation Extensions/NSURL+OCVaultTools.m
@@ -31,6 +31,11 @@
 	NSString *vaultRootPath = OCVault.storageRootURL.path;
 	NSString *path = self.path;
 
+	if (vaultRootPath == nil)
+	{
+		return (NO);
+	}
+
 	if (![vaultRootPath hasSuffix:@"/"])
 	{
 		vaultRootPath = [vaultRootPath stringByAppendingString:@"/"];


### PR DESCRIPTION
## Description
Fixes a crash when using the iOS app on macOS and dropping a file onto the app's window to upload a file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
