### PR TITLE
[feature/webapp-url-delegation] Configuration options for in-app web-app URL opening

### DIFF
--- a/doc/CONFIGURATION.json
+++ b/doc/CONFIGURATION.json
@@ -388,6 +388,42 @@
     "categoryTag" : "actions",
     "classIdentifier" : "action",
     "className" : "ownCloudAppShared.Action",
+    "defaultValue" : "with-default-browser",
+    "description" : "Determines how to open links that an web app (presented in-app) wants to open in a new window.",
+    "flatIdentifier" : "action.in-app-web-app-link-open-mode",
+    "key" : "in-app-web-app-link-open-mode",
+    "label" : "In-app WebApp link open mode",
+    "possibleValues" : [
+      {
+        "description" : "Asks the user whether to open the link in the in-app browser or the default browser.",
+        "value" : "choice"
+      },
+      {
+        "description" : "Denies opening the link and informs the user.",
+        "value" : "deny"
+      },
+      {
+        "description" : "Opens the link in the in-app browser, possibly navigating away from the WebApp.",
+        "value" : "navigate"
+      },
+      {
+        "description" : "Silently denies opening the link without bringing up an alert, logging that a link-opening was denied.",
+        "value" : "silent-deny"
+      },
+      {
+        "description" : "Opens the link in the default browser.",
+        "value" : "with-default-browser"
+      }
+    ],
+    "status" : "advanced",
+    "type" : "string"
+  },
+  {
+    "autoExpansion" : "none",
+    "category" : "Actions",
+    "categoryTag" : "actions",
+    "classIdentifier" : "action",
+    "className" : "ownCloudAppShared.Action",
     "defaultValue" : "auto",
     "description" : "Determines how to open a document in a web app.",
     "flatIdentifier" : "action.open-in-web-app-mode",

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -296,6 +296,35 @@ action.create-document-mode
 
 |advanced `candidate`
 
+|**In-app WebApp link open mode** +
+ +
+action.in-app-web-app-link-open-mode
+|string
+|`with-default-browser`
+|Determines how to open links that an web app (presented in-app) wants to open in a new window.
+[cols="1,1"]
+!===
+! Value
+! Description
+! `choice`
+! Asks the user whether to open the link in the in-app browser or the default browser.
+
+! `deny`
+! Denies opening the link and informs the user.
+
+! `navigate`
+! Opens the link in the in-app browser, possibly navigating away from the WebApp.
+
+! `silent-deny`
+! Silently denies opening the link without bringing up an alert, logging that a link-opening was denied.
+
+! `with-default-browser`
+! Opens the link in the default browser.
+
+!===
+
+|advanced `candidate`
+
 |**Open In WebApp mode** +
  +
 action.open-in-web-app-mode

--- a/ownCloud/Resources/Localizable.xcstrings
+++ b/ownCloud/Resources/Localizable.xcstrings
@@ -57865,6 +57865,16 @@
         }
       }
     },
+    "Navigate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigieren"
+          }
+        }
+      }
+    },
     "Network unavailable" : {
       "localizations" : {
         "ar" : {
@@ -63215,6 +63225,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Online"
+          }
+        }
+      }
+    },
+    "Open" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffnen"
           }
         }
       }

--- a/ownCloud/Resources/Localizable.xcstrings
+++ b/ownCloud/Resources/Localizable.xcstrings
@@ -32319,6 +32319,7 @@
       }
     },
     "Enabling this option will attempt to mask private data, so it does not become part of any log. Since logging is a development and debugging feature, though, we can't guarantee that the log file will be free of any private data even with this option enabled. Therefore, please look through any log file and verify its free of any data you're not comfortable sharing before sharing it with anybody." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -53874,6 +53875,7 @@
       }
     },
     "Mask private data" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -72802,6 +72804,7 @@
       }
     },
     "Privacy" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -98725,6 +98728,16 @@
         }
       }
     },
+    "The web app attempted to open the URL below. Opening was denied by configuration." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Webanwendung hat versucht die nachstehende URL zu öffnen. Das Öffnen wurde per Konfiguration abgelehnt."
+          }
+        }
+      }
+    },
     "Theme" : {
       "comment" : "User Interface Settings",
       "localizations" : {
@@ -99289,6 +99302,7 @@
       }
     },
     "This folder is empty. Fill it with content:" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -107551,6 +107565,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "警告"
