### PR TITLE
[feature/last-picked] Add Recent Locations to location picker

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -40,6 +40,7 @@ disabled_rules:
     - nesting
     - comma
     - large_tuple
+    - force_cast
 custom_rules:
   empty_line_after_guard_statement:
     included: ".*\\.swift"

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -342,6 +342,8 @@
 		DC59087D2AA8B82200BFF393 /* BookmarkSetupStepPrepopulateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC59087C2AA8B82200BFF393 /* BookmarkSetupStepPrepopulateViewController.swift */; };
 		DC59087F2AA8D25400BFF393 /* CertificateSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC59087E2AA8D25400BFF393 /* CertificateSummaryView.swift */; };
 		DC5C48A32918FB7400EBC053 /* CollectionSidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5C48A22918FB7400EBC053 /* CollectionSidebarViewController.swift */; };
+		DC5D397F2DDC649700EEDFE7 /* RecentLocationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */; };
+		DC5D39812DDC64A400EEDFE7 /* RecentLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */; };
 		DC5D58FF2A7166A300BFF393 /* ThemeCSS+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D58FE2A7166A300BFF393 /* ThemeCSS+SystemColors.swift */; };
 		DC60F2A629802ABE00905EC8 /* UINavigationItem+NavigationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60F2A529802ABE00905EC8 /* UINavigationItem+NavigationContent.swift */; };
 		DC60F2A829802B0900905EC8 /* NavigationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60F2A729802B0900905EC8 /* NavigationContent.swift */; };
@@ -1335,6 +1337,8 @@
 		DC59087C2AA8B82200BFF393 /* BookmarkSetupStepPrepopulateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSetupStepPrepopulateViewController.swift; sourceTree = "<group>"; };
 		DC59087E2AA8D25400BFF393 /* CertificateSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateSummaryView.swift; sourceTree = "<group>"; };
 		DC5C48A22918FB7400EBC053 /* CollectionSidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarViewController.swift; sourceTree = "<group>"; };
+		DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentLocationStore.swift; sourceTree = "<group>"; };
+		DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentLocation.swift; sourceTree = "<group>"; };
 		DC5D58FE2A7166A300BFF393 /* ThemeCSS+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThemeCSS+SystemColors.swift"; sourceTree = "<group>"; };
 		DC5D9E742496512400BFFE8E /* MessageQueueExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageQueueExample.swift; sourceTree = "<group>"; };
 		DC60F2A529802ABE00905EC8 /* UINavigationItem+NavigationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+NavigationContent.swift"; sourceTree = "<group>"; };
@@ -2536,6 +2540,7 @@
 		DC298CAA29362534009FA87F /* Location Picker */ = {
 			isa = PBXGroup;
 			children = (
+				DC5D397E2DDC649700EEDFE7 /* Recent Location */,
 				DC298CA829362523009FA87F /* ClientLocationPicker.swift */,
 				DC298CAB29362710009FA87F /* ClientLocationPickerViewController.swift */,
 			);
@@ -2649,6 +2654,15 @@
 				DC9219FB2966179600F538EE /* OCShare+Interactions.swift */,
 			);
 			path = "Data Item Interactions";
+			sourceTree = "<group>";
+		};
+		DC5D397E2DDC649700EEDFE7 /* Recent Location */ = {
+			isa = PBXGroup;
+			children = (
+				DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */,
+				DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */,
+			);
+			path = "Recent Location";
 			sourceTree = "<group>";
 		};
 		DC60F2A429802A7500905EC8 /* Navigation Content */ = {
@@ -4824,6 +4838,7 @@
 				DCB6B1FD292CF2DB00D27573 /* NavigationRevocationManager.swift in Sources */,
 				DCB1B8C229C8A6E500BFF393 /* ThemeCSSView.swift in Sources */,
 				DC0A357724C0E43200FB58FC /* ProgressSummarizer.swift in Sources */,
+				DC5D397F2DDC649700EEDFE7 /* RecentLocationStore.swift in Sources */,
 				DCB6B205292D859B00D27573 /* UIViewController+NavigationRevocation.swift in Sources */,
 				392CFEB72705831700631D2B /* LAContext+Extension.swift in Sources */,
 				DCE4E48724C1F9F50051722F /* CreateFolderAction.swift in Sources */,
@@ -4841,6 +4856,7 @@
 				DC99154C28E636A500DA0AB8 /* SegmentView.swift in Sources */,
 				DCD864122811FC5700CA6631 /* GradientView.swift in Sources */,
 				DC99154E28E6371500DA0AB8 /* SegmentViewItem.swift in Sources */,
+				DC5D39812DDC64A400EEDFE7 /* RecentLocation.swift in Sources */,
 				DCFC9ED528002F33005D9144 /* CollectionViewCellConfiguration.swift in Sources */,
 				DC0074112D52685000C1C6F7 /* OCDrive+ManagementActions.swift in Sources */,
 				DCBAEADB29A3674700BFF393 /* OCItemPolicy+UniversalItemListCellContentProvider.swift in Sources */,

--- a/ownCloud.xcodeproj/project.pbxproj
+++ b/ownCloud.xcodeproj/project.pbxproj
@@ -344,6 +344,9 @@
 		DC5C48A32918FB7400EBC053 /* CollectionSidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5C48A22918FB7400EBC053 /* CollectionSidebarViewController.swift */; };
 		DC5D397F2DDC649700EEDFE7 /* RecentLocationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */; };
 		DC5D39812DDC64A400EEDFE7 /* RecentLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */; };
+		DC5D39862DDE6D4E00EEDFE7 /* RecentLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D39852DDE6D4E00EEDFE7 /* RecentLocationCell.swift */; };
+		DC5D398B2DDE743300EEDFE7 /* RecentLocation+Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D398A2DDE743300EEDFE7 /* RecentLocation+Interactions.swift */; };
+		DC5D398D2DE06B2600EEDFE7 /* RecentLocation+UniversalItemListCellContentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D398C2DE06B2600EEDFE7 /* RecentLocation+UniversalItemListCellContentProvider.swift */; };
 		DC5D58FF2A7166A300BFF393 /* ThemeCSS+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D58FE2A7166A300BFF393 /* ThemeCSS+SystemColors.swift */; };
 		DC60F2A629802ABE00905EC8 /* UINavigationItem+NavigationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60F2A529802ABE00905EC8 /* UINavigationItem+NavigationContent.swift */; };
 		DC60F2A829802B0900905EC8 /* NavigationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60F2A729802B0900905EC8 /* NavigationContent.swift */; };
