### PR TITLE
ci: open PR for translation updates instead of pushing directly

### DIFF
--- a/.github/workflows/pull-transifex.yml
+++ b/.github/workflows/pull-transifex.yml
@@ -5,18 +5,22 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions: {}
+
 jobs:
   pull-translations:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
           ref: "master"
+          persist-credentials: false
 
       - name: l10n-pull
-        uses: transifex/cli-action@v2
+        uses: transifex/cli-action@584fd205cbe598773b5a81ce711fa44842678189 # v2
         with:
           token: ${{ secrets.TX_TOKEN }}
           args: pull --force --skip --all
@@ -46,8 +50,21 @@ jobs:
       - name: Run ocstringstool
         run: /tmp/ocstringstool normalize "ownCloud/Resources" "ownCloud Action Extension" "ownCloud File Provider" "ownCloud Share Extension" "ownCloudAppFramework/Resources"
 
-      - uses: GuillaumeFalourd/git-commit-push@v1.3
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         with:
-          email: devops@owncloud.com
-          name: ownClouders
-          commit_message: "[tx] updated translations from transifex"
+          app-id: ${{ secrets.TRANSLATION_APP_ID }}
+          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
+
+      - name: Create or update translations PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/translations-update
+          base: master
+          commit-message: "chore: update translations from transifex"
+          title: "chore: update translations from transifex"
+          body: "Automated translation update from Transifex. This pull request is updated on each sync run — merging it will close it and a fresh one will be opened on the next change."
+          delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
## Summary
- Replaces direct commit + push (via `GuillaumeFalourd/git-commit-push` + SSH deploy key) with `peter-evans/create-pull-request` via a GitHub App token
- All existing post-processing steps retained (JSON beautification with `jq`, Swift `ocstringstool` normalization)
- Translations are now proposed via a `chore/translations-update` PR against `master` — same approach as used in `owncloud/client` and `owncloud/android`
- Removed `DEPLOYMENT_SSH_KEY` dependency; downgraded `contents` permission to `read`

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify a PR is opened against `master`
- [ ] Verify JSON formatting and `ocstringstool` normalization steps still run correctly
- [ ] Confirm `TX_TOKEN`, `TRANSLATION_APP_ID` and `TRANSLATION_APP_PRIVATE_KEY` secrets are available in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)