### PR TITLE
ci: rename SBOM GitHub App secrets to SBOM_APP_ID/KEY

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -55,8 +55,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         with:
-          app-id: ${{ secrets.TRANSLATION_APP_ID }}
-          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SBOM_APP_ID }}
+          private-key: ${{ secrets.SBOM_APP_PRIVATE_KEY }}
       - name: Create or update SBOM PR
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:


### PR DESCRIPTION
Standardize SBOM workflow to use \`SBOM_APP_ID\` / \`SBOM_APP_PRIVATE_KEY\` instead of the overloaded \`TRANSLATION_APP_*\` secrets.

Org-level secrets are already provisioned.