### PR TITLE
chore: pin calens action to specific commit hash

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -19,7 +19,7 @@ jobs:
           ref: "master"
           persist-credentials: false
 
-      - uses: actionhippie/calens@v1
+      - uses: actionhippie/calens@244f3e5c328b842a740113859b87bbebf697f63b # v1.13.1
         with:
           target: CHANGELOG.md
 


### PR DESCRIPTION
## Summary

- Pins `actionhippie/calens` from `@v1` to commit hash `244f3e5c328b842a740113859b87bbebf697f63b` (v1.13.1) for supply chain security

🤖 Generated with [Claude Code](https://claude.com/claude-code)