### PR TITLE
[fix/ack-darkmode] Fix text visibility of acknowledgments in dark mode

### DIFF
--- a/ownCloud/Settings/AcknowledgementsTableViewController.swift
+++ b/ownCloud/Settings/AcknowledgementsTableViewController.swift
@@ -39,7 +39,8 @@ class AcknowledgementsTableViewController: StaticTableViewController {
 								let textViewController = TextViewController()
 								let licenseText : NSMutableAttributedString = NSMutableAttributedString()
 								let textAttributes : [NSAttributedString.Key : Any] = [
-									.font : UIFont.systemFont(ofSize: UIFont.systemFontSize)
+									.font : UIFont.systemFont(ofSize: UIFont.systemFontSize),
+									.foregroundColor : UIColor.label
 								]
 
 								textViewController.title = "\(licenseTitle) \(OCLocalizedString("license", nil))"


### PR DESCRIPTION
## Description
Ensures visibility of acknowledgment texts in dark mode.

## Related Issue
#1483

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
