### PR TITLE
ci: fix calens workflow permissions for reusable workflow call

### DIFF
--- a/.github/workflows/calens.yml
+++ b/.github/workflows/calens.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   changelog:


### PR DESCRIPTION
## Summary

- `permissions: {}` forbids all permissions, but the reusable calens workflow requests `contents: read` — causing `startup_failure` on every push to master
- Fix: grant `contents: read` at the caller level

Same fix as owncloud/android#4826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)