+          }
+        }
+      }
+    },
+    "Web app requests to open link" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webanwendung möchte Link öffnen"
           }
         }
       }

--- a/ownCloudAppShared/Client/Actions/Implementations/ClientWebAppViewController.swift
+++ b/ownCloudAppShared/Client/Actions/Implementations/ClientWebAppViewController.swift
@@ -62,10 +62,10 @@ open class ClientWebAppViewController: UIViewController, WKUIDelegate {
 			var openAction, navigateAction: UIAlertAction?
 
 			title = OCLocalizedString("Web app requests to open link", nil)
-			openAction = UIAlertAction(title: "Open", style: .default) { (_) in
+			openAction = UIAlertAction(title: OCLocalizedString("Open", nil), style: .default) { (_) in
 				OCAuthenticationBrowserSessionCustomScheme.open(url) // Open in default browser
 			}
-			navigateAction = UIAlertAction(title: "Navigate", style: .default) { (_) in
+			navigateAction = UIAlertAction(title: OCLocalizedString("Navigate", nil), style: .default) { (_) in
 				webView.load(navigationAction.request) // Navigate
 			}
 

--- a/ownCloudAppShared/Client/Actions/Implementations/ClientWebAppViewController.swift
+++ b/ownCloudAppShared/Client/Actions/Implementations/ClientWebAppViewController.swift
@@ -53,6 +53,60 @@ open class ClientWebAppViewController: UIViewController, WKUIDelegate {
 		return configuration
 	}
 
+	public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+		if navigationAction.targetFrame == nil, let url = navigationAction.request.url,
+		   let openModeRaw = OpenInWebAppAction.classSetting(forOCClassSettingsKey: .inAppWebAppLinkOpenMode) as? String,
+		   let openMode = InAppWebAppLinkOpenMode(rawValue: openModeRaw) {
+			// Web app wants to open a link in a new window
+			var title: String
+			var openAction, navigateAction: UIAlertAction?
+
+			title = OCLocalizedString("Web app requests to open link", nil)
+			openAction = UIAlertAction(title: "Open", style: .default) { (_) in
+				OCAuthenticationBrowserSessionCustomScheme.open(url) // Open in default browser
+			}
+			navigateAction = UIAlertAction(title: "Navigate", style: .default) { (_) in
+				webView.load(navigationAction.request) // Navigate
+			}
+
+			switch openMode {
+				case .withDefaultBrowser:
+					navigateAction = nil
+
+				case .navigate:
+					openAction = nil
+
+				case .choice:
+					// allow all actions
+					break
+
+				case .deny:
+					title = OCLocalizedString("The web app attempted to open the URL below. Opening was denied by configuration.", nil)
+					openAction = nil
+					navigateAction = nil
+
+				case .silentDeny:
+					Log.debug("ClientWebAppViewController denied opening a link.")
+					return nil
+			}
+
+			let alert = ThemedAlertController(title: title, message: url.absoluteString, preferredStyle: .alert)
+			let cancelAction = UIAlertAction(title: OCLocalizedString("Cancel", nil), style: .cancel)
+
+			if let openAction {
+				alert.addAction(openAction)
+			}
+			if let navigateAction {
+				alert.addAction(navigateAction)
+			}
+			alert.addAction(cancelAction)
+
+			present(alert, animated: true)
+		}
+
+		return nil // nil -> do not open; webView -> open in originating webView (default)
+	}
+
 	override public func loadView() {
 		let rootView = UIView()
 

--- a/ownCloudAppShared/Client/Actions/Implementations/OpenInWebAppAction.swift
+++ b/ownCloudAppShared/Client/Actions/Implementations/OpenInWebAppAction.swift
@@ -21,6 +21,7 @@ import ownCloudSDK
 
 public extension OCClassSettingsKey {
 	static let openInWebAppMode = OCClassSettingsKey("open-in-web-app-mode")
+	static let inAppWebAppLinkOpenMode = OCClassSettingsKey("in-app-web-app-link-open-mode")
 }
 
 public enum OpenInWebAppActionMode: String {
@@ -30,10 +31,19 @@ public enum OpenInWebAppActionMode: String {
 	case inAppWithDefaultBrowserOption = "in-app-with-default-browser-option"
 }
 
+public enum InAppWebAppLinkOpenMode: String {
+	case withDefaultBrowser = "with-default-browser"
+	case navigate = "navigate"
+	case choice = "choice"
+	case deny = "deny"
+	case silentDeny = "silent-deny"
+}
+
 public class OpenInWebAppAction: Action {
 	public static func registerSettings() {
 		self.registerOCClassSettingsDefaults([
-			.openInWebAppMode : OpenInWebAppActionMode.auto.rawValue
+			.openInWebAppMode : OpenInWebAppActionMode.auto.rawValue,
+			.inAppWebAppLinkOpenMode : InAppWebAppLinkOpenMode.withDefaultBrowser.rawValue
 		], metadata: [
 			.openInWebAppMode : [
 				.type 		: OCClassSettingsMetadataType.string,
@@ -57,6 +67,36 @@ public class OpenInWebAppAction: Action {
 					[
 						OCClassSettingsMetadataKey.value 	: OpenInWebAppActionMode.inAppWithDefaultBrowserOption.rawValue,
 						OCClassSettingsMetadataKey.description 	: "Open inline in an in-app browser, but provide a button to open the document in the default browser (may require the user to sign in)."
+					]
+				]
+			],
+
+			.inAppWebAppLinkOpenMode : [
+				.type 		: OCClassSettingsMetadataType.string,
+				.label		: "In-app WebApp link open mode",
+				.description 	: "Determines how to open links that an web app (presented in-app) wants to open in a new window.",
+				.status		: OCClassSettingsKeyStatus.advanced,
+				.category	: "Actions",
+				.possibleValues : [
+					[
+						OCClassSettingsMetadataKey.value 	: InAppWebAppLinkOpenMode.withDefaultBrowser.rawValue,
+						OCClassSettingsMetadataKey.description 	: "Opens the link in the default browser."
+					],
+					[
+						OCClassSettingsMetadataKey.value 	: InAppWebAppLinkOpenMode.navigate.rawValue,
+						OCClassSettingsMetadataKey.description 	: "Opens the link in the in-app browser, possibly navigating away from the WebApp."
+					],
+					[
+						OCClassSettingsMetadataKey.value 	: InAppWebAppLinkOpenMode.choice.rawValue,
+						OCClassSettingsMetadataKey.description 	: "Asks the user whether to open the link in the in-app browser or the default browser."
+					],
+					[
+						OCClassSettingsMetadataKey.value 	: InAppWebAppLinkOpenMode.deny.rawValue,
+						OCClassSettingsMetadataKey.description 	: "Denies opening the link and informs the user."
+					],
+					[
+						OCClassSettingsMetadataKey.value 	: InAppWebAppLinkOpenMode.silentDeny.rawValue,
+						OCClassSettingsMetadataKey.description 	: "Silently denies opening the link without bringing up an alert, logging that a link-opening was denied."
 					]
 				]
 			]


### PR DESCRIPTION
## Description
Adds a new option `action.in-app-web-app-link-open-mode` to allow configuring behavior when in-app web apps want to open a URL in a new window.

Possible values:
- `with-default-browser`: ask the user if the link should be opened in the default browser **(default)**
- `navigate`: ask the user if the in-app browser hosting the web apps should navigate to the link
- `choice`: ask the user whether to delegate link opening to the default browser or perform an in-app navigation 
- `deny`: deny opening the link and tell the user
- `silent-deny`: silently deny opening the link (effectively turning it into a no-op) and log a debug message (not including the URL)

## Related Issue
OCSRE-2029
OCSRE-2031

## Screenshots (if appropriate):
<img width="2388" height="1668" alt="Screenshot 2026-07-31 at 16 36 04" src="https://github.com/user-attachments/assets/15f2a68c-df71-4072-ac0e-ea98482f40d8" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