@@ -1339,6 +1342,9 @@
 		DC5C48A22918FB7400EBC053 /* CollectionSidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarViewController.swift; sourceTree = "<group>"; };
 		DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentLocationStore.swift; sourceTree = "<group>"; };
 		DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentLocation.swift; sourceTree = "<group>"; };
+		DC5D39852DDE6D4E00EEDFE7 /* RecentLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentLocationCell.swift; sourceTree = "<group>"; };
+		DC5D398A2DDE743300EEDFE7 /* RecentLocation+Interactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentLocation+Interactions.swift"; sourceTree = "<group>"; };
+		DC5D398C2DE06B2600EEDFE7 /* RecentLocation+UniversalItemListCellContentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecentLocation+UniversalItemListCellContentProvider.swift"; sourceTree = "<group>"; };
 		DC5D58FE2A7166A300BFF393 /* ThemeCSS+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThemeCSS+SystemColors.swift"; sourceTree = "<group>"; };
 		DC5D9E742496512400BFFE8E /* MessageQueueExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageQueueExample.swift; sourceTree = "<group>"; };
 		DC60F2A529802ABE00905EC8 /* UINavigationItem+NavigationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+NavigationContent.swift"; sourceTree = "<group>"; };
@@ -2661,6 +2667,9 @@
 			children = (
 				DC5D39802DDC64A400EEDFE7 /* RecentLocation.swift */,
 				DC5D397D2DDC649700EEDFE7 /* RecentLocationStore.swift */,
+				DC5D39852DDE6D4E00EEDFE7 /* RecentLocationCell.swift */,
+				DC5D398C2DE06B2600EEDFE7 /* RecentLocation+UniversalItemListCellContentProvider.swift */,
+				DC5D398A2DDE743300EEDFE7 /* RecentLocation+Interactions.swift */,
 			);
 			path = "Recent Location";
 			sourceTree = "<group>";
@@ -4739,6 +4748,7 @@
 				DC298CAE2936598B009FA87F /* DriveGridCell.swift in Sources */,
 				DC46F3D5284563BD00038880 /* OCAction+Interactions.swift in Sources */,
 				DC8E99E5297EEB2800594697 /* ClientLocationBarController.swift in Sources */,
+				DC5D39862DDE6D4E00EEDFE7 /* RecentLocationCell.swift in Sources */,
 				DCFC9ECC28002303005D9144 /* CollectionViewSection.swift in Sources */,
 				DC89EA602993AC4F00BFF393 /* NSUserActivity+SaveRestore.swift in Sources */,
 				DC62F567292504060095BB5D /* AccountConnection.swift in Sources */,
@@ -4810,6 +4820,7 @@
 				DC60F2AA29802D5800905EC8 /* NavigationContentItem.swift in Sources */,
 				DC16213E2B8FF06800EB17F8 /* OCSidebarItem+Interactions.swift in Sources */,
 				DC0A356F24C0E42700FB58FC /* StaticTableViewController.swift in Sources */,
+				DC5D398B2DDE743300EEDFE7 /* RecentLocation+Interactions.swift in Sources */,
 				DC62F569292504510095BB5D /* AccountConnectionPool.swift in Sources */,
 				DC0A358F24C0E46000FB58FC /* PointerEffect.swift in Sources */,
 				DC921A022966D5F800F538EE /* OCShare+UniversalItemListCellContentProvider.swift in Sources */,
@@ -4873,6 +4884,7 @@
 				DC298CAC29362710009FA87F /* ClientLocationPickerViewController.swift in Sources */,
 				DC081C89299B8E5800BFF393 /* AppStateActionRevealItem.swift in Sources */,
 				DCB6B1EF292B979600D27573 /* MessageGroup.swift in Sources */,
+				DC5D398D2DE06B2600EEDFE7 /* RecentLocation+UniversalItemListCellContentProvider.swift in Sources */,
 				DC5C48A32918FB7400EBC053 /* CollectionSidebarViewController.swift in Sources */,
 				DC6C0A542923FFF30045FF2A /* AccountControllerSection.swift in Sources */,
 				DCFA56432975734A0092C89F /* BrowserNavigationViewController.swift in Sources */,

--- a/ownCloud/Resources/Localizable.xcstrings
+++ b/ownCloud/Resources/Localizable.xcstrings
@@ -698,6 +698,9 @@
         }
       }
     },
+    "{{freeSpace}} of {{totalSpace}} available" : {
+
+    },
     "{{itemCount}} items with {{totalSize}} total ({{fileCount}} files, {{folderCount}} folders)" : {
       "localizations" : {
         "ar" : {
@@ -5849,6 +5852,7 @@
       }
     },
     "Albums" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -6091,6 +6095,7 @@
       }
     },
     "All Photos" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7895,6 +7900,9 @@
           }
         }
       }
+    },
+    "Are you sure you want to delete this space? This action cannot be undone." : {
+
     },
     "Are you sure you want to unshare these items?" : {
       "localizations" : {
@@ -10648,6 +10656,9 @@
         }
       }
     },
+    "Available space" : {
+
+    },
     "Average" : {
       "localizations" : {
         "ar" : {
@@ -11968,6 +11979,9 @@
         }
       }
     },
+    "Bytes" : {
+
+    },
     "Camera details" : {
       "localizations" : {
         "ar" : {
@@ -12085,6 +12099,9 @@
           }
         }
       }
+    },
+    "Can't edit only manager" : {
+
     },
     "Cancel" : {
       "comment" : "Server List",
@@ -13901,6 +13918,9 @@
         }
       }
     },
+    "Choose an image for the space" : {
+
+    },
     "Choose destination directory…" : {
       "localizations" : {
         "ar" : {
@@ -14354,6 +14374,9 @@
           }
         }
       }
