### PR TITLE
[fix/close-preview-on-delete] "Close" viewer when viewed item is being deleted

### DIFF
--- a/ownCloud/Resources/Localizable.xcstrings
+++ b/ownCloud/Resources/Localizable.xcstrings
@@ -41571,6 +41571,9 @@
         }
       }
     },
+    "Item removed" : {
+
+    },
     "Item with same name already exists" : {
       "localizations" : {
         "ar" : {
@@ -85842,6 +85845,9 @@
           }
         }
       }
+    },
+    "This item no longer exists on the server." : {
+
     },
     "This permission is needed to upload photos and videos from your photo library." : {
       "localizations" : {


### PR DESCRIPTION
## Description
If an item is being deleted while being viewed, the viewer shows a "Item removed" message and - if it is the only file being viewed and the viewer is not the only item in the browser history - "closes" the viewer by removing it from history.

## Related Issue
#1484

## Screenshots (if appropriate):
"Item removed" view | &nbsp;
--|--
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-08-30 at 21 41 19" src="https://github.com/user-attachments/assets/20cc428d-a913-42c3-b330-206a81a715c8" /> | &nbsp;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
