### PR TITLE
ci: use reusable calens workflow from reusable-workflows

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -1,43 +1,15 @@
 name: Calens Changelog
-# This workflow is triggered on pushes to the repository.
+
 on:
   push:
     branches:
-    - master
+      - master
 
 permissions: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Generate Calens Changelog
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: "master"
-          persist-credentials: false
-
-      - uses: actionhippie/calens@244f3e5c328b842a740113859b87bbebf697f63b # v1.13.1
-        with:
-          target: CHANGELOG.md
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
-        with:
-          app-id: ${{ secrets.TRANSLATION_APP_ID }}
-          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
-
-      - name: Create or update changelog PR
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          branch: chore/changelog-update
-          base: master
-          commit-message: "chore: update changelog"
-          title: "chore: update changelog"
-          body: "Automated changelog update via Calens. This pull request is updated on each push to `master` — merging it will close it and a fresh one will be opened on the next change."
-          delete-branch: true
-          sign-commits: true
+  changelog:
+    uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
+    secrets:
+      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
+      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Replaces the inline calens job with a call to `owncloud/reusable-workflows/.github/workflows/calens.yml@main`
- Trigger (push to master) and behaviour are unchanged
- Also gains the "Show diff" and "Output" diagnostic steps from the reusable workflow

## Test plan

- [ ] Merge owncloud/reusable-workflows#<reusable-pr> first
- [ ] Push to master — confirm a `chore/changelog-update` PR is created/updated as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)