+    },
+    "Close" : {
+
     },
     "Close actions menu" : {
       "localizations" : {
@@ -18595,6 +18618,9 @@
         }
       }
     },
+    "Create image" : {
+
+    },
     "Create link" : {
       "localizations" : {
         "ar" : {
@@ -18948,6 +18974,9 @@
           }
         }
       }
+    },
+    "Create space" : {
+
     },
     "Creating %ld folders…" : {
       "comment" : "Progress summarizer",
@@ -21509,6 +21538,9 @@
         }
       }
     },
+    "Delete space \"{{driveName}}\"?" : {
+
+    },
     "Delete unused local copies" : {
       "localizations" : {
         "ar" : {
@@ -22347,6 +22379,9 @@
         }
       }
     },
+    "Details" : {
+
+    },
     "Diagnostic Overview" : {
       "comment" : "Diagnostic",
       "localizations" : {
@@ -23055,6 +23090,12 @@
           }
         }
       }
+    },
+    "Disable space" : {
+
+    },
+    "Disabled" : {
+
     },
     "Discard changes" : {
       "localizations" : {
@@ -25248,6 +25289,18 @@
         }
       }
     },
+    "Edit description" : {
+
+    },
+    "Edit image" : {
+
+    },
+    "Edit space" : {
+
+    },
+    "Emoji or text" : {
+
+    },
     "Enable" : {
       "localizations" : {
         "ar" : {
@@ -26080,6 +26133,9 @@
           }
         }
       }
+    },
+    "Enter a emoji or text" : {
+
     },
     "Enter a new code with %ld digits" : {
       "localizations" : {
@@ -26926,6 +26982,18 @@
           }
         }
       }
+    },
+    "Error creating space" : {
+
+    },
+    "Error deleting {{driveName}}" : {
+
+    },
+    "Error disabling {{driveName}}" : {
+
+    },
+    "Error enabling {{driveName}}" : {
+
     },
     "Error fetching transactions" : {
       "localizations" : {
@@ -32812,6 +32880,9 @@
         }
       }
     },
+    "GB" : {
+
+    },
     "General" : {
       "localizations" : {
         "ar" : {
@@ -34220,6 +34291,9 @@
         }
       }
     },
+    "Hide disabled spaces" : {
+
+    },
     "Histogram" : {
       "localizations" : {
         "ar" : {
@@ -34588,6 +34662,9 @@
           }
         }
       }
+    },
+    "If only one member is a manager, that member's permissions can't be edited." : {
+
     },
     "If you 'Continue', you will be prompted to allow the '{{app.name}}' app to open the {{authmethodName}} login page where you can enter your credentials." : {
       "localizations" : {
@@ -35999,6 +36076,9 @@
           }
         }
       }
+    },
+    "Image Playground" : {
+
     },
     "Images" : {
       "localizations" : {
@@ -38775,6 +38855,9 @@
         }
       }
     },
+    "KB" : {
+
+    },
     "Keywords" : {
       "localizations" : {
         "ar" : {
@@ -40086,6 +40169,9 @@
         }
       }
     },
+    "Limit space" : {
+
+    },
     "Limited Photo Access" : {
       "comment" : "Limited photo library access",
       "localizations" : {
@@ -40578,6 +40664,7 @@
       }
     },
     "Links" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -42857,6 +42944,9 @@
         }
       }
     },
+    "Markdown" : {
+
+    },
     "Markup" : {
       "localizations" : {
         "ar" : {
@@ -43353,6 +43443,9 @@
         }
       }
     },
+    "MB" : {
+
+    },
     "Media Export" : {
       "localizations" : {
         "ar" : {
@@ -43844,6 +43937,9 @@
           }
         }
       }
+    },
+    "Members" : {
+
     },
     "Messages" : {
       "localizations" : {
@@ -54831,6 +54927,9 @@
         }
       }
     },
+    "PB" : {
+
+    },
     "PDF Documents" : {
       "localizations" : {
         "ar" : {
@@ -56267,6 +56366,9 @@
         }
       }
     },
+    "Pick a photo" : {
+
+    },
     "Pick file or folder" : {
       "localizations" : {
         "ca" : {
@@ -56857,6 +56959,9 @@
           }
         }
       }
+    },
+    "Please enter a quota equal or less than 1 PB." : {
+
     },
     "Please note: Folders can only be pasted into the %@ app and the same account." : {
       "localizations" : {
@@ -58652,6 +58757,9 @@
         }
       }
     },
+    "Preview" : {
+
+    },
     "Previous" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -59990,6 +60098,9 @@
         }
       }
     },
+    "Public Links" : {
+
+    },
     "Purchase" : {
       "localizations" : {
         "ar" : {
@@ -60475,6 +60586,12 @@
         }
       }
     },
+    "Quota" : {
+
+    },
+    "Quota too high" : {
+
+    },
     "Read" : {
       "localizations" : {
         "ar" : {
@@ -60846,6 +60963,9 @@
           }
         }
       }
+    },
+    "Recent locations" : {
+
     },
     "Recents" : {
       "localizations" : {
@@ -73734,6 +73854,9 @@
         }
       }
     },
+    "Show disabled spaces" : {
+
+    },
     "Show folders on top" : {
       "localizations" : {
         "ar" : {
@@ -75756,6 +75879,9 @@
         }
       }
     },
+    "space" : {
+
+    },
     "Space" : {
       "localizations" : {
         "ca" : {
@@ -75867,6 +75993,9 @@
           }
         }
       }
+    },
+    "Space Actions" : {
+
     },
     "Spaces" : {
       "localizations" : {
@@ -76942,6 +77071,9 @@
         }
       }
     },
+    "Subtitle" : {
+
+    },
     "Switch Theme Style" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -77906,6 +78038,9 @@
         }
       }
     },
+    "TB" : {
+
+    },
     "Terms Of Use" : {
       "localizations" : {
         "ar" : {
@@ -78153,6 +78288,9 @@
           }
         }
       }
+    },
+    "Text/Emoji" : {
+
     },
     "Thank you for using %@.\n" : {
       "localizations" : {
@@ -85482,6 +85620,9 @@
           }
         }
       }
