### PR TITLE
[fix/confidential-office-pan-zoom] Fix pan/zoom issue when using confidential overlay options

### DIFF
--- a/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
+++ b/ownCloud/Client/Viewer/QuickLook/PreviewViewController.swift
@@ -7,18 +7,19 @@
 //
 
 /*
-* Copyright (C) 2018, ownCloud GmbH.
-*
-* This code is covered by the GNU Public License Version 3.
-*
-* For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
-* You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
-*
-*/
+ * Copyright (C) 2018, ownCloud GmbH.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
 
 import UIKit
 import ownCloudSDK
 import QuickLook
+import ownCloudApp
 import ownCloudAppShared
 
 class GestureView : UIView {
@@ -147,9 +148,14 @@ extension PreviewViewController: UIGestureRecognizerDelegate {
 
 // MARK: - Display Extension.
 extension PreviewViewController: DisplayExtension {
-	private static let supportedFormatsRegex = try? NSRegularExpression(pattern: "\\A((text/)|(image/svg)|(model/(vnd|usd))|(application/(rtf|x-rtf|doc))|(application/x-iwork*)|(application/(vnd.|ms))(?!(oasis|android))(ms|openxmlformats)?)", options: .caseInsensitive)
+	static let supportedFormatsRegex = try? NSRegularExpression(pattern: "\\A((text/)|(image/svg)|(model/(vnd|usd))|(application/(rtf|x-rtf|doc))|(application/x-iwork*)|(application/(vnd.|ms))(?!(oasis|android))(ms|openxmlformats)?)", options: .caseInsensitive)
 
 	static var customMatcher: OCExtensionCustomContextMatcher? = { (context, defaultPriority) in
+		guard !ConfidentialManager.shared.markConfidentialViews else {
+			// If watermark/confidential overlays are used, QLPreviewController no longer reacts to scroll and zoom events,
+			// so use WebKit's support for QuickLook formats instead in that case.
+			return .noMatch
+		}
 
 		guard let regex = supportedFormatsRegex else { return .noMatch }
 

--- a/ownCloud/Client/Viewer/WebView/WebViewDisplayViewController.swift
+++ b/ownCloud/Client/Viewer/WebView/WebViewDisplayViewController.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import ownCloudSDK
+import ownCloudApp
 import ownCloudAppShared
 import WebKit
 
@@ -138,6 +139,15 @@ extension WebViewDisplayViewController: DisplayExtension {
 
 			if matches > 0 {
 				return .locationMatch
+			}
+
+			// If watermark/confidential overlays are used, QLPreviewController no longer reacts to scroll and zoom events,
+			// so use WebKit's support for QuickLook formats instead in that case.
+			if ConfidentialManager.shared.confidentialSettingsEnabled {
+				if let quickLookRegex = PreviewViewController.supportedFormatsRegex,
+				   quickLookRegex.numberOfMatches(in: mimeType, options: .reportCompletion, range: NSRange(location: 0, length: mimeType.count)) > 0 {
+					return .locationMatch
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
PreviewViewController/WebViewDisplayViewController: if watermark/confidential overlays are used, QLPreviewController no longer reacts to scroll and zoom events, so use WebKit's support for QuickLook formats instead in those cases.

Testing note: test with multi-page/multi-slide documents to reproduce the issue.

## Related Issue
https://github.com/owncloud/enterprise/issues/7224

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
