### PR TITLE
[fix/space-creation-multitaps] Prevent multiple taps on Create/Save Space button

### DIFF
--- a/ownCloudAppShared/Client/Spaces/SpaceManagementViewController.swift
+++ b/ownCloudAppShared/Client/Spaces/SpaceManagementViewController.swift
@@ -318,6 +318,9 @@ public class SpaceManagementViewController: CollectionViewController {
 			return
 		}
 
+		// Disable select button to prevent triggering creation multiple times (fixes KOKO-1383)
+		bottomButtonBar?.selectButton.isEnabled = false
+
 		switch mode {
 			case .create:
 				core.createDrive(withName: name, description: subtitle, quota: NSNumber(value: quotaTotalBytes ?? 0), template: .default) { [weak self] error, drive in


### PR DESCRIPTION
## Description
- SpaceManagementViewController: prevent multiple taps on "Create" or "Save" that could lead to triggering the creation / editing action multiple times

## Related Issue
KOKO-1383

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
