### PR TITLE
[fix/generate-sbom-gitignore] Fix SBOM generation commit step error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ Pods/
 # End of https://www.gitignore.io/api/xcode,swift,macos,objective-c
 /fastlane/fastlane/Appfile
 /Gemfile.lock
+/enterprise/register/Gemfile.lock


### PR DESCRIPTION
## Description
- generate-sbom.yml: fix error in commit step due to enterprise/register/Gemfile.lock being created, by adding it to the gitignore file

Problem can be seen in action [here](https://github.com/owncloud/ios-app/actions/runs/16468469281/job/46551555548)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
