### PR TITLE
ci: open PR for changelog updates instead of pushing directly

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -5,21 +5,39 @@ on:
     branches:
     - master
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Generate Calens Changelog
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
           ref: "master"
+          persist-credentials: false
+
       - uses: actionhippie/calens@v1
         with:
           target: CHANGELOG.md
-      - uses: GuillaumeFalourd/git-commit-push@v1.3
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         with:
-          email: devops@owncloud.com
-          name: ownClouders
-          commit_message: "Calens changelog updated"
-          files: CHANGELOG.md
+          app-id: ${{ secrets.TRANSLATION_APP_ID }}
+          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
+
+      - name: Create or update changelog PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/changelog-update
+          base: master
+          commit-message: "chore: update changelog"
+          title: "chore: update changelog"
+          body: "Automated changelog update via Calens. This pull request is updated on each push to `master` — merging it will close it and a fresh one will be opened on the next change."
+          delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
## Summary
- Replaces direct commit + push (via `GuillaumeFalourd/git-commit-push` + SSH deploy key) with `peter-evans/create-pull-request` via a GitHub App token
- Changelog is now proposed via a `chore/changelog-update` PR against `master` instead of being committed directly — same approach as owncloud/ios-app#1532
- Removed `DEPLOYMENT_SSH_KEY` dependency; downgraded `contents` permission to `read`

## Test plan
- [ ] Push a commit to `master` and verify a `chore/changelog-update` PR is opened
- [ ] Confirm `TRANSLATION_APP_ID` and `TRANSLATION_APP_PRIVATE_KEY` secrets are available in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)