### PR TITLE
[chore/build-and-analyze] Update build-and-analyze.yml

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@6.0.2
         with:
           submodules: true
       - name: mxcl/Xcodebuild

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           submodules: true
       - name: mxcl/Xcodebuild
-        uses: mxcl/xcodebuild@v3.6.0
+        uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5 # v3.6.0
         with:
           scheme: ownCloud
           action: build


### PR DESCRIPTION
## Description
Updates the used version of the `action/checkout` and `mxcl/xcodebuild` actions and pins them to a commit rather than a tag.