### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,9 @@
-## Submitting issues
+# Contributing
 
-If you have questions about how to use ownCloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
+Thank you for your interest in contributing to this project!
 
-### Guidelines
-* [Report the issue](https://github.com/owncloud/ios-app/issues/new) using our [template][template], it includes all the informations we need to track down the issue.
-* This repository is *only* for issues within the ownCloud iOS app code. Issues in other components should be reported in their own repositores: 
-  - [ownCloud core](https://github.com/owncloud/core/issues)
-  - [Android client](https://github.com/owncloud/android/issues)
-  - [Desktop client](https://github.com/owncloud/client/issues)
-  - [ownCloud apps](https://github.com/owncloud/apps/issues) (e.g. Calendar, Contacts...)
-* Search the existing issues first, it's likely that your issue was already reported.
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
 
-If your issue appears to be a bug, and hasn't been reported, open a new issue.
-
-Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
-
-[template]: https://github.com/owncloud/ios-app/blob/master/.github/issue_template.md
-[mailinglist]: https://mailman.owncloud.org/mailman/listinfo/user
-[forum]: https://central.owncloud.org/
-[irc]: http://webchat.freenode.net/?channels=owncloud&uio=d4
-
-## Contributing to Source Code
-
-Thanks for wanting to contribute source code to ownCloud. That's great!
-
-Before we're able to merge your code into the ownCloud app for iOS, you need to sign our [Contributor Agreement][agreement].
-
-### Guidelines
-* Contribute your code in the branch 'master'. It will give us a better chance to test your code before merging it with stable code.
-* For your first contribution, start a pull request on master and send us the signed [Contributor Agreement][agreement].
-* Keep on using pull requests for your next contributions although you own write permissions.
-
-[agreement]: http://owncloud.org/about/contributor-agreement/
-
-## Translations
-Please submit translations via [Transifex][transifex].
-
-[transifex]: https://www.transifex.com/projects/p/owncloud/
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,116 @@
-# [ownCloud](https://owncloud.org) iOS App
+# ownCloud iOS App
 
-## 📲 Download
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-Our iOS app is free for downloading available on the AppStore
+[![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
-<a href="https://apps.apple.com/app/id1359583808?itsct=apps_box_badge&amp;itscg=30200" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1561593600" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
+The official ownCloud iOS application, built entirely in Swift for iOS 16+. It provides seamless file sync and share functionality with native iPadOS support, multi-account management, drag-and-drop operations, certificate management, password manager integration, and deep integration with the iOS Files app for cross-app collaboration.
 
-####  🌎 https://ownCloud.com
+## Getting Started
 
-| Account List                                                 | File List                                                    | File Actions                                                 | Preview Files                                                | Quick Access                                                 | Settings                                                     |
-| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| <img src="doc/images/en-US/iPhone 11 Pro Max-11_ios_accounts_list_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> | <img src="doc/images/en-US/iPhone 11 Pro Max-20_ios_files_list_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> | <img src="doc/images/en-US/iPhone 11 Pro Max-21_ios_files_actions_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> | <img src="doc/images/en-US/iPhone 11 Pro Max-22_ios_files_preview_pdf_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> | <img src="doc/images/en-US/iPhone 11 Pro Max-40_ios_quick_access_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> | <img src="doc/images/en-US/iPhone 11 Pro Max-60_ios_settings_demo.png" alt="Simulator Screen Shot - iPhone 11 Pro"> |
+Follow the steps below to build the iOS app from source.
 
-## 😍 Features
+### Prerequisites
 
-* 🦋 Using the current iOS frameworks
-* ⭐️ Exclusively built for iOS
-* 🛠 Written in Swift
-* 📂 Seamless integration with iOS files for improved collaboration
-* 🕹 Multi-select with drag and drop features for efficient file management
-* 👑 Using iPadOS features for pro users
-* ✅ Certificate management and password manager integration for boosting security
-* 🏳️‍🌈 Multiple UI themes with dark and light colors
-* 🚢 Free on the AppStore
-* 🇪🇺 Localised in many languages
-* 📱iOS 11+
-* 🧩 License: [GPLv3](https://github.com/owncloud/ios-app/LICENSE)
+- Xcode (latest stable)
+- iOS 16+ deployment target
+- CocoaPods or Swift Package Manager
 
-## 🛠 Build our App
+### Build
 
-To build our App, please read our [SETUP.md](https://github.com/owncloud/ios-app/blob/master/SETUP.md)
+For detailed build instructions, see [SETUP.md](SETUP.md).
 
-```
-$ read SETUP.md
+```bash
+# Clone with submodules (includes ios-sdk)
+git clone --recursive https://github.com/owncloud/ios-app.git
 ```
 
-## 📖 Documentation & Help
+## Documentation
 
-The documentation for the app can be viewed here: [iOS Documentation](https://doc.owncloud.com/ios-app/)
+- [iOS App Documentation](https://doc.owncloud.com/ios-app/)
+- [Build Setup Guide](SETUP.md)
+- [Docs & Guides](https://owncloud.com/docs-guides/)
+- [Translations on Transifex](https://www.transifex.com/owncloud/)
 
-Support and help can be found here: [Docs & Guides](https://owncloud.com/docs-guides/)
+## Part of the ownCloud Mobile Ecosystem
 
-## 🇪🇺 Translate
+This is the native iOS client for [ownCloud](https://owncloud.com). It connects to both ownCloud Infinite Scale (oCIS) and ownCloud Server 10 instances.
 
-The App is translated in many languages. If your language is missing or if you want to improve a string, you are welcome!
-This can be done in [Transifex](https://www.transifex.com/signup/?join_project=owncloud).
+Available as a free download on the [App Store](https://apps.apple.com/app/id1359583808).
 
+## Community & Support
 
-## 💡 Found a bug or have some ideas for improvement?
+**[Star](https://github.com/owncloud/ios-app)** this repo and **Watch** for release notifications!
 
-- 💬 Open a new issue on [Github](https://github.com/owncloud/ios-app/issues/new)
-- 🐥 Don't forget to follow us on [Twitter](https://twitter.com/owncloud) 
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-## 📋 Start Contributing
+## Contributing
 
-Make sure you read [SETUP.md](https://github.com/owncloud/ios-app/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
-Easy starting points are also reviewing [pull requests](https://github.com/owncloud/ios-app/pulls) and working on [good first issue](https://github.com/owncloud/ios-app/labels/good%20first%20issue).
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-## ☁️ ownCloud Server
+### Workflow
 
-[Learn](https://owncloud.org/news/how-to-set-up-an-owncloud-in-3-minutes/), how you can easily setup your own ownCloud server in 3 minutes or test our ownCloud iOS app with our demo server:
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
 
-- [Download](https://apps.apple.com/app/id1359583808) our iOS App
-- Add account 
+## Translations
 
-### Demo credentials
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud-ios/>**
 
-| Server URL | demo.owncloud.com |
-| ---------- | ----------------- |
-| User       | demo              |
-| Password   | demo              |
+Please submit translations via Transifex -- do not open pull requests for translation changes.
 
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [GPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **Complete relicensing**: GPL-3.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,49 +1,10 @@
-## Support for ownCloud iOS App 
+# Support
 
-We use GitHub for tracking bugs and feature requests. 
+For support with this project, please use the following channels:
 
-### Community Forums
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
 
-* [ownCloud Central](https://central.owncloud.org/): ownClouds main help desk. Get in touch with our community and devs and work on solutions together.
-
-### Social Media
-
-Follow us, stay up-to-date and get in touch with us.
-
-* [Facebook](https://www.facebook.com/ownClouders/)
-* [Twitter](https://twitter.com/owncloud)
-* [Google+](https://plus.google.com/+OwncloudOfficial)
-* [YouTube](https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw)
-
-### ownCloud Documentation
-
-Install instructions, user guides and everything you need about ownCloud.
-
-* [Documentationl](https://doc.owncloud.com/)
-
-### ownCloud FAQ
-
-* [Read FAQ](https://owncloud.org/faq/): All recurring questions in one place.
-
-### Security
-
-* [Take me there](https://owncloud.org/security/): ownCloud is all about security. Read here everything about it.
-
-
-### Stack Overflow
-
-The ownCloud Community is active on Stack Overflow, you can post your questions there: 
-
-* [ownCloud on Stack Overflow](http://stackoverflow.com/questions/tagged/owncloud)
-
-  * Here are some tips for [about how to ask good questions](http://stackoverflow.com/help/how-to-ask).
-  * Don't forget to check to see [what's on topic](http://stackoverflow.com/help/on-topic).
-
-
-### General ownCloud help
-
-* [Help](https://owncloud.org/help/)
-
-### Mail Support
-
-* Support mail: apps@owncloud.com.
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,68 @@
+# agents.md -- ownCloud iOS App
+
+## Repository Overview
+
+The official ownCloud iOS client, written in Swift. Licensed under GPL-3.0, targeting iOS 16+. Uses the ios-sdk (included as a submodule) for all server communication.
+
+## Architecture & Key Paths
+
+- `ownCloud/` -- Main app target
+- `ownCloudAppFramework/` -- Shared framework code
+- `ownCloudAppShared/` -- Shared utilities across extensions
+- `ownCloud.xcodeproj/` -- Xcode project
+- `ownCloud Action Extension/` -- iOS Action Extension
+- `ownCloud File Provider/` -- iOS Files integration
+- `ownCloud Share Extension/` -- Share Sheet extension
+- `ownCloud Intents/` -- Siri/Shortcuts intents
+- `ios-sdk/` -- Git submodule: ownCloud iOS SDK
+- `fastlane/` -- Fastlane deployment configuration
+- `doc/` -- Screenshots and documentation images
+- `SETUP.md` -- Build instructions
+- `CONTRIBUTING.md` -- Contribution guidelines
+- `SUPPORT.md` -- Support resources
+
+## Development Conventions
+
+- Swift codebase targeting iOS 16+
+- Xcode as the primary build system
+- Fastlane for CI/CD and App Store deployment
+- Translations via Transifex
+
+## Build & Test Commands
+
+```bash
+# Build instructions are in SETUP.md
+# Clone with submodules:
+git clone --recursive https://github.com/owncloud/ios-app.git
+# Open ownCloud.xcodeproj in Xcode and build
+```
+
+## Important Constraints
+
+- Licensed under GPL-3.0 (copyleft). Apache 2.0 migration requires resolving copyleft dependencies.
+- The ios-sdk submodule is also GPL-3.0.
+- All contributions require a DCO sign-off.
+- The LICENSE file in the repository root is the authoritative license source.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+This is a native iOS app built with Swift and UIKit. The app uses a modular architecture with separate extensions for Files, Share Sheet, and Intents. The ios-sdk submodule handles all server API communication. Any changes should be made using Xcode-compatible project settings.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>