+    },
+    "User" : {
+
     },
     "User Interface" : {
       "localizations" : {

--- a/ownCloudAppShared/Client/Collection Views/CollectionViewCellProvider+StandardImplementations.swift
+++ b/ownCloudAppShared/Client/Collection Views/CollectionViewCellProvider+StandardImplementations.swift
@@ -37,6 +37,7 @@ public extension CollectionViewCellProvider {
 		OCItemPolicy.registerUniversalCellProvider()	// Cell providers for .itemPolicy
 		OCIdentity.registerUniversalCellProvider()	// Cell providers for .identity
 		OptionItem.registerUniversalCellProvider()	// Cell providers for .optionItem
+		RecentLocation.registerUniversalCellProvider()	// Cell providers for .recentLocation
 
 		// Other cell providers
 		OCSidebarItem.registerCellProvider()		// Cell provider for .sidebarItem

--- a/ownCloudAppShared/Client/View Controllers/Location Breadcrumbs/OCLocation+Breadcrumbs.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Breadcrumbs/OCLocation+Breadcrumbs.swift
@@ -31,9 +31,13 @@ public extension OCLocation {
 	}
 
 	func displayName(in context: ClientContext?) -> String {
+		return displayName(with: context?.core)
+	}
+
+	func displayName(with core: OCCore?) -> String {
 		switch type {
 			case .drive:
-				if let core = context?.core, let driveID, let drive = core.drive(withIdentifier: driveID, attachedOnly: false), let driveName = drive.name {
+				if let core, let driveID, let drive = core.drive(withIdentifier: driveID, attachedOnly: false), let driveName = drive.name {
 					return driveName
 				}
 				return OCLocalizedString("Space", nil)
@@ -60,9 +64,13 @@ public extension OCLocation {
 	}
 
 	func displayIcon(in context: ClientContext?, forSidebar: Bool = false) -> UIImage? {
+		return displayIcon(with: context?.core, forSidebar: forSidebar)
+	}
+
+	func displayIcon(with core: OCCore?, forSidebar: Bool = false) -> UIImage? {
 		switch type {
 			case .drive:
-				if let core = context?.core, let driveID, let drive = core.drive(withIdentifier: driveID, attachedOnly: false), let specialType = drive.specialType {
+				if let core, let driveID, let drive = core.drive(withIdentifier: driveID, attachedOnly: false), let specialType = drive.specialType {
 					switch specialType {
 						case .personal:
 							return OCSymbol.icon(forSymbolName: forSidebar ? "person" : "person.fill")

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/ClientLocationPicker.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/ClientLocationPicker.swift
@@ -370,6 +370,22 @@ public class ClientLocationPicker : NSObject {
 						return false
 					}
 
+					switch self.startLocation.clientLocationLevel {
+						case .drive:
+							// If picker is limited to a drive, don't show recents from other drives
+							if location.driveID != self.startLocation.driveID {
+								return false
+							}
+
+						case .account:
+							// If picker is limited to an account, don't show recents from other accounts
+							if location.bookmarkUUID != self.startLocation.bookmarkUUID {
+								return false
+							}
+
+						default: break
+					}
+
 					return true
 				}
 			}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/ClientLocationPicker.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/ClientLocationPicker.swift
@@ -73,7 +73,7 @@ public class ClientLocationPicker : NSObject {
 
 	// MARK: - Options
 	public var showFavorites: Bool
-	public var recentLocations: [OCLocation]?
+	public var showRecentLocations: Bool
 
 	public var startLocation: OCLocation
 	public var maximumLevel: LocationLevel
@@ -109,6 +109,7 @@ public class ClientLocationPicker : NSObject {
 	public init(location: OCLocation, maximumLevel: LocationLevel = .folder, showFavorites: Bool = true, showRecents: Bool = true, selectButtonTitle: String?, selectPrompt: String? = nil, headerTitle: String? = nil, headerSubTitle: String? = nil, headerView: UIView? = nil, requiredPermissions: OCItemPermissions? = [.createFile], avoidConflictsWith conflictItems: [OCItem]?, choiceHandler: @escaping ChoiceHandler) {
 		self.startLocation = location
 		self.showFavorites = showFavorites
+		self.showRecentLocations = showRecents
 		self.selectButtonTitle = selectButtonTitle ?? OCLocalizedString("Select folder", nil)
 		self.selectPrompt = selectPrompt
 		self.headerTitle = headerTitle
@@ -254,15 +255,28 @@ public class ClientLocationPicker : NSObject {
 		return sectionDataSource
 	}
 
-	func provideViewController(for location: OCLocation, maximumLevel: LocationLevel, context: ClientContext) -> CollectionViewController? {
-		let sectionDataSource = provideDataSource(for: location, maximumLevel: maximumLevel, context: context)
+	func provideViewController(for location: OCLocation, extraSections: [CollectionViewSection]? = nil, maximumLevel: LocationLevel, context: ClientContext) -> CollectionViewController? {
+		let sectionsDataSource = provideDataSource(for: location, maximumLevel: maximumLevel, context: context)
 		var viewController: CollectionViewController?
 
-		if let sectionDataSource = sectionDataSource {
+		if let sectionsDataSource {
+			var effectiveSectionsDataSource: OCDataSource? = sectionsDataSource
+
+			if let extraSections {
+				effectiveSectionsDataSource = OCDataSourceComposition(sources: [
+					OCDataSourceArray(items: extraSections),
+					sectionsDataSource
+				])
+			}
+
 			viewController = CollectionViewController(context: context, sections: nil, useStackViewRoot: true, hierarchic: true)
-			viewController?.sectionsDataSource = sectionDataSource
+			viewController?.sectionsDataSource = effectiveSectionsDataSource
 		} else {
 			viewController = location.openItem(from: nil, with: context, animated: true, pushViewController: false, completion: nil) as? CollectionViewController
+
+			if let extraSections, let viewController {
+				viewController.insert(sections: extraSections, at: 0)
+			}
 		}
 
 		if let viewController {
@@ -299,6 +313,81 @@ public class ClientLocationPicker : NSObject {
 		return viewController
 	}
 
+	// MARK: - Recent locations
+	lazy var recentLocationsDatasource: OCDataSource? = {
+		var datasources: [OCDataSource] = []
+
+		switch startLocation.clientLocationLevel {
+			case .accounts:
+				for bookmark in OCBookmarkManager.shared.bookmarks {
+					if let accountDatasource = recentLocationStore(for: bookmark.uuid)?.dataSource {
+						datasources.append(accountDatasource)
+					}
+				}
+
+			case .account, .drive, .folder:
+				if let accountDatasource = recentLocationStore(for: startLocation.bookmarkUUID)?.dataSource {
+					datasources.append(accountDatasource)
+				}
+		}
+
+		let datasource = OCDataSourceComposition(sources: datasources, applyCustomizations: { [weak self] compositionSource in
+			// Sort by date (more recent first)
+			compositionSource.sortComparator = { (src1, ref1, src2, ref2) -> ComparisonResult in
+				if let record1 = try? src1.record(forItemRef: ref1),
+				   let record2 = try? src2.record(forItemRef: ref2),
+				   let location1 = record1.item as? RecentLocation,
+				   let location2 = record2.item as? RecentLocation,
+				   let timestamp1 = location1.timestamp,
+				   let timestamp2 = location2.timestamp {
+				   	if timestamp1.timeIntervalSinceReferenceDate > timestamp2.timeIntervalSinceReferenceDate {
+						return .orderedAscending
+					} else if timestamp1.timeIntervalSinceReferenceDate < timestamp2.timeIntervalSinceReferenceDate {
+						return .orderedDescending
+					}
+				}
+				return .orderedSame
+			}
+
+			// Do not include locations that aren't allowed
+			if self?.allowedLocationFilter != nil {
+				compositionSource.filter = { [weak self] source, itemRef in
+					guard let self, let allowedLocationFilter = self.allowedLocationFilter,
+					      let itemRec = try? source.record(forItemRef: itemRef),
+					      let recentLocation = itemRec.item as? RecentLocation,
+					      let location = recentLocation.location else { return false }
+
+					return allowedLocationFilter(location, (location.bookmarkUUID == self.rootContext?.core?.bookmark.uuid) ? self.rootContext : nil)
+				}
+			}
+		})
+
+		return datasource
+	}()
+
+	var recentLocationsStores: [UUID : RecentLocationStore] = [:] // store stores strongly and at the picker level, so they get retained for the lifetime of the picker and deallocated once the picker is dismissed
+	func recentLocationStore(for bookmarkUUID: UUID?) -> RecentLocationStore? {
+		guard let bookmarkUUID else { return nil }
+
+		if let recentLocationStore = recentLocationsStores[bookmarkUUID] {
+			return recentLocationStore
+		}
+
+		if let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID) {
+			let recentLocationStore = RecentLocationStore(for: bookmark)
+			recentLocationsStores[bookmark.uuid] = recentLocationStore
+			return recentLocationStore
+		}
+
+		return nil
+	}
+
+	func addRecent(location: OCLocation, from core: OCCore) {
+		if let bookmarkUUID = location.bookmarkUUID {
+			recentLocationStore(for: bookmarkUUID)?.add(location: location)
+		}
+	}
+
 	// MARK: - Presentation & Choice
 	var rootNavigationController: UINavigationController?
 	var rootViewController: CollectionViewController?
@@ -306,6 +395,7 @@ public class ClientLocationPicker : NSObject {
 
 	public func pickerViewControllerForPresentation(with baseContext: ClientContext? = nil) -> UIViewController? {
 		let navigationController = ThemeNavigationController()
+		var extraSections: [CollectionViewSection]?
 
 		// Set up navigation controller and context
 		rootNavigationController = navigationController
@@ -333,9 +423,26 @@ public class ClientLocationPicker : NSObject {
 			}
 		})
 
+		// Set up recent locations
+		if showRecentLocations, let recentLocationsDatasource {
+			// Add recents section on top
+			let itemSize = NSCollectionLayoutSize(widthDimension: .estimated(64), heightDimension: .estimated(64))
+			let item = NSCollectionLayoutItem(layoutSize: itemSize)
+			let recentsSection = CollectionViewSection(identifier: "recents", dataSource: recentLocationsDatasource, cellStyle: .init(with: .gridCell), cellLayout: .sideways(item: item, groupSize: itemSize, edgeSpacing: NSCollectionLayoutEdgeSpacing(leading: .fixed(10), top: .fixed(0), trailing: .fixed(10), bottom: .fixed(0)), contentInsets: NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0), orthogonalScrollingBehaviour: .continuous), clientContext: baseContext)
+			recentsSection.hideIfEmptyDataSource = recentLocationsDatasource
+
+			recentsSection.boundarySupplementaryItems = [
+				.mediumTitle(OCLocalizedString("Recent locations",nil), pinned: true)
+			]
+
+			extraSections = [
+				recentsSection
+			]
+		}
+
 		// Compose view controller
 		if let rootContext = rootContext {
-			rootViewController = provideViewController(for: startLocation, maximumLevel: maximumLevel, context: rootContext)
+			rootViewController = provideViewController(for: startLocation, extraSections: extraSections, maximumLevel: maximumLevel, context: rootContext)
 			if let rootViewController {
 				navigationController.pushViewController(rootViewController, animated: false)
 
@@ -372,6 +479,7 @@ public class ClientLocationPicker : NSObject {
 								item?.bookmarkUUID = bookmarkUUID
 							}
 							OnMainThread {
+								self.addRecent(location: location, from: core)
 								choiceHandler(item, location, context, cancelled)
 							}
 						})
@@ -381,6 +489,9 @@ public class ClientLocationPicker : NSObject {
 					// Add missing location for item
 					if item.bookmarkUUID == nil, let bookmarkUUID = context?.core?.bookmark.uuid.uuidString {
 						item.bookmarkUUID = bookmarkUUID
+					}
+					if let itemLocation = item.location, let core = context?.core {
+						addRecent(location: itemLocation, from: core)
 					}
 					choiceHandler(item, item.location, context, cancelled)
 					return

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+Interactions.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+Interactions.swift
@@ -1,0 +1,38 @@
+//
+//  RecentLocation+Interactions.swift
+//  ownCloudAppShared
+//
+//  Created by Felix Schwarz on 21.05.25.
+//  Copyright © 2025 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2025, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+
+extension RecentLocation : DataItemSelectionInteraction {
+	func handleSelection(in viewController: UIViewController?, with context: ClientContext?, completion: ((Bool, Bool) -> Void)?) -> Bool {
+		// Determine if this location is presented in the context of a ClientLocationPickerViewController ..
+		var parentViewController = viewController
+
+		while !(parentViewController is ClientLocationPickerViewController) && parentViewController?.parent != nil {
+			parentViewController = parentViewController?.parent
+		}
+
+		// .. if it is: navigate to the location!
+		if let locationPicker = (parentViewController as? ClientLocationPickerViewController)?.locationPicker, let location {
+			locationPicker.navigate(to: location)
+			return true
+		}
+
+		return false
+	}
+}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+UniversalItemListCellContentProvider.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+UniversalItemListCellContentProvider.swift
@@ -1,0 +1,83 @@
+//
+//  RecentLocation+UniversalItemListCellContentProvider.swift
+//  ownCloudAppShared
+//
+//  Created by Felix Schwarz on 23.05.25.
+//  Copyright © 2025 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2025, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+import ownCloudSDK
+
+extension RecentLocation: UniversalItemListCellContentProvider {
+	public func provideContent(for cell: UniversalItemListCell, context: ClientContext?, configuration: CollectionViewCellConfiguration?, updateContent: @escaping UniversalItemListCell.ContentUpdater) {
+		let content = UniversalItemListCell.Content(with: self)
+
+		// Icon
+		content.icon = (location?.isDriveRoot == true) ? .drive : .folder
+
+		// Title
+		if let displayName {
+			content.title = .folder(name: displayName)
+		}
+
+		// Details
+		var detailsLine: [SegmentViewItem] = []
+
+		if let driveName, location?.type != .drive {
+			let driveDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "square.grid.2x2.fill"), title: driveName, style: .plain, titleTextStyle: .footnote)
+			driveDetailItem.lines = [ .primary, .singleLine ]
+			detailsLine.append(driveDetailItem)
+		}
+
+		if let bookmarkUUID = location?.bookmarkUUID, let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID) {
+			let accountDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "server.rack"), title: bookmark.displayName ?? bookmark.shortName, style: .plain, titleTextStyle: .footnote)
+			accountDetailItem.lines = [ .secondary, .singleLine ]
+			detailsLine.append(accountDetailItem)
+		}
+
+		for item in detailsLine {
+			item.insets = .zero
+			item.iconTitleSpacing = 3
+		}
+
+		content.details = detailsLine
+
+		_ = updateContent(content)
+	}
+}
+
+extension RecentLocation {
+	static func registerUniversalCellProvider() {
+		let cellRegistration = UICollectionView.CellRegistration<RecentLocationCell, CollectionViewController.ItemRef> { (cell, indexPath, collectionItemRef) in
+			collectionItemRef.ocCellConfiguration?.configureCell(for: collectionItemRef, with: { itemRecord, item, cellConfiguration in
+				if let recentLocation = OCDataRenderer.default.renderItem(item, asType: .recentLocation, error: nil, withOptions: nil) as? RecentLocation {
+					cell.fill(from: recentLocation, context: cellConfiguration.clientContext, configuration: cellConfiguration)
+				}
+			})
+		}
+
+		CollectionViewCellProvider.register(CollectionViewCellProvider(for: .recentLocation, with: { collectionView, cellConfiguration, itemRecord, itemRef, indexPath in
+			switch cellConfiguration?.style.type {
+				default:
+					let cell = collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemRef)
+
+					if cellConfiguration?.highlight == true {
+						cell.revealHighlight = true
+					}
+
+					return cell
+			}
+		}))
+	}
+}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+UniversalItemListCellContentProvider.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation+UniversalItemListCellContentProvider.swift
@@ -35,13 +35,13 @@ extension RecentLocation: UniversalItemListCellContentProvider {
 		var detailsLine: [SegmentViewItem] = []
 
 		if let driveName, location?.type != .drive {
-			let driveDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "square.grid.2x2.fill"), title: driveName, style: .plain, titleTextStyle: .footnote)
+			let driveDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "square.grid.2x2.fill"), title: driveName, style: .plain, titleTextStyle: .footnote, linebreakMode: .byTruncatingMiddle)
 			driveDetailItem.lines = [ .primary, .singleLine ]
 			detailsLine.append(driveDetailItem)
 		}
 
 		if let bookmarkUUID = location?.bookmarkUUID, let bookmark = OCBookmarkManager.shared.bookmark(for: bookmarkUUID) {
-			let accountDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "server.rack"), title: bookmark.displayName ?? bookmark.shortName, style: .plain, titleTextStyle: .footnote)
+			let accountDetailItem = SegmentViewItem(with: OCSymbol.icon(forSymbolName: "server.rack"), title: bookmark.displayName ?? bookmark.shortName, style: .plain, titleTextStyle: .footnote, linebreakMode: .byTruncatingMiddle)
 			accountDetailItem.lines = [ .secondary, .singleLine ]
 			detailsLine.append(accountDetailItem)
 		}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation.swift
@@ -1,0 +1,60 @@
+//
+//  RecentLocation.swift
+//  ownCloudAppShared
+//
+//  Created by Felix Schwarz on 20.05.25.
+//  Copyright © 2025 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2025, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+import ownCloudSDK
+
+@objc class RecentLocation: NSObject, NSSecureCoding, OCDataItem, OCDataItemVersioning {
+	var location: OCLocation?
+	var timestamp: Date?
+
+	init(location: OCLocation, timestamp: Date = .now) {
+		self.location = location
+		self.timestamp = timestamp
+	}
+
+	// MARK: - NSSecureCoding
+	static var supportsSecureCoding: Bool = true
+
+	func encode(with coder: NSCoder) {
+		coder.encode(location, forKey: "location")
+		coder.encode(timestamp, forKey: "timestamp")
+	}
+
+	required init?(coder: NSCoder) {
+		location = coder.decodeObject(of: OCLocation.self, forKey: "location")
+		timestamp = coder.decodeObject(of: NSDate.self, forKey: "timestamp") as? Date
+	}
+
+	// MARK: - OCDataItem + Versioning
+	var dataItemType: OCDataItemType {
+		return .recentLocation
+	}
+
+	var dataItemReference: OCDataItemReference {
+		return location?.dataItemReference ?? ("\(self)" as NSString)
+	}
+
+	var dataItemVersion: OCDataItemVersion {
+		return "\(location?.dataItemVersion ?? ("-" as NSString))@\(timestamp?.timeIntervalSince1970 ?? 0)" as NSString
+	}
+}
+
+extension OCDataItemType {
+	static let recentLocation: OCDataItemType = OCDataItemType(rawValue: "recentLocation")
+}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocation.swift
@@ -23,9 +23,18 @@ import ownCloudSDK
 	var location: OCLocation?
 	var timestamp: Date?
 
-	init(location: OCLocation, timestamp: Date = .now) {
+	var displayName: String?
+	var driveName: String?
+
+	init(location: OCLocation, timestamp: Date = .now, from core: OCCore) {
 		self.location = location
 		self.timestamp = timestamp
+
+		self.displayName = location.displayName(with: core)
+
+		if let driveID = location.driveID {
+			self.driveName = core.drive(withIdentifier: driveID, attachedOnly: true)?.name
+		}
 	}
 
 	// MARK: - NSSecureCoding
@@ -34,11 +43,15 @@ import ownCloudSDK
 	func encode(with coder: NSCoder) {
 		coder.encode(location, forKey: "location")
 		coder.encode(timestamp, forKey: "timestamp")
+		coder.encode(displayName, forKey: "displayName")
+		coder.encode(driveName, forKey: "driveName")
 	}
 
 	required init?(coder: NSCoder) {
 		location = coder.decodeObject(of: OCLocation.self, forKey: "location")
 		timestamp = coder.decodeObject(of: NSDate.self, forKey: "timestamp") as? Date
+		displayName = coder.decodeObject(of: NSString.self, forKey: "displayName") as? String
+		driveName = coder.decodeObject(of: NSString.self, forKey: "driveName") as? String
 	}
 
 	// MARK: - OCDataItem + Versioning

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
@@ -1,0 +1,48 @@
+//
+//  RecentLocationCell.swift
+//  ownCloudAppShared
+//
+//  Created by Felix Schwarz on 21.05.25.
+//  Copyright © 2025 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2025, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+import ownCloudSDK
+
+class RecentLocationCell: UniversalItemListCell {
+	override func prepareViews() {
+		super.prepareViews()
+		cssSelectors = [.recentLocation]
+	}
+
+	override func updateConfiguration(using state: UICellConfigurationState) {
+		super.updateConfiguration(using: state)
+
+		let collection = Theme.shared.activeCollection
+		var backgroundConfig = backgroundConfiguration?.updated(for: state)
+
+		if state.isHighlighted || state.isSelected || (state.cellDropState == .targeted) {
+			backgroundConfig?.backgroundColor = collection.css.getColor(.fill, state: [.highlighted], for: self)
+		} else {
+			backgroundConfig?.backgroundColor = collection.css.getColor(.fill, for: self)
+		}
+
+		backgroundConfig?.cornerRadius = 8
+
+		backgroundConfiguration = backgroundConfig
+	}
+}
+
+extension ThemeCSSSelector {
+	static let recentLocation = ThemeCSSSelector(rawValue: "recentLocation")
+}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
@@ -25,6 +25,22 @@ class RecentLocationCell: UniversalItemListCell {
 		cssSelectors = [.recentLocation]
 	}
 
+	override func updateLayoutConstraints() {
+		super.updateLayoutConstraints()
+
+		// Limit title label to one line
+		titleLabel.numberOfLines = 1
+
+		// Add constraint to limit width
+		let maxWidthConstraint = self.widthAnchor.constraint(lessThanOrEqualToConstant: 240)
+		maxWidthConstraint.isActive = true // .. activate it ..
+
+		// .. and add it to self.cellConstraints
+		var constraints = cellConstraints ?? []
+		constraints.append(maxWidthConstraint)
+		cellConstraints = constraints
+	}
+
 	override func updateConfiguration(using state: UICellConfigurationState) {
 		super.updateConfiguration(using: state)
 

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationCell.swift
@@ -35,6 +35,9 @@ class RecentLocationCell: UniversalItemListCell {
 		let maxWidthConstraint = self.widthAnchor.constraint(lessThanOrEqualToConstant: 240)
 		maxWidthConstraint.isActive = true // .. activate it ..
 
+		// Clip contents to avoid very long account names spilling out of the cell
+		clipsToBounds = true
+
 		// .. and add it to self.cellConstraints
 		var constraints = cellConstraints ?? []
 		constraints.append(maxWidthConstraint)

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
@@ -1,0 +1,88 @@
+//
+//  RecentLocationStore.swift
+//  ownCloudAppShared
+//
+//  Created by Felix Schwarz on 20.05.25.
+//  Copyright © 2025 ownCloud GmbH. All rights reserved.
+//
+
+/*
+ * Copyright (C) 2025, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+import ownCloudSDK
+
+class RecentLocationStore: NSObject {
+	static let maximumStoredLocations: Int = 10
+
+	var bookmark: OCBookmark
+	var vault: OCVault
+
+	@objc var locations: [RecentLocation] = []
+
+	init(for bookmark: OCBookmark) {
+		self.bookmark = bookmark
+		self.vault = OCVault(bookmark: bookmark)
+
+		super.init()
+
+		self.vault.keyValueStore?.registerClasses(NSSet(array: [NSArray.self, RecentLocation.self]) as! Set<AnyHashable>, forKey: .recentLocations)
+		self.vault.keyValueStore?.addObserver({ store, owner, key, newValue in
+			if let recentLocations = newValue as? [RecentLocation],
+			    let store = owner as? RecentLocationStore {
+				store.locations = recentLocations
+			}
+		}, forKey: .recentLocations, withOwner: self, initial: true)
+	}
+
+	deinit {
+		vault.keyValueStore?.removeObserver(forOwner: self, forKey: .recentLocations)
+	}
+
+	func add(location: OCLocation) {
+		if location.bookmarkUUID == nil {
+			location.bookmarkUUID = bookmark.uuid
+		}
+
+		let recentLocation = RecentLocation(location: location)
+		var newLocations = [
+			recentLocation
+		]
+
+		for location in locations {
+			if location.location?.dataItemReference == recentLocation.location?.dataItemReference {
+				// Skip identical locations, so the same location isn't stored multiple times
+				continue
+			}
+			newLocations.append(location)
+		}
+
+		// Limit number of stored entries
+		while newLocations.count > RecentLocationStore.maximumStoredLocations {
+			newLocations.removeLast()
+		}
+
+		// Store updated locations
+		locations = newLocations
+		vault.keyValueStore?.storeObject(locations as NSArray, forKey: .recentLocations)
+	}
+
+	private var _dataSource: OCDataSource?
+	var dataSource: OCDataSource? {
+		if _dataSource == nil {
+			_dataSource = OCDataSourceKVO(object: self, keyPath: "locations")
+		}
+		return _dataSource
+	}
+}
+
+public extension OCKeyValueStoreKey {
+	static let recentLocations = OCKeyValueStoreKey(rawValue: "recentLocations")
+}

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
@@ -33,7 +33,7 @@ class RecentLocationStore: NSObject {
 
 		super.init()
 
-		self.vault.keyValueStore?.registerClasses(NSSet(array: [NSArray.self, RecentLocation.self]) as! Set<AnyHashable>, forKey: .recentLocations)
+		self.vault.keyValueStore?.registerClasses(NSSet(array: [NSArray.self, RecentLocation.self]) as! Set<AnyHashable>, forKey: .recentLocations) // force cast can't be avoided here, unfortunately
 		self.vault.keyValueStore?.addObserver({ store, owner, key, newValue in
 			if let recentLocations = newValue as? [RecentLocation],
 			    let store = owner as? RecentLocationStore {

--- a/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
+++ b/ownCloudAppShared/Client/View Controllers/Location Picker/Recent Location/RecentLocationStore.swift
@@ -46,12 +46,12 @@ class RecentLocationStore: NSObject {
 		vault.keyValueStore?.removeObserver(forOwner: self, forKey: .recentLocations)
 	}
 
-	func add(location: OCLocation) {
+	func add(location: OCLocation, from core: OCCore) {
 		if location.bookmarkUUID == nil {
 			location.bookmarkUUID = bookmark.uuid
 		}
 
-		let recentLocation = RecentLocation(location: location)
+		let recentLocation = RecentLocation(location: location, from: core)
 		var newLocations = [
 			recentLocation
 		]

--- a/ownCloudAppShared/User Interface/SegmentView/SegmentViewItemView.swift
+++ b/ownCloudAppShared/User Interface/SegmentView/SegmentViewItemView.swift
@@ -96,7 +96,7 @@ public class SegmentViewItemView: ThemeView, ThemeCSSAutoSelector {
 			titleView?.setContentHuggingPriority(titleViewHugging, for: .horizontal)
 			titleView?.setContentHuggingPriority(.required, for: .vertical)
 			titleView?.setContentCompressionResistancePriority(.required, for: .vertical)
-			titleView?.setContentCompressionResistancePriority(.required, for: .horizontal)
+			titleView?.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
 
 			views.append(titleView!)
 		}

--- a/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
+++ b/ownCloudAppShared/User Interface/Theme/ThemeCollection.swift
@@ -519,6 +519,9 @@ public class ThemeCollection : NSObject {
 			ThemeCSSRecord(selectors: [.insetGrouped, .collection, .sectionHeader], 	property: .fill,   value: groupedCollectionBackgroundColor),
 			ThemeCSSRecord(selectors: [.insetGrouped, .collection, .cell, .action], 	property: .fill,   value: cellStateSet.regular.backgroundColor),
 
+			ThemeCSSRecord(selectors: [.collection, .cell, .recentLocation],	property: .fill,   value: groupedCollectionBackgroundColor),
+			ThemeCSSRecord(selectors: [.collection, .cell, .recentLocation],	property: .fill,   value: groupedCollectionBackgroundColor),
+
 			// - Table View
 			ThemeCSSRecord(selectors: [.table],     	    	   	property: .fill,   value: cellStateSet.regular.backgroundColor),
 			ThemeCSSRecord(selectors: [.grouped, .table],  	    	   	property: .fill,   value: groupedCollectionBackgroundColor),


### PR DESCRIPTION
## Description
Adds a row of recently picked locations to the Location Picker for quick access.

## Screenshots (if appropriate):
Within same account | Across accounts (media uploads) | Share Extension
---|----|---
<img width="515" alt="Bildschirmfoto 2025-05-23 um 12 03 56" src="https://github.com/user-attachments/assets/33c771a3-7835-4f6b-9271-abea8d13f4bb" /> | <img width="559" alt="Bildschirmfoto 2025-05-23 um 12 07 03" src="https://github.com/user-attachments/assets/557fc9c5-314b-404f-8e3c-7fead4a34b7e" /> | <img width="559" alt="Bildschirmfoto 2025-05-30 um 10 07 49" src="https://github.com/user-attachments/assets/9bb66a6d-c7ba-425a-be4d-a33f296e42fb" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## QA

Test plan: https://github.com/owncloud/QA/blob/master/Mobile/iOS/Executions/Version%2012.6/Recent%20locations%20picker.md

Reports:

- [X] (1) Move operation shows entries from other spaces https://github.com/owncloud/ios-app/pull/1467#issuecomment-2955428253 [FIXED]
- [X] (2) Removed folder is retained in the list https://github.com/owncloud/ios-app/pull/1467#issuecomment-2955460826 [WONT FIX]
- [x] (3) No padding in cell https://github.com/owncloud/ios-app/pull/1467#issuecomment-2955692861 [FIXED]
- [x] (4) Cell width expands a lot if display name is longer than usual https://github.com/owncloud/ios-app/pull/1467#issuecomment-2955704542 [FIXED]
- [X] (5) Icons in cells https://github.com/owncloud/ios-app/pull/1467#issuecomment-2955734100 [WONT FIX]
