### PR TITLE
[chore/fix-config-doc-script] Fix GenerateDocs script error

### DIFF
--- a/tools/GenerateDocs/generate_docs.sh
+++ b/tools/GenerateDocs/generate_docs.sh
@@ -4,7 +4,7 @@
 xcodebuild test \
 -project ../../ownCloud.xcodeproj \
 -scheme ownCloud \
--destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
+-destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
 -only-testing ownCloudTests/MetadataDocumentationTests/testUpdateConfigurationJSONFromMetadata
 
 # Make temporary copy


### PR DESCRIPTION
## Description
Use newer device in `tools/GenerateDocs/generate_docs.sh` to fix an Xcode error running the document generator.