### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic"

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -11,7 +11,7 @@ It should only be used with dedicated test servers, test data - and test devices
 - spaces do not yet show a member count or provide access to a list of members
 - subscription of spaces can't be turned on/off yet
 - handling of detached drives with user data in them (see OCVault.detachedDrives)
-- [x] support for OC10 sharing is incomplete: federated shares support missing
+- [x] support for ownCloud Classic sharing is incomplete: federated shares support missing
 - [x] spaces support for Shortcuts
 
 Missing:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This can be done in [Transifex](https://www.transifex.com/signup/?join_project=o
 Make sure you read [SETUP.md](https://github.com/owncloud/ios-app/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
 Easy starting points are also reviewing [pull requests](https://github.com/owncloud/ios-app/pulls) and working on [good first issue](https://github.com/owncloud/ios-app/labels/good%20first%20issue).
 
-## ☁️ ownCloud Server
+## ☁️ ownCloud Classic
 
 [Learn](https://owncloud.org/news/how-to-set-up-an-owncloud-in-3-minutes/), how you can easily setup your own ownCloud server in 3 minutes or test our ownCloud iOS app with our demo server:
 

--- a/ownCloud/Bookmarks/Account Setup and Authentication.md
+++ b/ownCloud/Bookmarks/Account Setup and Authentication.md
@@ -175,7 +175,7 @@ OpenID Configuration     | `GET`              | `$serverURL/.well-known/openid-c
 
 ##### WebDAV endpoint
 
-For historic reasons (ownCloud Classic 10), the availability of Basic Auth and OAuth2 is determined by the response to an unauthenticated `PROPFIND` request to the WebDAV endpoint. 
+For historic reasons (ownCloud Classic), the availability of Basic Auth and OAuth2 is determined by the response to an unauthenticated `PROPFIND` request to the WebDAV endpoint. 
 
 This request is skipped if `$skipWWWAuthenticateChecks` is `true`, which is the case when OpenID Connect Discovery was successful or `authentication.skip-www-authenticate-checks` was set to true.
 
@@ -241,7 +241,7 @@ Query parameter         | Contents                | Status   | Comment
 `client_id`             | configured value        | required | The value of `authentication-oauth2.oa2-client-id` (default: `mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1`).
 `redirect_uri`          | configured value        | required | The value of `authentication-oauth2.oa2-redirect-uri` (default: `oc://ios.owncloud.com`).
 `state`                 | random UUID             | optional | A pre-filled UUID. See [the specification](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-00#section-4.1.1.3) for details.
-`user`                  | `$username`             | optional | Filled with pre-provided username (supported by the ownCloud Classic 10 OAuth2 implementation).
+`user`                  | `$username`             | optional | Filled with pre-provided username (supported by the ownCloud Classic OAuth2 implementation).
 
 It then uses `$serverURL` and the configured OAuth2 Authorization Endpoint path (`authentication-oauth2.oa2-authorization-endpoint`) to compose the `$authorizationURL`:
 

--- a/ownCloud/Bookmarks/Account Setup and Authentication.md
+++ b/ownCloud/Bookmarks/Account Setup and Authentication.md
@@ -175,7 +175,7 @@ OpenID Configuration     | `GET`              | `$serverURL/.well-known/openid-c
 
 ##### WebDAV endpoint
 
-For historic reasons (ownCloud 10), the availability of Basic Auth and OAuth2 is determined by the response to an unauthenticated `PROPFIND` request to the WebDAV endpoint. 
+For historic reasons (ownCloud Classic 10), the availability of Basic Auth and OAuth2 is determined by the response to an unauthenticated `PROPFIND` request to the WebDAV endpoint. 
 
 This request is skipped if `$skipWWWAuthenticateChecks` is `true`, which is the case when OpenID Connect Discovery was successful or `authentication.skip-www-authenticate-checks` was set to true.
 
@@ -241,7 +241,7 @@ Query parameter         | Contents                | Status   | Comment
 `client_id`             | configured value        | required | The value of `authentication-oauth2.oa2-client-id` (default: `mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1`).
 `redirect_uri`          | configured value        | required | The value of `authentication-oauth2.oa2-redirect-uri` (default: `oc://ios.owncloud.com`).
 `state`                 | random UUID             | optional | A pre-filled UUID. See [the specification](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-00#section-4.1.1.3) for details.
-`user`                  | `$username`             | optional | Filled with pre-provided username (supported by the ownCloud 10 OAuth2 implementation).
+`user`                  | `$username`             | optional | Filled with pre-provided username (supported by the ownCloud Classic 10 OAuth2 implementation).
 
 It then uses `$serverURL` and the configured OAuth2 Authorization Endpoint path (`authentication-oauth2.oa2-authorization-endpoint`) to compose the `$authorizationURL`:
 


### PR DESCRIPTION
Renames the legacy server product to **ownCloud Classic** in the repository’s documentation prose (`README.md` heading, `KNOWN_ISSUES.md`, and `ownCloud/Bookmarks/Account Setup and Authentication.md`), applying the version only as additional information where relevant ("ownCloud Classic 10").

**Scope:** documentation prose only. The instance-sense phrase "your own ownCloud server in 3 minutes" is intentionally left unchanged; URLs and historical `CHANGELOG.md` are untouched. The published iOS docs live in `docs-client-ios-app` and were already rebranded separately.

Part of the cross-repo rebrand campaign tracked in owncloud/docs#5111 (Tier B — code-repo docs).